### PR TITLE
provide zoom-reset and clamp on scale factor

### DIFF
--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -319,9 +319,7 @@ Editor::Editor()
   view_models_action->setChecked(true);
   view_menu->addSeparator();
 
-  zoom_fit_action =
-    view_menu->addAction("&Fit to Window", this, &Editor::zoom_fit);
-  zoom_fit_action->setEnabled(false);
+  view_menu->addAction("&Reset zoom level", this, &Editor::zoom_reset);
 
   // HELP MENU
   QMenu* help_menu = menuBar()->addMenu("&Help");
@@ -740,11 +738,12 @@ void Editor::view_models()
   create_scene();
 }
 
-void Editor::zoom_fit()
+void Editor::zoom_reset()
 {
-  // todo: implement this for real
-  //map_view->set_absolute_scale(1.0);
-  map_view->resetMatrix();
+  const double viewport_scale = 1.0;
+  QTransform t;
+  t.scale(viewport_scale, viewport_scale);
+  map_view->setTransform(t);
 }
 
 void Editor::mouse_event(const MouseType t, QMouseEvent* e)

--- a/rmf_traffic_editor/gui/editor.h
+++ b/rmf_traffic_editor/gui/editor.h
@@ -150,7 +150,7 @@ private:
   void level_edit();
   void update_level_buttons();
 
-  void zoom_fit();
+  void zoom_reset();
   void view_models();
 
   void help_about();
@@ -181,7 +181,6 @@ private:
   QGraphicsScene* scene = nullptr;
   MapView* map_view = nullptr;
 
-  QAction* zoom_fit_action = nullptr;
   QAction* view_models_action = nullptr;
 
   const QString tool_id_to_string(const int id);

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -34,11 +34,19 @@ void MapView::wheelEvent(QWheelEvent* e)
   // calculate the map position before we scale things
   const QPointF p_start = mapToScene(e->pos());
 
-  // scale things
+  // sanity check: clamp the scale if it has become super tiny
+  const double scale_factor = transform().m11();
+
   if (e->delta() > 0)
-    scale(1.1, 1.1);
+  {
+    if (scale_factor < 100)
+      scale(1.1, 1.1);
+  }
   else
-    scale(0.9, 0.9);
+  {
+    if (scale_factor > 0.01)
+      scale(0.9, 0.9);
+  }
 
   // calculate the mouse map position now that we've scaled
   const QPointF p_end = mapToScene(e->pos());


### PR DESCRIPTION
Fix #315 and provide a better solution for #311 by providing a zoom-reset menu action (for recovery) and a zoom-clamp calculation in the mouse-wheel handler to prevent the zoom factor from flying to zero, which make it impossible to recover.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>