### PR TITLE
Bug/add layer button not visible in new building

### DIFF
--- a/rmf_traffic_editor/gui/crowd_sim/crowd_sim_impl.cpp
+++ b/rmf_traffic_editor/gui/crowd_sim/crowd_sim_impl.cpp
@@ -71,7 +71,8 @@ YAML::Node CrowdSimImplementation::_output_obstacle_node() const
   obstacle_node.SetStyle(YAML::EmitterStyle::Flow);
   obstacle_node["class"] = 1;
   obstacle_node["type"] = "nav_mesh";
-  obstacle_node["file_name"] = this->_navmesh_filename_list[0];
+  if (!_navmesh_filename_list.empty())
+    obstacle_node["file_name"] = this->_navmesh_filename_list[0];
   return obstacle_node;
 }
 

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -149,7 +149,7 @@ Editor::Editor()
     level_table,
     &BuildingLevelTable::redraw_scene,
     this,
-    &Editor::create_scene);
+    &Editor::level_table_update_slot);
 
   lift_table = new LiftTable;
   connect(
@@ -1285,9 +1285,11 @@ void Editor::layer_add_button_clicked()
   if (layer_dialog.exec() != QDialog::Accepted)
     return;
   printf("added a layer: [%s]\n", layer.name.c_str());
+  layer.load_image();
   level.layers.push_back(layer);
   level.layer_added();
   populate_layers_table();
+  create_scene();
   setWindowModified(true);
 }
 
@@ -2518,4 +2520,10 @@ void Editor::clear_current_tool_buffer()
       latest_add_edge = NULL;
     }
   }
+}
+
+void Editor::level_table_update_slot()
+{
+  update_tables();
+  create_scene();
 }

--- a/rmf_traffic_editor/gui/editor.h
+++ b/rmf_traffic_editor/gui/editor.h
@@ -148,7 +148,7 @@ private:
 
   void level_add();
   void level_edit();
-  void update_level_buttons();
+  void level_table_update_slot();
 
   void zoom_fit();
   void view_models();

--- a/rmf_traffic_editor/gui/layer.cpp
+++ b/rmf_traffic_editor/gui/layer.cpp
@@ -42,7 +42,11 @@ bool Layer::from_yaml(const std::string& _name, const YAML::Node& y)
   if (y["visible"])
     visible = y["visible"].as<bool>();
 
-  // now try to load the image
+  return load_image();
+}
+
+bool Layer::load_image()
+{
   QImageReader image_reader(QString::fromStdString(filename));
   image_reader.setAutoTransform(true);
   QImage image = image_reader.read();

--- a/rmf_traffic_editor/gui/layer.h
+++ b/rmf_traffic_editor/gui/layer.h
@@ -48,6 +48,8 @@ public:
 
   bool from_yaml(const std::string& name, const YAML::Node& data);
   YAML::Node to_yaml() const;
+
+  bool load_image();
 };
 
 #endif


### PR DESCRIPTION
As reported in #305, newly-added layers would not render without a save-exit-load cycle, which is obviously not super great UX. This PR fixes that by slightly refactoring the `Layer` class so that it can load image files on-demand, not just in its `from_layer()` loading function.