### PR TITLE
building_map_server: don't crash when missing image file

### DIFF
--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -90,14 +90,13 @@ class BuildingMapServer(Node):
             image_path = os.path.join(self.map_dir, image_filename)
 
             if os.path.exists(image_path):
-                print('opening: {}'.format(image_path))
+                self.get_logger().info(f'opening: {image_path}')
                 with open(image_path, 'rb') as image_file:
                     image.data = image_file.read()
-                print('read {} byte image: {}'.format(
-                    len(image.data), image_filename))
+                self.get_logger().info(f'read {len(image.data)} byte image')
                 msg.images.append(image)
             else:
-                print(f'WARNING: unable to open image: [{image_path}]')
+                self.get_logger().error(f'unable to open image: {image_path}')
 
         if (len(level.doors)):
             for door in level.doors:

--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -89,12 +89,15 @@ class BuildingMapServer(Node):
 
             image_path = os.path.join(self.map_dir, image_filename)
 
-            print('opening: {}'.format(image_path))
-            with open(image_path, 'rb') as image_file:
-                image.data = image_file.read()
-            print('read {} byte image: {}'.format(
-                len(image.data), image_filename))
-            msg.images.append(image)
+            if os.path.exists(image_path):
+                print('opening: {}'.format(image_path))
+                with open(image_path, 'rb') as image_file:
+                    image.data = image_file.read()
+                print('read {} byte image: {}'.format(
+                    len(image.data), image_filename))
+                msg.images.append(image)
+            else:
+                print(f'WARNING: unable to open image: [{image_path}]')
 
         if (len(level.doors)):
             for door in level.doors:


### PR DESCRIPTION
Currently, `building_map_server` crashes on startup when a building-floorplan image file is missing. Because the floorplan images are only needed for UI's and not "the rest of RMF," this PR changes this crash to an error message in the log. Fixes #333