### PR TITLE
Feature/display layer transforms in freefleet format

### DIFF
--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -98,6 +98,7 @@ Editor::Editor()
       {
         layer_idx = row;
         layer_table->update(building, level_idx, layer_idx);
+        populate_property_editor(building.levels[level_idx].layers[layer_idx-1]);
       }
     });
 
@@ -1440,6 +1441,15 @@ void Editor::populate_property_editor(const Polygon& polygon)
   property_editor->blockSignals(false);  // re-enable callbacks
 }
 
+void Editor::populate_property_editor(const Layer& layer)
+{
+  Level* level = active_level();
+  if (level == nullptr)
+    return;
+  level->compute_layer_transforms();
+  layer.populate_property_editor(property_editor);
+}
+
 void Editor::clear_property_editor()
 {
   property_editor->setRowCount(0);
@@ -2616,7 +2626,7 @@ void Editor::layer_table_update_slot()
   create_scene();
 }
 
-const Level* Editor::active_level() const
+Level* Editor::active_level()
 {
   if (level_idx < static_cast<int>(building.levels.size()))
     return &building.levels[level_idx];
@@ -2624,12 +2634,12 @@ const Level* Editor::active_level() const
   return nullptr;
 }
 
-const Layer* Editor::active_layer() const
+Layer* Editor::active_layer()
 {
   if (layer_idx <= 0)
     return nullptr;
 
-  const Level* const level = active_level();
+  Level* const level = active_level();
   if (!level)
     return nullptr;
 

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -98,7 +98,8 @@ Editor::Editor()
       {
         layer_idx = row;
         layer_table->update(building, level_idx, layer_idx);
-        populate_property_editor(building.levels[level_idx].layers[layer_idx-1]);
+        populate_property_editor(
+          building.levels[level_idx].layers[layer_idx-1]);
       }
     });
 

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -98,8 +98,9 @@ Editor::Editor()
       {
         layer_idx = row;
         layer_table->update(building, level_idx, layer_idx);
-        populate_property_editor(
-          building.levels[level_idx].layers[layer_idx-1]);
+        if (layer_idx > 0)
+          populate_property_editor(
+            building.levels[level_idx].layers[layer_idx-1]);
       }
     });
 

--- a/rmf_traffic_editor/gui/editor.h
+++ b/rmf_traffic_editor/gui/editor.h
@@ -180,8 +180,8 @@ private:
   Polygon* selected_polygon = nullptr;
   QUuid clicked_feature_id;
 
-  const Level* active_level() const;
-  const Layer* active_layer() const;
+  Level* active_level();
+  Layer* active_layer();
 
   QGraphicsScene* scene = nullptr;
   MapView* map_view = nullptr;
@@ -219,6 +219,7 @@ private:
   void populate_property_editor(const Feature& feature);
   void populate_property_editor(const Fiducial& fiducial);
   void populate_property_editor(const Polygon& polygon);
+  void populate_property_editor(const Layer& layer);
 
   QTableWidgetItem* create_table_item(const QString& str,
     bool editable = false);

--- a/rmf_traffic_editor/gui/layer.cpp
+++ b/rmf_traffic_editor/gui/layer.cpp
@@ -20,6 +20,7 @@
 #include <QImageReader>
 #include <QGraphicsPixmapItem>
 #include <QGraphicsScene>
+#include <QTableWidget>
 #include "layer.h"
 using std::string;
 using std::vector;
@@ -284,4 +285,24 @@ void Layer::colorize_image()
     }
   }
   pixmap = QPixmap::fromImage(colorized_image);
+}
+
+void Layer::populate_property_editor(QTableWidget* property_editor) const
+{
+  property_editor->blockSignals(true);
+  property_editor->setRowCount(transform_strings.size());
+  for (size_t i = 0; i < transform_strings.size(); i++)
+  {
+    QTableWidgetItem* label_item = new QTableWidgetItem(
+      QString::fromStdString(transform_strings[i].first));
+    label_item->setFlags(Qt::NoItemFlags);
+
+    QTableWidgetItem* value_item = new QTableWidgetItem(
+      QString::fromStdString(transform_strings[i].second));
+    value_item->setFlags(Qt::NoItemFlags);
+
+    property_editor->setItem(i, 0, label_item);
+    property_editor->setItem(i, 1, value_item);
+  }
+  property_editor->blockSignals(false);
 }

