### PR TITLE
rename building_map_tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Welcome!
 This repository has the following directories:
  * `rmf_traffic_editor`: GUI for annotating floorplans to create traffic patterns
  * `rmf_building_map_tools`: Python-based tools to use and manipulate the map files created by `rmf_traffic_editor`, such as:
-   * a ROS 2 node to serve maps using `building_map_msgs`
+   * a ROS 2 node to serve maps using `rmf_building_map_msgs`
    * translators to simulators such as Gazebo
    * translators to navigation packages such as `rmf_core`
 

--- a/rmf_building_map_tools/CHANGELOG.rst
+++ b/rmf_building_map_tools/CHANGELOG.rst
@@ -1,6 +1,10 @@
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Changelog for package building_map_tools
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package rmf_building_map_tools
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1.2.0 (2021-03-29)
+------------------
+* migration to open-rmf org, rename to `rmf_building_map_tools`
 
 1.2.0 (2021-01-06)
 ------------------

--- a/rmf_building_map_tools/QUALITY_DECLARATION.md
+++ b/rmf_building_map_tools/QUALITY_DECLARATION.md
@@ -1,8 +1,8 @@
-This document is a declaration of software quality for the `building_map_tools` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+This document is a declaration of software quality for the `rmf_building_map_tools` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
 
-# `building_map_tools` Quality Declaration
+# `rmf_building_map_tools` Quality Declaration
 
-The package `building_map_tools` claims to be in the **Quality Level 4** category.
+The package `rmf_building_map_tools` claims to be in the **Quality Level 4** category.
 
 Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
 
@@ -10,11 +10,11 @@ Below are the rationales, notes, and caveats for this claim, organized by each r
 
 ### Version Scheme [1.i]
 
-`building_map_tools` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+`rmf_building_map_tools` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
 
 ### Version Stability [1.ii]
 
-`building_map_tools` is at a stable version, i.e. `>= 1.0.0`.
+`rmf_building_map_tools` is at a stable version, i.e. `>= 1.0.0`.
 The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
 
 ### Public API Declaration [1.iii]
@@ -23,27 +23,27 @@ All installed Python packages are part of the public API.
 
 ### API Stability Policy [1.iv]
 
-`building_map_tools` will not break public API within a major version number.
+`rmf_building_map_tools` will not break public API within a major version number.
 
 ### ABI Stability Policy [1.v]
 
-`building_map_tools` will not break public ABI within a major version number.
+`rmf_building_map_tools` will not break public ABI within a major version number.
 
 ### API and ABI Stability Within a Released ROS Distribution [1.vi]
 
-`building_map_tools` will not break public API or ABI within a released ROS distribution, i.e. no major releases into the same ROS distribution once that ROS distribution is released.
+`rmf_building_map_tools` will not break public API or ABI within a released ROS distribution, i.e. no major releases into the same ROS distribution once that ROS distribution is released.
 
 ## Change Control Process [2]
 
-`building_map_tools` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+`rmf_building_map_tools` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
 
 ### Change Requests [2.i]
 
-`building_map_tools` requires that all changes occur through a pull request.
+`rmf_building_map_tools` requires that all changes occur through a pull request.
 
 ### Contributor Origin [2.ii]
 
-`building_map_tools` does not require a confirmation of contributor origin.
+`rmf_building_map_tools` does not require a confirmation of contributor origin.
 
 ### Peer Review Policy [2.iii]
 
@@ -63,15 +63,15 @@ All pull requests must resolve related documentation changes before merging.
 
 ### Feature Documentation [3.i]
 
-`building_map_tools` does not provide documentation.
+`rmf_building_map_tools` does not provide documentation.
 
 ### Public API Documentation [3.ii]
 
-`building_map_tools` does not document its public API.
+`rmf_building_map_tools` does not document its public API.
 
 ### License [3.iii]
 
-The license for `building_map_tools` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+The license for `rmf_building_map_tools` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
 
 ### Copyright Statement [3.iv]
 
@@ -87,29 +87,29 @@ This quality declaration has not been externally peer-reviewed and is not regist
 
 ### Feature Testing [4.i]
 
-`building_map_tools` does not provide feature tests.
+`rmf_building_map_tools` does not provide feature tests.
 
 ### Public API Testing [4.ii]
 
-`building_map_tools` does not provide API tests.
+`rmf_building_map_tools` does not provide API tests.
 
 ### Coverage [4.iii]
 
