### PR TITLE
auto download crowdsim models

### DIFF
--- a/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
+++ b/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
@@ -51,10 +51,10 @@ def get_crowdsim_models(input_filename):
             for model in model_types:
                 name = model["model_uri"].split("://")[-1]
                 actor_names.append(name)
-            logger.info(f"Models: {actor_names} are used in crowdsim")
+            logger.info(f"Models: {actor_names} are used in crowd_sim")
         except Exception as e:
-            logger.error(f"Could not get crowdsim models, error: {e}."
-                         " Ignore models in cloud_sim...")
+            logger.error(f"Could not get crowd_sim models, error: {e}."
+                         " Ignore models in crowd_sim...")
         return actor_names
 
 


### PR DESCRIPTION
This PR addresses https://github.com/open-rmf/rmf_demos/pull/14#issuecomment-809037834.

According to input `buildiing.yaml` file, the `building_map_model_downloader` will automatically download the specified `crowd_sim` models/actors from fuel. Will ignore otherwise.