### PR TITLE
update layer image immediately after OK button

### DIFF
--- a/rmf_traffic_editor/gui/layer_dialog.cpp
+++ b/rmf_traffic_editor/gui/layer_dialog.cpp
@@ -175,6 +175,10 @@ void LayerDialog::ok_button_clicked()
       return;
     }
   }
+
+  layer.filename = filename_line_edit->text().toStdString();
+  layer.load_image();
+
   /*
   // todo: figure out how to test for valid numeric values;
   // this doesn't work but there must be a similar function somewhere


### PR DESCRIPTION
Immediately re-load layer image after filename is changed and OK is pressed in the layer edit dialog box. Fix #324.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>