### PR TITLE
PBR textures for walls and floors in Ignition Gazebo

### DIFF
--- a/rmf_building_map_tools/building_map/floor.py
+++ b/rmf_building_map_tools/building_map/floor.py
@@ -292,7 +292,9 @@ class Floor:
             texture_name = self.params['texture_name'].value
 
         pbr_textures = get_pbr_textures(self.params)
-        texture_filename = add_pbr_material(visual_ele, model_name, f'floor_{floor_cnt}', texture_name, f'{model_path}/meshes', pbr_textures)
+        texture_filename = add_pbr_material(
+                visual_ele, model_name, f'floor_{floor_cnt}', texture_name,
+                f'{model_path}/meshes', pbr_textures)
 
         mtl_path = f'{model_path}/meshes/floor_{floor_cnt}.mtl'
         with open(mtl_path, 'w') as f:

--- a/rmf_building_map_tools/building_map/floor.py
+++ b/rmf_building_map_tools/building_map/floor.py
@@ -6,7 +6,7 @@ import shapely.ops
 
 from xml.etree.ElementTree import SubElement
 
-from .material_utils import copy_texture
+from .material_utils import add_pbr_material, copy_texture, get_pbr_textures
 from .param_value import ParamValue
 
 triangulation_debugging = False
@@ -291,7 +291,8 @@ class Floor:
         if 'texture_name' in self.params:
             texture_name = self.params['texture_name'].value
 
-        texture_filename = copy_texture(texture_name, meshes_path)
+        pbr_textures = get_pbr_textures(self.params)
+        texture_filename = add_pbr_material(visual_ele, model_name, f'floor_{floor_cnt}', texture_name, f'{model_path}/meshes', pbr_textures)
 
         mtl_path = f'{model_path}/meshes/floor_{floor_cnt}.mtl'
         with open(mtl_path, 'w') as f:

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -153,14 +153,12 @@ class Level:
         # crude method to identify all unique params list in walls
         for wall in self.walls:
             # check if param exists, if not use default val
-            tex = "default"
-            alpha = 1.0
-            if "texture_name" in wall.params:
-                tex = wall.params["texture_name"].value
-            if "alpha" in wall.params:
-                alpha = wall.params["alpha"].value
-            if [tex, alpha] not in wall_params_list:
-                wall_params_list.append([tex, alpha])
+            if "texture_name" not in wall.params:
+                wall.params["texture_name"] = 'default'
+            if "alpha" not in wall.params:
+                wall.params["alpha"] = 1.0
+            if wall.params not in wall_params_list:
+                wall_params_list.append(wall.params)
         print(f'Walls Generation, wall params list: {wall_params_list}')
 
         wall_cnt = 0

--- a/rmf_building_map_tools/building_map/material_utils.py
+++ b/rmf_building_map_tools/building_map/material_utils.py
@@ -9,12 +9,13 @@ from xml.etree.ElementTree import ElementTree, Element, SubElement
 
 def get_pbr_textures(params):
     pbr_texture_types = ['metalness_map', 'roughness_map',
-            'normal_map', 'environment_map', 'light_map']
+                         'normal_map', 'environment_map', 'light_map']
     pbr_textures = {}
     for pbr_key, param in params.items():
         if pbr_key in pbr_texture_types:
             pbr_textures[pbr_key] = param.value
     return pbr_textures
+
 
 def copy_texture(texture_name, dest_path):
     texture_filename = f'{texture_name}.png'
@@ -40,14 +41,16 @@ def copy_texture(texture_name, dest_path):
     print(f'  wrote {texture_path_dest}')
     return texture_filename
 
-def add_pbr_material(visual_ele, model_name, obj_name, texture_name, meshes_path, pbr_textures = {}):
+
+def add_pbr_material(visual_ele, model_name, obj_name,
+                     texture_name, meshes_path, pbr_textures):
     # Check if the texture is a URL and copy texture
     texture_filename = copy_texture(texture_name, meshes_path)
     material_ele = SubElement(visual_ele, 'material')
     diffuse_ele = SubElement(material_ele, 'diffuse')
     diffuse_ele.text = '1.0 1.0 1.0'
     specular_ele = SubElement(material_ele, 'specular')
-    specular_ele.text = '0.1 0.1 0.1' # TODO check specular value
+    specular_ele.text = '0.1 0.1 0.1'  # TODO check specular value
     pbr_ele = SubElement(material_ele, 'pbr')
     metal_ele = SubElement(pbr_ele, 'metal')
     # Diffuse tag for PBR

