### PR TITLE
Fix material values for sdf compliance

### DIFF
--- a/rmf_building_map_tools/building_map/utils.py
+++ b/rmf_building_map_tools/building_map/utils.py
@@ -20,9 +20,9 @@ def door_material(options):
     material_ele = Element('material')
     # blue-green glass as a default, so it's easy to see
     ambient_ele = SubElement(material_ele, 'ambient')
-    ambient_ele.text = '{} {} {} {}'.format(120, 60, 0, 0.6)
+    ambient_ele.text = '{} {} {} {}'.format(0.5, 0.25, 0, 0.6)
     diffuse_ele = SubElement(material_ele, 'diffuse')
-    diffuse_ele.text = '{} {} {} {}'.format(120, 60, 0, 0.6)
+    diffuse_ele.text = '{} {} {} {}'.format(0.5, 0.25, 0, 0.6)
     if 'ignition' in options:
         pbr_ele = SubElement(material_ele, 'pbr')
         metal_ele = SubElement(pbr_ele, 'metal')


### PR DESCRIPTION
## Bug fix

### Fixed bug

Similar to [rmf_demos #22](https://github.com/open-rmf/rmf_demos/pull/22), since `libsdformat11` ambient / diffuse values outside of the range dictated by the specification [0.0 - 1.0] cause runtime errors. This makes it impossible to run the scenarios in Ignition Edifice (and later version).

### Fix applied

Scaled the door ambient and diffuse values down to the specification's range