--- a/rmf_traffic_editor/gui/layer.cpp
+++ b/rmf_traffic_editor/gui/layer.cpp
@@ -168,10 +168,12 @@ void Layer::draw(
   // for purposes of the origin mark, let's say the origin is the center
   // of the first pixel of the image
   const QPointF origin(
-    transform.translation().x() / level_meters_per_pixel +
-      0.5 * transform.scale() / level_meters_per_pixel * cos(transform.yaw() - M_PI / 4),
-    transform.translation().y() / level_meters_per_pixel -
-      0.5 * transform.scale() / level_meters_per_pixel * sin(transform.yaw() - M_PI / 4));
+    transform.translation().x() / level_meters_per_pixel
+    + 0.5 * transform.scale() / level_meters_per_pixel *
+    cos(transform.yaw() - M_PI / 4),
+    transform.translation().y() / level_meters_per_pixel
+    - 0.5 * transform.scale() / level_meters_per_pixel *
+    sin(transform.yaw() - M_PI / 4));
 
   scene->addEllipse(
     origin.x() - origin_radius,

--- a/rmf_traffic_editor/gui/layer.cpp
+++ b/rmf_traffic_editor/gui/layer.cpp
@@ -161,6 +161,31 @@ void Layer::draw(
 
   item->setRotation(-1.0 * transform.yaw() * 180.0 / M_PI);
 
+  double origin_radius = 0.5 / level_meters_per_pixel;
+  QPen origin_pen(color, origin_radius / 4.0, Qt::SolidLine, Qt::RoundCap);
+  //origin_pen.setWidthF(origin_radius / 4);
+
+  // for purposes of the origin mark, let's say the origin is the center
+  // of the first pixel of the image
+  const QPointF origin(
+    transform.translation().x() / level_meters_per_pixel +
+      0.5 * transform.scale() / level_meters_per_pixel * cos(transform.yaw() - M_PI / 4),
+    transform.translation().y() / level_meters_per_pixel -
+      0.5 * transform.scale() / level_meters_per_pixel * sin(transform.yaw() - M_PI / 4));
+
+  scene->addEllipse(
+    origin.x() - origin_radius,
+    origin.y() - origin_radius,
+    2 * origin_radius,
+    2 * origin_radius,
+    origin_pen);
+
+  QPointF x_arrow(
+    origin.x() + 2.0 * origin_radius * cos(transform.yaw()),
+    origin.y() - 2.0 * origin_radius * sin(transform.yaw()));
+  scene->addLine(QLineF(origin, x_arrow), origin_pen);
+
+
   for (Feature& feature : features)
     feature.draw(scene, color, transform, level_meters_per_pixel);
 }
@@ -276,14 +301,20 @@ void Layer::colorize_image()
     for (int col_idx = 0; col_idx < image.width(); col_idx++)
     {
       const uint8_t in = in_row[col_idx];
-      if (in < 100)
+      if (in < 100 || row_idx == 0 || row_idx == image.height() - 1)
         out_row[col_idx] = color.rgba();
       else if (in > 200)
         out_row[col_idx] = qRgba(0, 0, 0, 0);
       else
         out_row[col_idx] = qRgba(in, in, in, 50);
     }
+
+    // draw bold first/last columns the requested color on the image,
+    // so it's easier to see what's going on with its transform
+    out_row[0] = color.rgba();
+    out_row[image.width()-1] = color.rgba();
   }
+
   pixmap = QPixmap::fromImage(colorized_image);
 }
 

--- a/rmf_traffic_editor/gui/layer.h
+++ b/rmf_traffic_editor/gui/layer.h
@@ -29,6 +29,7 @@
 
 class QGraphicsScene;
 class QGraphicsPixmapItem;
+class QTableWidget;
 
 
 class Layer
@@ -86,6 +87,10 @@ public:
   QPointF transform_layer_to_global(const QPointF& layer_point);
 
   void clear_selection();
+
+  void populate_property_editor(QTableWidget* property_editor) const;
+
+  std::vector<std::pair<std::string, std::string>> transform_strings;
 };
 
 #endif

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -2211,13 +2211,6 @@ void Level::compute_layer_transform(const size_t layer_idx)
       "5cm FreeFleet -> RMF\ntranslate, rotate, scale",
       ff_rmf.to_string()));
 
-  /*
-  layer.transform_strings.push_back(
-    std::make_pair(
-      "RMF -> 5cm FreeFleet\nscale, rotate, translate",
-      ff_rmf.inverse().to_string()));
-  */
-
   Transform grid_rmf;
   grid_rmf.setScale(layer.transform.scale());
   grid_rmf.setYaw(-(fmod(layer.transform.yaw() + M_PI, 2 * M_PI) - M_PI));

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -2159,7 +2159,8 @@ void Level::compute_layer_transform(const size_t layer_idx)
   gridcells_rmf.setYaw(fmod(layer.transform.yaw() + M_PI, 2 * M_PI) - M_PI);
   const double gx =
     (layer.transform.translation().x() +
-    layer.image.height() * gridcells_rmf.scale() * sin(gridcells_rmf.yaw()));  const double gy =
+    layer.image.height() * gridcells_rmf.scale() * sin(gridcells_rmf.yaw()));
+  const double gy =
     (layer.transform.translation().y() +
     layer.image.height() * gridcells_rmf.scale() * cos(gridcells_rmf.yaw()));
   gridcells_rmf.setTranslation(QPointF(gx, gy));

