### PR TITLE
[Optimization] Remove duplicated textures

### DIFF
--- a/rmf_building_map_tools/building_map/floor.py
+++ b/rmf_building_map_tools/building_map/floor.py
@@ -307,8 +307,6 @@ class Floor:
 
         print(f'  wrote {mtl_path}')
 
-        print(f'  wrote {mtl_path}')
-
         texture_path_source = os.path.join(
             get_package_share_directory('rmf_building_map_tools'),
             f'textures/{texture_name}.png')

--- a/rmf_building_map_tools/building_map/floor.py
+++ b/rmf_building_map_tools/building_map/floor.py
@@ -288,6 +288,10 @@ class Floor:
 
         print(f'  wrote {obj_path}')
 
+        texture_name = 'blue_linoleum'
+        if 'texture_name' in self.params:
+            texture_name = self.params['texture_name'].value
+
         mtl_path = f'{model_path}/meshes/floor_{floor_cnt}.mtl'
         with open(mtl_path, 'w') as f:
             f.write('# The Great Editor v0.0.1\n')
@@ -299,17 +303,15 @@ class Floor:
             f.write('Ni 1.0\n')  # no idea what this is
             f.write('d 1.0\n')  # alpha (maybe?)
             f.write('illum 2\n')  # illumination model (enum)
-            f.write(f'map_Kd floor_{floor_cnt}.png\n')
+            f.write(f'map_Kd {texture_name}.png\n')
 
         print(f'  wrote {mtl_path}')
 
-        texture_name = 'blue_linoleum'
-        if 'texture_name' in self.params:
-            texture_name = self.params['texture_name'].value
+        print(f'  wrote {mtl_path}')
 
         texture_path_source = os.path.join(
             get_package_share_directory('rmf_building_map_tools'),
             f'textures/{texture_name}.png')
-        texture_path_dest = f'{model_path}/meshes/floor_{floor_cnt}.png'
+        texture_path_dest = f'{model_path}/meshes/{texture_name}.png'
         shutil.copyfile(texture_path_source, texture_path_dest)
         print(f'  wrote {texture_path_dest}')


### PR DESCRIPTION
## Performance optimization

### Fixed bug

When generating floor models, every floor has its own texture and copies the same texture file over and over with different names. This caused a lot of unnecessary memory (and disk) usage, as well as longer simulation loading times.

### Fix applied

This fix removes the textures duplication and makes each .mtl file point to a single shared texture.
I evaluated by running `nvidia-smi` with both ignition and gazebo classic on the `airport_terminal` world.

#### Gazebo - before:

```
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
[...]
|    0   N/A  N/A   3678687      G   gzserver                            4MiB |
|    0   N/A  N/A   3678689      G   gzclient                          930MiB |
+-----------------------------------------------------------------------------+
```

#### Gazebo - after:

```
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
[...]
|    0   N/A  N/A   3681090      G   gzserver                            4MiB |
|    0   N/A  N/A   3681102      G   gzclient                          614MiB |
+-----------------------------------------------------------------------------+
```

#### Ignition - before:

```
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
[...]
|    0   N/A  N/A   3654940      G   ign gazebo gui                   1156MiB |
+-----------------------------------------------------------------------------+
```

#### Ignition - after:

```
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
[...]
|    0   N/A  N/A   3682221      G   ign gazebo gui                    836MiB |
+-----------------------------------------------------------------------------+
```

The gain seems is about what I would expect, this specific world has 75 floor objects and the texture size is between 100KB and 1.9MB