-`building_map_tools` does not track coverage statistics.
+`rmf_building_map_tools` does not track coverage statistics.
 
 ### Performance [4.iv]
 
-`building_map_tools` does not test performance.
+`rmf_building_map_tools` does not test performance.
 
 ### Linters and Static Analysis [4.v]
 
-`building_map_tools` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+`rmf_building_map_tools` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
 
 ## Dependencies [5]
 
 ### Direct Runtime ROS Dependencies [5.i]
 
-Below are the required direct runtime ROS dependencies of `building_map_tools` and their evaluations.
+Below are the required direct runtime ROS dependencies of `rmf_building_map_tools` and their evaluations.
 
 #### rclpy
 
@@ -120,9 +120,9 @@ It is assumed to be **Quality Level 3** based on its wide-spread use, use of cha
 
 `std_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/std_msgs/QUALITY_DECLARATION.md).
 
-#### building_map_msgs
+#### rmf_building_map_msgs
 
-`building_map_msgs` is [**Quality Level 3**](https://github.com/osrf/traffic_editor/blob/master/building_map_msgs/QUALITY_DECLARATION.md).
+`rmf_building_map_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_building_map_msgs/blob/main/rmf_building_map_msgs/QUALITY_DECLARATION.md).
 
 #### python3-requests
 
@@ -134,18 +134,18 @@ It is assumed to be **Quality Level 3** based on its wide-spread use, use of cha
 
 ### Optional Direct Runtime ROS Dependencies [5.ii]
 
-`building_map_tools` has no optional runtime ROS dependencies.
+`rmf_building_map_tools` has no optional runtime ROS dependencies.
 
 ### Direct Runtime non-ROS Dependency [5.iii]
 
-`building_map_tools` has no runtime non-ROS dependencies.
+`rmf_building_map_tools` has no runtime non-ROS dependencies.
 
 ## Platform Support [6]
 
 ### Target platforms [6.i]
 
-`building_map_tools` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
-`building_map_tools` supports ROS Eloquent.
+`rmf_building_map_tools` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`rmf_building_map_tools` supports ROS Eloquent.
 
 ## Security [7]
 

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -125,7 +125,7 @@ class Building:
             raise RuntimeError("expected either gazebo or ignition in options")
 
         template_path = os.path.join(
-            get_package_share_directory('building_map_tools'),
+            get_package_share_directory('rmf_building_map_tools'),
             f'templates/{template_name}')
         tree = parse(template_path)
         sdf = tree.getroot()

--- a/rmf_building_map_tools/building_map/floor.py
+++ b/rmf_building_map_tools/building_map/floor.py
@@ -316,7 +316,7 @@ class Floor:
             texture_name = self.params['texture_name'].value
 
         texture_path_source = os.path.join(
-            get_package_share_directory('building_map_tools'),
+            get_package_share_directory('rmf_building_map_tools'),
             f'textures/{texture_name}.png')
         texture_path_dest = f'{model_path}/meshes/floor_{floor_cnt}.png'
         shutil.copyfile(texture_path_source, texture_path_dest)

--- a/rmf_building_map_tools/building_map/wall.py
+++ b/rmf_building_map_tools/building_map/wall.py
@@ -197,7 +197,7 @@ class Wall:
 
         print(f'  copying wall textures into {meshes_path}')
         texture_path_source = os.path.join(
-            get_package_share_directory('building_map_tools'),
+            get_package_share_directory('rmf_building_map_tools'),
             f'textures/{self.texture_name}.png')
         texture_path_dest = f'{meshes_path}/{self.texture_name}.png'
         shutil.copyfile(texture_path_source, texture_path_dest)

--- a/rmf_building_map_tools/building_map_server/test/test_map_client.py
+++ b/rmf_building_map_tools/building_map_server/test/test_map_client.py
@@ -7,8 +7,8 @@ from rclpy.qos import QoSHistoryPolicy as History
 from rclpy.qos import QoSDurabilityPolicy as Durability
 from rclpy.qos import QoSReliabilityPolicy as Reliability
 
-from building_map_msgs.msg import BuildingMap
-from building_map_msgs.msg import GraphEdge
+from rmf_building_map_msgs.msg import BuildingMap
+from rmf_building_map_msgs.msg import GraphEdge
 
 
 class BuildingMapClient(Node):

--- a/rmf_building_map_tools/package.xml
+++ b/rmf_building_map_tools/package.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>building_map_tools</name>
+  <name>rmf_building_map_tools</name>
   <version>1.2.0</version>
