### PR TITLE
Convert wall textures from 1D to 2D

### DIFF
--- a/rmf_building_map_tools/building_map/wall.py
+++ b/rmf_building_map_tools/building_map/wall.py
@@ -61,7 +61,7 @@ class Wall:
 
             # calculate faces for all the wall segments
             wall_verts = np.array([])
-            texture_lengths = [0]
+            texture_lengths = []
 
             # normal #1 is the vertical normal for wall "caps"
             norms = np.array([[0, 0, 1]])
@@ -116,7 +116,7 @@ class Wall:
                 ))
 
                 # in the future we may have texture tiles of different scale,
-                # but for now let's assume 1-meter x 1-meter tiles, so we don't
+                # but for now we assume 2.5-meter x 1-meter tiles, so we don't
                 # need to scale the texture coordinates currently.
                 texture_lengths.append(wlen)
 
@@ -125,8 +125,14 @@ class Wall:
                 f.write(f'v {v[0]:.4f} {v[1]:.4f} {h:.4f}\n')
 
             for length in texture_lengths:
+                f.write(f'vt 0.000 0.000\n')
+                f.write(f'vt 0.000 1.000\n')
                 f.write(f'vt {length:.4f} 0.000\n')
                 f.write(f'vt {length:.4f} 1.000\n')
+                f.write(f'vt {(length + self.wall_thickness):.4f} 0.000\n')
+                f.write(f'vt {(length + self.wall_thickness):.4f} 1.000\n')
+                f.write(f'vt {(2*length + self.wall_thickness):.4f} 0.000\n')
+                f.write(f'vt {(2*length + self.wall_thickness):.4f} 1.000\n')
 
             for norm in norms:
                 f.write(f'vn {norm[0]:.4f} {norm[1]:.4f} {norm[2]:.4f}\n')
@@ -139,43 +145,43 @@ class Wall:
             for w in range(0, len(self.walls)):
                 # first the side facing 'north' before rotation
                 f.write(
-                    f'f {w*8+1}/1/{w*4+2}'
-                    f' {w*8+2}/2/{w*4+2}'
-                    f' {w*8+3}/1/{w*4+2}\n')
+                    f'f {w*8+1}/{w*8+1}/{w*4+2}'
+                    f' {w*8+2}/{w*8+2}/{w*4+2}'
+                    f' {w*8+3}/{w*8+3}/{w*4+2}\n')
                 f.write(
-                    f'f {w*8+4}/2/{w*4+2}'
-                    f' {w*8+3}/1/{w*4+2}'
-                    f' {w*8+2}/2/{w*4+2}\n')
+                    f'f {w*8+4}/{w*8+4}/{w*4+2}'
+                    f' {w*8+3}/{w*8+3}/{w*4+2}'
+                    f' {w*8+2}/{w*8+2}/{w*4+2}\n')
 
                 # now the 'east' side
                 f.write(
-                    f'f {w*8+3}/1/{w*4+3}'
-                    f' {w*8+4}/2/{w*4+3}'
-                    f' {w*8+5}/1/{w*4+3}\n')
+                    f'f {w*8+3}/{w*8+3}/{w*4+3}'
+                    f' {w*8+4}/{w*8+4}/{w*4+3}'
+                    f' {w*8+5}/{w*8+5}/{w*4+3}\n')
                 f.write(
-                    f'f {w*8+6}/2/{w*4+3}'
-                    f' {w*8+5}/1/{w*4+3}'
-                    f' {w*8+4}/2/{w*4+3}\n')
+                    f'f {w*8+6}/{w*8+6}/{w*4+3}'
+                    f' {w*8+5}/{w*8+5}/{w*4+3}'
+                    f' {w*8+4}/{w*8+4}/{w*4+3}\n')
 
                 # now the 'south' side
                 f.write(
-                    f'f {w*8+5}/1/{w*4+4}'
-                    f' {w*8+6}/2/{w*4+4}'
-                    f' {w*8+7}/1/{w*4+4}\n')
+                    f'f {w*8+5}/{w*8+5}/{w*4+4}'
+                    f' {w*8+6}/{w*8+6}/{w*4+4}'
+                    f' {w*8+7}/{w*8+7}/{w*4+4}\n')
                 f.write(
-                    f'f {w*8+8}/2/{w*4+4}'
-                    f' {w*8+7}/1/{w*4+4}'
-                    f' {w*8+6}/2/{w*4+4}\n')
+                    f'f {w*8+8}/{w*8+8}/{w*4+4}'
+                    f' {w*8+7}/{w*8+7}/{w*4+4}'
+                    f' {w*8+6}/{w*8+6}/{w*4+4}\n')
 
                 # now the 'west' side
                 f.write(
-                    f'f {w*8+7}/1/{w*4+5}'
-                    f' {w*8+8}/2/{w*4+5}'
-                    f' {w*8+1}/1/{w*4+5}\n')
+                    f'f {w*8+7}/{w*8+7}/{w*4+5}'
+                    f' {w*8+8}/{w*8+8}/{w*4+5}'
+                    f' {w*8+1}/{w*8+1}/{w*4+5}\n')
                 f.write(
-                    f'f {w*8+2}/2/{w*4+5}'
-                    f' {w*8+1}/1/{w*4+5}'
-                    f' {w*8+8}/2/{w*4+5}\n')
+                    f'f {w*8+2}/{w*8+2}/{w*4+5}'
+                    f' {w*8+1}/{w*8+1}/{w*4+5}'
+                    f' {w*8+8}/{w*8+8}/{w*4+5}\n')
 
                 # now the top "cap" of this wall segment
                 f.write(f'f {w*8+2}/1/1 {w*8+6}/1/1 {w*8+4}/1/1\n')


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Walls' textures are now 2D instead of 1D, this allows mapping complex textures to wall and removing the glitches that appeared when some textures (such as tiles) were applied to walls.

### Implementation description

To be fully honest I don't understand 100% the obj specification and whether the logic I added for the texture vertices is correct. I tried to follow the same ordering as the polygon vertices and "unwrap" the wall textures manually.

This implementation is only a starting point, followup work should parametrize texture scale for walls, as it happens for floors, as well as adding more wall specific textures. Now we are assuming 2.5m height x 1m width textures.
I split the results in a classic western way.

**The good**, what would happen if we parametrized the texture height and applied the correct scale to a tiles texture (example taken from airport world):

![image](https://user-images.githubusercontent.com/9111558/115677529-257e2780-a383-11eb-8e16-c546bdfc3685.png)

**The bad**, the state with the current PR, vertical scale is wrong since the texture is 1x1 but we assume 2.5x1:

![image](https://user-images.githubusercontent.com/9111558/115677614-3b8be800-a383-11eb-8a37-9f63440d8971.png)

**The ugly**, what it was before this PR (!)

![image](https://user-images.githubusercontent.com/9111558/115677644-46df1380-a383-11eb-842e-04603c51d90e.png)