--- a/rmf_building_map_tools/building_map/material_utils.py
+++ b/rmf_building_map_tools/building_map/material_utils.py
@@ -60,6 +60,8 @@ def add_pbr_material(visual_ele, model_name, obj_name,
     pbr_map_eles = []
     for pbr_type, pbr_name in pbr_textures.items():
         pbr_map_eles.append(SubElement(metal_ele, pbr_type))
+        if (pbr_type == 'light_map'):
+            pbr_map_eles[-1].set('uv_set', '1')
         pbr_filename = copy_texture(pbr_name, meshes_path)
         pbr_map_eles[-1].text = f'model://{model_name}/meshes/{pbr_filename}'
 

--- a/rmf_building_map_tools/building_map/material_utils.py
+++ b/rmf_building_map_tools/building_map/material_utils.py
@@ -53,6 +53,10 @@ def add_pbr_material(visual_ele, model_name, obj_name,
     specular_ele.text = '0.1 0.1 0.1'  # TODO check specular value
     pbr_ele = SubElement(material_ele, 'pbr')
     metal_ele = SubElement(pbr_ele, 'metal')
+    metalness_ele = SubElement(metal_ele, 'metalness')
+    # Sensible default for floors / walls not to be made out of metal
+    # TODO parametrize
+    metalness_ele.text = '0.0'
     # Diffuse tag for PBR
     albedo_map_ele = SubElement(metal_ele, 'albedo_map')
     albedo_map_ele.text = f'model://{model_name}/meshes/{texture_filename}'

--- a/rmf_building_map_tools/building_map/material_utils.py
+++ b/rmf_building_map_tools/building_map/material_utils.py
@@ -7,6 +7,15 @@ from urllib.parse import urlparse
 from xml.etree.ElementTree import ElementTree, Element, SubElement
 
 
+def get_pbr_textures(params):
+    pbr_texture_types = ['metalness_map', 'roughness_map',
+            'normal_map', 'environment_map', 'light_map']
+    pbr_textures = {}
+    for pbr_key, param in params.items():
+        if pbr_key in pbr_texture_types:
+            pbr_textures[pbr_key] = param.value
+    return pbr_textures
+
 def copy_texture(texture_name, dest_path):
     texture_filename = f'{texture_name}.png'
     texture_path_dest = f'{dest_path}/{texture_filename}'
@@ -29,4 +38,49 @@ def copy_texture(texture_name, dest_path):
         shutil.copyfile(texture_path_source, texture_path_dest)
 
     print(f'  wrote {texture_path_dest}')
+    return texture_filename
+
+def add_pbr_material(visual_ele, model_name, obj_name, texture_name, meshes_path, pbr_textures = {}):
+    # Check if the texture is a URL and copy texture
+    texture_filename = copy_texture(texture_name, meshes_path)
+    material_ele = SubElement(visual_ele, 'material')
+    diffuse_ele = SubElement(material_ele, 'diffuse')
+    diffuse_ele.text = '1.0 1.0 1.0'
+    specular_ele = SubElement(material_ele, 'specular')
+    specular_ele.text = '0.1 0.1 0.1' # TODO check specular value
+    pbr_ele = SubElement(material_ele, 'pbr')
+    metal_ele = SubElement(pbr_ele, 'metal')
+    # Diffuse tag for PBR
+    albedo_map_ele = SubElement(metal_ele, 'albedo_map')
+    albedo_map_ele.text = f'model://{model_name}/meshes/{texture_filename}'
+    # Now add all PBR textures
+    pbr_map_eles = []
+    for pbr_type, pbr_name in pbr_textures.items():
+        pbr_map_eles.append(SubElement(metal_ele, pbr_type))
+        pbr_filename = copy_texture(pbr_name, meshes_path)
+        pbr_map_eles[-1].text = f'model://{model_name}/meshes/{pbr_filename}'
+
+    # For compatibility, create material script with diffuse texture for gazebo
+    script_ele = SubElement(material_ele, 'script')
+    script_uri_ele = SubElement(script_ele, 'uri')
+    script_uri_ele.text = f'model://{model_name}/meshes/'
+    material_name = f'{obj_name}_Diffuse'
+    script_name_ele = SubElement(script_ele, 'name')
+    script_name_ele.text = material_name
+    # Now create the OGRE1 script, append diffuse material
+    with open(f'{meshes_path}/model.material', 'a') as f:
+        f.write(f'material {material_name}\n')
+        f.write('{\n')
+        f.write('\ttechnique\n')
+        f.write('\t{\n')
+        f.write('\t\tpass\n')
+        f.write('\t\t{\n')
+        f.write('\t\t\ttexture_unit\n')
+        f.write('\t\t\t{\n')
+        f.write(f'\t\t\t\ttexture {texture_filename}\n')
+        f.write('\t\t\t}\n')
+        f.write('\t\t}\n')
+        f.write('\t}\n')
+        f.write('}\n')
+    # TODO remove
     return texture_filename

--- a/rmf_building_map_tools/building_map/param_value.py
+++ b/rmf_building_map_tools/building_map/param_value.py
@@ -11,3 +11,6 @@ class ParamValue:
 
     def to_yaml(self):
         return [self.type, self.value]
+
+    def __eq__(self, other):
+        return self.type == other.type and self.value == other.value

--- a/rmf_building_map_tools/building_map/wall.py
+++ b/rmf_building_map_tools/building_map/wall.py
@@ -27,7 +27,6 @@ class Wall:
             if wall_params == checked_wall.params:
                 self.walls.append(checked_wall)
 
-
     def __str__(self):
         return f'wall {self.wall_cnt} with param {self.texture_name}, \
             {self.alpha})'
@@ -35,7 +34,8 @@ class Wall:
     def __repr__(self):
         return self.__str__()
 
-    def generate_wall_visual_mesh(self, model_name, model_path, texture_filename):
+    def generate_wall_visual_mesh(self, model_name, model_path,
+                                  texture_filename):
         print(f'generate_wall_visual_mesh({model_name}, {model_path})')
 
         meshes_path = f'{model_path}/meshes'
@@ -237,5 +237,9 @@ class Wall:
         c_bitmask_ele = SubElement(c_contact_ele, 'collide_bitmask')
         c_bitmask_ele.text = '0x01'
 
-        texture_filename = add_pbr_material(visual_ele, model_name, f'wall_{wall_cnt}', self.texture_name.value, f'{model_path}/meshes', self.pbr_textures)
-        self.generate_wall_visual_mesh(model_name, model_path, texture_filename)
+        texture_filename = add_pbr_material(
+                visual_ele, model_name, f'wall_{wall_cnt}',
+                self.texture_name.value, f'{model_path}/meshes',
+                self.pbr_textures)
+        self.generate_wall_visual_mesh(model_name, model_path,
+                                       texture_filename)


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This PR is a followup of #342, and is to work towards #343. It adds support to `rmf_building_map_tools` for PBR textures to be used in Ignition, specifically metalness, roughness, normal, environment and light maps.

### Implementation description

The YAML format now has additional parameters for walls and floors that follow the same naming convention as the [SDF metal PBR workflow](http://sdformat.org/spec?ver=1.8&elem=material#pbr_metal).
For ease of review the PR doesn't yet include all the `rmf_traffic_editor` GUI work to include the parameters, hence they have to be added manually to the yaml file. An example gist for the office world that can be used to test the PR is [here](https://gist.github.com/luca-della-vedova/846103f59f0190dd3de59840052f49fe).

Followup work will be to add the parameters to the `rmf_traffic_editor` GUI and autopopulate them when possible (i.e. if a `[...]_Diffuse.png` texture is present, the Normal map should default to `[...]_Normal.png`)

Before the PR:
![image](https://user-images.githubusercontent.com/9111558/116053425-40b3a480-a6ad-11eb-8497-322566b552a3.png)

After the PR (notice the reflections on the floor for the ceiling lights given by the environment map. It looks better when moving around I promise!
![image](https://user-images.githubusercontent.com/9111558/116053302-1d88f500-a6ad-11eb-9cbc-cfa0219406c9.png)

While implementing I took the chance to do a small refactor of the wall parameters and how they were grouped by adding an equality operator to parameters, this made the implementation quite a bit cleaner (otherwise we had to keep comparing parameters manually every time a new one was added).

A small issue that I couldn't figure out yet is that the `model.material` file created [here](https://github.com/open-rmf/rmf_traffic_editor/compare/feature/pbr_textures?expand=1#diff-b13c13bd9ab2f46c4791fc58532ba225db2ad0a762a72efffa85325147ca8faaR74-R87) has duplicated entries which makes me think that  the generate function is called twice for each wall / floor.
It still works but it makes me wonder if there is some part of the map generator that is responsible for this issue and if there is a chance for optimizing it.