### PR TITLE
Fix/test maps build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
         cd ws
         source /opt/ros/foxy/setup.bash
         colcon build --packages-select rmf_traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
+        colcon build --packages-up-to rmf_traffic_editor_test_maps -DNO_DOWNLOAD_MODELS=True
 
     - name: test
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
         cd ws
         source /opt/ros/foxy/setup.bash
         colcon build --packages-select rmf_traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
-        colcon build --packages-up-to rmf_traffic_editor_test_maps -DNO_DOWNLOAD_MODELS=True
+        colcon build --packages-up-to rmf_traffic_editor_test_maps --cmake-args -DNO_DOWNLOAD_MODELS=True
 
     - name: test
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
         cd ws
         source /opt/ros/foxy/setup.bash
         colcon build --packages-select rmf_traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
-        colcon build --packages-up-to rmf_traffic_editor_test_maps --cmake-args -DNO_DOWNLOAD_MODELS=True
+        colcon build --packages-up-to test_maps --cmake-args -DNO_DOWNLOAD_MODELS=True
 
     - name: test
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: non-ros-deps
       run: |
         sudo apt-get update
-        sudo apt-get install -y git cmake wget libyaml-cpp-dev qt5-default libceres-dev libeigen3-dev
+        sudo apt-get install -y git cmake wget libyaml-cpp-dev qt5-default libceres-dev libeigen3-dev python3-shapely python3-requests python3-yaml
 
     - name: build
       shell: bash

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -14,6 +14,7 @@ from .floor import Floor
 from .wall import Wall
 from .hole import Hole
 from .model import Model
+from .param_value import ParamValue
 from .transform import Transform
 from .vertex import Vertex
 from .doors.swing_door import SwingDoor
@@ -154,9 +155,10 @@ class Level:
         for wall in self.walls:
             # check if param exists, if not use default val
             if "texture_name" not in wall.params:
-                wall.params["texture_name"] = 'default'
+                wall.params["texture_name"] =
+                    ParamValue([ParamValue.STRING, 'default'])
             if "alpha" not in wall.params:
-                wall.params["alpha"] = 1.0
+                wall.params["alpha"] = ParamValue([ParamValue.DOUBLE, 1.0])
             if wall.params not in wall_params_list:
                 wall_params_list.append(wall.params)
         print(f'Walls Generation, wall params list: {wall_params_list}')

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -155,8 +155,8 @@ class Level:
         for wall in self.walls:
             # check if param exists, if not use default val
             if "texture_name" not in wall.params:
-                wall.params["texture_name"] =
-                ParamValue([ParamValue.STRING, 'default'])
+                wall.params["texture_name"] = ParamValue(
+                        [ParamValue.STRING, 'default'])
             if "alpha" not in wall.params:
                 wall.params["alpha"] = ParamValue([ParamValue.DOUBLE, 1.0])
             if wall.params not in wall_params_list:

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -156,7 +156,7 @@ class Level:
             # check if param exists, if not use default val
             if "texture_name" not in wall.params:
                 wall.params["texture_name"] =
-                    ParamValue([ParamValue.STRING, 'default'])
+                ParamValue([ParamValue.STRING, 'default'])
             if "alpha" not in wall.params:
                 wall.params["alpha"] = ParamValue([ParamValue.DOUBLE, 1.0])
             if wall.params not in wall_params_list:


### PR DESCRIPTION
## Bug fix

### Fixed bug

When a map had an empty wall `texture_name` field (i.e. in `test_maps`), the default initialization assigned the value to a string while downstream code expected a ParamValue, this caused runtime errors.

### Fix applied

The assignment has been changed to ParamValue, also github actions have been updated to compile `test_maps` to test for this kind of regressions in the future.

Note to self / others, we should probably rename the package to `rmf_traffic_editor_test_maps` and not `test_maps`.