### PR TITLE
Fix/ci package name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
       with:
-        path: ws/src/traffic_editor
+        path: ws/src/rmf_traffic_editor
 
     - name: non-ros-deps
       run: |
@@ -26,14 +26,14 @@ jobs:
       run: |
         cd ws
         source /opt/ros/foxy/setup.bash
-        colcon build --packages-select traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
+        colcon build --packages-select rmf_traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
 
     - name: test
       shell: bash
       run: |
         cd ws
         source /opt/ros/foxy/setup.bash
-        QT_QPA_PLATFORM=offscreen colcon test --packages-select traffic_editor
+        QT_QPA_PLATFORM=offscreen colcon test --packages-select rmf_traffic_editor
 
     - name: test-results
       shell: bash

--- a/rmf_traffic_editor/QUALITY_DECLARATION.md
+++ b/rmf_traffic_editor/QUALITY_DECLARATION.md
@@ -122,14 +122,6 @@ This quality declaration has not been externally peer-reviewed and is not regist
 
 Below are the required direct runtime non-ROS dependencies of `rmf_traffic_editor` and their evaluations.
 
-#### ignition-plugin
-
-`ignition-plugin` is assumed to be **Quality Level 3** based on its change control process, CI, tests, and documentation.
-
-#### ignition-common3
-
-`ignition-common3` is assumed to be **Quality Level 3** based on its change control process, CI, tests, and documentation.
-
 #### yaml-cpp
 
 The [`yaml-cpp` library](https://github.com/jbeder/yaml-cpp) is assumed to be **Quality Level 3** due to its wide use, provided documentation, use of testing, and version number above 1.0.0.

--- a/rmf_traffic_editor/README.md
+++ b/rmf_traffic_editor/README.md
@@ -25,8 +25,7 @@ workspace in `~/colcon_workspace` and build `traffic-editor` there:
 ```bash
 sudo apt update
 sudo apt install libyaml-cpp-dev qt5-default \
-  libopencv-dev libopencv-videoio-dev \
-  libignition-plugin-dev libignition-common3-dev
+  libopencv-dev libopencv-videoio-dev
 mkdir -p ~/colcon_workspace/src
 cd ~/colcon_workspace/src
 git clone https://github.com/open-rmf/rmf_traffic_editor

--- a/rmf_traffic_editor/package.xml
+++ b/rmf_traffic_editor/package.xml
@@ -9,8 +9,6 @@
 
   <build_depend>ament_cmake</build_depend>
   <build_depend>ament_index_cpp</build_depend>
-  <build_depend>ignition-plugin</build_depend>
-  <build_depend>ignition-common3</build_depend>
   <build_depend>yaml-cpp</build_depend>
   <build_depend>libqt5-concurrent</build_depend>
   <build_depend>libqt5-widgets</build_depend>

--- a/rmf_traffic_editor/test/CMakeLists.txt
+++ b/rmf_traffic_editor/test/CMakeLists.txt
@@ -11,6 +11,6 @@ target_link_libraries(
 
 ament_add_test(
   test_gui
-  COMMAND "$<TARGET_FILE:test_gui>" -o ${AMENT_TEST_RESULTS_DIR}/traffic_editor/test_gui.xml,xml -o -,txt
-  OUTPUT_FILE ${AMENT_TEST_RESULTS_DIR}/traffic_editor/test_gui/output.log
+  COMMAND "$<TARGET_FILE:test_gui>" -o ${AMENT_TEST_RESULTS_DIR}/rmf_traffic_editor/test_gui.xml,xml -o -,txt
+  OUTPUT_FILE ${AMENT_TEST_RESULTS_DIR}/rmf_traffic_editor/test_gui/output.log
 )


### PR DESCRIPTION
## Bug fix

### Fixed bug

CI was not doing anything since `traffic_editor` has been renamed to `rmf_traffic_editor`. It was also installing Ignition packages that are not needed anymore.

### Fix applied

Fixed the github workflow, as well as the tests CMakeLists, so it correctly compiles and tests `rmf_traffic_editor`, also removed the unnecessary Ignition dependencies.