--- a/rmf_traffic_editor/gui/level.h
+++ b/rmf_traffic_editor/gui/level.h
@@ -233,9 +233,6 @@ private:
     double hinge_y,
     double door_length,
     double door_angle) const;
-
-public:
-  double transform_cost(const size_t layer_idx, const Transform& t);
 };
 
 #endif

--- a/rmf_traffic_editor/gui/level.h
+++ b/rmf_traffic_editor/gui/level.h
@@ -174,6 +174,9 @@ public:
   bool export_features(const std::string& filename) const;
   void optimize_layer_transforms();
 
+  void compute_layer_transforms();
+  void compute_layer_transform(const size_t layer_idx);
+
 private:
   double point_to_line_segment_distance(
     const double x,

--- a/rmf_traffic_editor/gui/transform.cpp
+++ b/rmf_traffic_editor/gui/transform.cpp
@@ -82,6 +82,7 @@ Transform Transform::inverse() const
   inv.setYaw(-_yaw);
   inv.setScale(1.0 / _scale);
   inv.setTranslation(
+    _scale *
     QPointF(
       cos(-_yaw) * translation().x() - sin(-_yaw) * translation().y(),
       sin(-_yaw) * translation().x() + cos(-_yaw) * translation().y()));

--- a/rmf_traffic_editor/gui/transform.cpp
+++ b/rmf_traffic_editor/gui/transform.cpp
@@ -82,7 +82,7 @@ Transform Transform::inverse() const
   inv.setYaw(-_yaw);
   inv.setScale(1.0 / _scale);
   inv.setTranslation(
-    _scale *
+    1.0 / _scale *
     QPointF(
       cos(-_yaw) * translation().x() - sin(-_yaw) * translation().y(),
       sin(-_yaw) * translation().x() + cos(-_yaw) * translation().y()));
@@ -98,8 +98,8 @@ string Transform::to_string() const
     sizeof(buf),
     "rotation: %.5f\n"
     "scale: %.5f\n"
-    "translation X: %.5f\n"
-    "translation Y: %.5f",
+    "trans X: %.5f\n"
+    "trans Y: %.5f",
     _yaw,
     _scale,
     _translation.x(),

--- a/rmf_traffic_editor/gui/transform.cpp
+++ b/rmf_traffic_editor/gui/transform.cpp
@@ -19,6 +19,8 @@
 
 #include "transform.hpp"
 
+using std::string;
+
 
 Transform::Transform()
 {
@@ -72,4 +74,34 @@ QPointF Transform::backwards(const QPointF& p) const
   const double rx = cos(-_yaw) * tsx + sin(-_yaw) * tsy;
   const double ry = -sin(-_yaw) * tsx + cos(-_yaw) * tsy;
   return QPointF(rx, ry);
+}
+
+Transform Transform::inverse() const
+{
+  Transform inv;
+  inv.setYaw(-_yaw);
+  inv.setScale(1.0 / _scale);
+  inv.setTranslation(
+    QPointF(
+      cos(-_yaw) * translation().x() - sin(-_yaw) * translation().y(),
+      sin(-_yaw) * translation().x() + cos(-_yaw) * translation().y()));
+  return inv;
+}
+
+string Transform::to_string() const
+{
+  // make a string the old fashioned way...
+  char buf[1024] = {0};
+  snprintf(
+    buf,
+    sizeof(buf),
+    "rotation: %.5f\n"
+    "scale: %.5f\n"
+    "translation X: %.5f\n"
+    "translation Y: %.5f",
+    _yaw,
+    _scale,
+    _translation.x(),
+    _translation.y());
+  return string(buf);
 }

--- a/rmf_traffic_editor/gui/transform.hpp
+++ b/rmf_traffic_editor/gui/transform.hpp
@@ -53,6 +53,10 @@ public:
 
   bool from_yaml(const YAML::Node& data);
   YAML::Node to_yaml() const;
+
+  Transform inverse() const;
+
+  std::string to_string() const;
 };
 
 #endif  // TRAFFIC_EDITOR__TRANSFORM_HPP


### PR DESCRIPTION
## New feature implementation

### Implemented feature

When clicking a layer in the layer-selection table, now the property editor will show the transformation parameters in a few different formats in the Property Editor.

### Implementation description

This PR uses the transform currently being used to render a layer and computes it in a few different conventions. Because there are several different ways to parameterize transforms for different schemes (forward, backwards, translate-then-rotate, rotate-then-translate, etc.), it seems useful to automatically compute them and display more than one convention in `traffic-editor` so that users can copy/paste the data into the integration framework they are using. We have tested this for the current FreeFleet convention (which, in retrospect, isn't super intuitive...) in a few different maps.

The trick with this transform calculation is that most robot frameworks use the lower-left corner of the image as the origin, but in `traffic-editor` we are currently annotating in image space, where the upper-left corner of the image is the origin. This just requires a tiny bit of trig to convert between the spaces, which is implemented in this PR.