### PR TITLE
handle editing multiple layers with same name.

### DIFF
--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -1179,7 +1179,7 @@ void Editor::populate_layers_table()
   if (level_idx >= static_cast<int>(building.levels.size()))
   {
     layers_table->clearContents();
-    return;// let's not crash...
+    return; // let's not crash...
   }
   const Level& level = building.levels[level_idx];
   layers_table->blockSignals(true);  // otherwise we get tons of callbacks
@@ -1260,11 +1260,12 @@ void Editor::layer_edit_button_clicked(const int row_idx)
 
   Level& level = building.levels[level_idx];
 
+  // make sure the requested layer exists
   if (row_idx <= 0)
-    return;  // currently, can't edit properties of the base floorplan layer
+    return;
 
   if (row_idx - 1 >= static_cast<int>(level.layers.size()))
-    return;  // requested layer doesn't exist
+    return;
 
   Layer& layer = level.layers[row_idx - 1];
   LayerDialog* dialog = new LayerDialog(this, layer, true);
@@ -1279,8 +1280,9 @@ void Editor::layer_edit_button_clicked(const int row_idx)
 
 void Editor::layer_table_update(const int row_idx)
 {
+  // make sure the requested layer exists
   if (row_idx <= 0)
-    return;  // currently, can't edit properties of the base floorplan layer
+    return;
 
   if (level_idx >= static_cast<int>(building.levels.size()))
     return;
@@ -1288,7 +1290,7 @@ void Editor::layer_table_update(const int row_idx)
   Level& level = building.levels[level_idx];
 
   if (row_idx - 1 >= static_cast<int>(level.layers.size()))
-    return;  // requested layer doesn't exist
+    return;
 
   Layer& layer = level.layers[row_idx - 1];
 

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -1176,8 +1176,11 @@ void Editor::delete_param_button_clicked()
 
 void Editor::populate_layers_table()
 {
-  if (building.levels.empty())
+  if (level_idx >= static_cast<int>(building.levels.size()))
+  {
+    layers_table->clearContents();
     return;// let's not crash...
+  }
   const Level& level = building.levels[level_idx];
   layers_table->blockSignals(true);  // otherwise we get tons of callbacks
   layers_table->setRowCount(2 + level.layers.size());
@@ -1246,32 +1249,54 @@ void Editor::layers_table_set_row(
     });
   connect(
     button, &QAbstractButton::clicked,
-    [=]() { this->layer_edit_button_clicked(label.toStdString()); });
+    [=]() { this->layer_edit_button_clicked(row_idx); });
 }
 
-void Editor::layer_edit_button_clicked(const std::string& label)
+void Editor::layer_edit_button_clicked(const int row_idx)
 {
-  printf("clicked: [%s]\n", label.c_str());
-  if (building.levels.empty())
+  printf("layer row clicked: [%d]\n", row_idx);
+  if (level_idx >= static_cast<int>(building.levels.size()))
     return;
-  // find the index of this layer in the current level
+
   Level& level = building.levels[level_idx];
-  for (size_t i = 0; i < level.layers.size(); i++)
-  {
-    Layer& layer = level.layers[i];
-    if (label != layer.name)
-      continue;
-    LayerDialog* dialog = new LayerDialog(this, layer, true);
-    dialog->show();
-    dialog->raise();
-    dialog->activateWindow();
-    connect(
-      dialog,
-      &LayerDialog::redraw,
-      this,
-      &Editor::create_scene);
-    return;  // only create a dialog for the first name match
-  }
+
+  if (row_idx <= 0)
+    return;  // currently, can't edit properties of the base floorplan layer
+
+  if (row_idx - 1 >= static_cast<int>(level.layers.size()))
+    return;  // requested layer doesn't exist
+
+  Layer& layer = level.layers[row_idx - 1];
+  LayerDialog* dialog = new LayerDialog(this, layer, true);
+  dialog->show();
+  dialog->raise();
+  dialog->activateWindow();
+  connect(
+    dialog,
+    &LayerDialog::redraw,
+    [=]() { layer_table_update(row_idx); });
+}
+
+void Editor::layer_table_update(const int row_idx)
+{
+  if (row_idx <= 0)
+    return;  // currently, can't edit properties of the base floorplan layer
+
+  if (level_idx >= static_cast<int>(building.levels.size()))
+    return;
+
+  Level& level = building.levels[level_idx];
+
+  if (row_idx - 1 >= static_cast<int>(level.layers.size()))
+    return;  // requested layer doesn't exist
+
+  Layer& layer = level.layers[row_idx - 1];
+
+  layers_table_set_row(
+    row_idx,
+    QString::fromStdString(layer.name),
+    layer.visible);
+  create_scene();
 }
 
 void Editor::layer_add_button_clicked()

--- a/rmf_traffic_editor/gui/editor.h
+++ b/rmf_traffic_editor/gui/editor.h
@@ -197,9 +197,10 @@ private:
     const int row_idx,
     const QString& label,
     const bool checked);
-  void layer_edit_button_clicked(const std::string& label);
+  void layer_edit_button_clicked(const int row_idx);
   void layer_add_button_clicked();
   void update_active_layer_checkboxes(int row_idx);
+  void layer_table_update(const int row_idx);
 
   BuildingLevelTable* level_table = nullptr;
   LiftTable* lift_table = nullptr;


### PR DESCRIPTION
Previously, if two layers were added with the same name, it would be impossible to edit the second one, because the layer editing dialog was only searching layers by name, not by index. Now the layer dialog finds the requested layer by index in the layers table. Fix #325 

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>