-  <description>Building map tools</description>
+  <description>RMF Building map tools</description>
   <maintainer email="mquigley@openrobotics.org">Morgan Quigley</maintainer>
   <license>Apache License 2.0</license>
 
-  <build_depend>building_map_msgs</build_depend>
+  <build_depend>rmf_building_map_msgs</build_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>building_map_msgs</exec_depend>
+  <exec_depend>rmf_building_map_msgs</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python3-requests</exec_depend>
   <exec_depend>python3-shapely</exec_depend>

--- a/rmf_building_map_tools/setup.cfg
+++ b/rmf_building_map_tools/setup.cfg
@@ -1,7 +1,7 @@
 [develop]
-script-dir=$base/lib/building_map_tools
+script-dir=$base/lib/rmf_building_map_tools
 [install]
-install-scripts=$base/lib/building_map_tools
+install-scripts=$base/lib/rmf_building_map_tools
 
 [options]
 setup_requires = pytest-runner

--- a/rmf_building_map_tools/setup.py
+++ b/rmf_building_map_tools/setup.py
@@ -1,7 +1,7 @@
 from glob import glob
 from setuptools import setup
 
-package_name = 'building_map_tools'
+package_name = 'rmf_building_map_tools'
 
 setup(
     name=package_name,
@@ -44,7 +44,7 @@ setup(
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
-    description='building_map_tools',
+    description='rmf_building_map_tools',
     license='Apache License, Version 2.0',
     tests_require=['pytest'],
     scripts=[],

--- a/rmf_traffic_editor/CHANGELOG.rst
+++ b/rmf_traffic_editor/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package rmf_traffic_editor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.2.x (2021-03-29)
+-----------------
+* Refactoring and Migration `#308 https://github.com/open-rmf/rmf_traffic_editor/pull/308`
+
 1.2.0 (2021-01-05)
 ------------------
 * Adds undo capability to a large part of the actions. (`#269 <https://github.com/osrf/traffic_editor/pull/269>`_) (`#266 <https://github.com/osrf/traffic_editor/pull/266>`_)

--- a/rmf_traffic_editor_test_maps/CMakeLists.txt
+++ b/rmf_traffic_editor_test_maps/CMakeLists.txt
@@ -26,19 +26,19 @@ foreach(path ${traffic_editor_paths})
   set(output_model_dir ${output_dir}/models)
 
   # first, generate the world
-  message("BUILDING WORLDFILE WITH COMMAND: ros2 run building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}")
+  message("BUILDING WORLDFILE WITH COMMAND: ros2 run rmf_building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}")
   if (NO_DOWNLOAD_MODELS)
     add_custom_command(
       DEPENDS ${map_path}
-      COMMAND ros2 run building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
+      COMMAND ros2 run rmf_building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
       OUTPUT ${output_world_path}
     )
   else()
-    message("DOWNLOADING MODELS WITH COMMAND: ros2 run building_map_tools building_map_model_downloader ${map_path}")
+    message("DOWNLOADING MODELS WITH COMMAND: ros2 run rmf_building_map_tools building_map_model_downloader ${map_path}")
     add_custom_command(
       DEPENDS ${map_path}
-      COMMAND ros2 run building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
-      COMMAND ros2 run building_map_tools building_map_model_downloader ${map_path}
+      COMMAND ros2 run rmf_building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
+      COMMAND ros2 run rmf_building_map_tools building_map_model_downloader ${map_path}
       OUTPUT ${output_world_path}
     )
   endif()

--- a/rmf_traffic_editor_test_maps/package.xml
+++ b/rmf_traffic_editor_test_maps/package.xml
@@ -4,13 +4,13 @@
   <name>test_maps</name>
   <version>1.2.0</version>
   <description>
-    Some test maps for traffic_editor and building_map_tools.
+    Some test maps for traffic_editor and rmf_building_map_tools.
   </description>
   <maintainer email="morgan@openrobotics.org">Morgan Quigley</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>building_map_tools</buildtool_depend>
+  <buildtool_depend>rmf_building_map_tools</buildtool_depend>
   <buildtool_depend>ros2run</buildtool_depend>
 
   <export>


### PR DESCRIPTION
Rename `buidling_map_tools` to `rmf_building_map_tools`, and a few instances of `rmf_building_map_msgs` . Merge along with: https://github.com/open-rmf/rmf_demos/pull/17