### PR TITLE
avoid crash in empty crowdsim save routine

### DIFF
--- a/rmf_traffic_editor/gui/crowd_sim/crowd_sim_impl.cpp
+++ b/rmf_traffic_editor/gui/crowd_sim/crowd_sim_impl.cpp
@@ -71,7 +71,8 @@ YAML::Node CrowdSimImplementation::_output_obstacle_node() const
   obstacle_node.SetStyle(YAML::EmitterStyle::Flow);
   obstacle_node["class"] = 1;
   obstacle_node["type"] = "nav_mesh";
-  obstacle_node["file_name"] = this->_navmesh_filename_list[0];
+  if (!_navmesh_filename_list.empty())
+    obstacle_node["file_name"] = this->_navmesh_filename_list[0];
   return obstacle_node;
 }
 


### PR DESCRIPTION
In certain conditions (especially when creating new buildings), a crash can be triggered by this line in the crowdsim `to_yaml()` function. Adding this one-line check avoids that situation.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>