### PR TITLE
improve building map tools

### DIFF
--- a/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
+++ b/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
@@ -33,10 +33,30 @@ parser.add_argument("INPUT_YAML", type=str,
                     help="Input building.yaml file to process")
 parser.add_argument("-m", "--model-path", type=str,
                     default="~/.gazebo/models/",
-                    help="Path to check models from and download models to")
+                    help="Path to check models from and download models to. \
+                        Redundant if using ignition fuel tools flag")
 parser.add_argument("-c", "--cache", type=str,
                     default="~/.pit_crew/model_cache.json",
                     help="Path to pit_crew model cache")
+parser.add_argument(
+    "-i",
+    "--include",
+    type=str,
+    help="Search this directory first for models. If -f flag is specified, \
+          then directory must follow ignition gazebo directory structure.")
+parser.add_argument(
+    "-f",
+    "--fuel_tools",
+    action='store_true',
+    help="Use ignition fuel tools to download models instead of http")
+parser.add_argument(
+    "-e",
+    "--export_path",
+    type=str,
+    default=None,
+    help="Export model downloaded using ignition fuel tools to a folder \
+                    with classic gazebo directory structure. Only relevant if \
+                    ignition fuel tools is used to download models.")
 
 
 def get_crowdsim_models(input_filename):
@@ -58,7 +78,13 @@ def get_crowdsim_models(input_filename):
         return actor_names
 
 
-def download_models(input_yaml, model_path=None, cache=None):
+def download_models(
+        input_yaml,
+        model_path=None,
+        cache=None,
+        include=None,
+        fuel_tools=False,
+        export_path=None):
     """Download models for a given input building yaml."""
     # Construct model set
     model_set = set()
@@ -82,11 +108,23 @@ def download_models(input_yaml, model_path=None, cache=None):
             else:
                 model_set.add(model.model_name)
 
+    # If we are using ignition fuel tools to download the models
+    # and we do not need to parse them, it means the model directory follows
+    # the ignition gazebo directory structure
+    ign = fuel_tools
+    logging.info("\nUsing Ignition Fuel directory struture : %s\n" % (ign))
+    # Ignitional fuel tools can only download to this folder, so we set the
+    # model path to it
+    if fuel_tools:
+        model_path = "~/.ignition/fuel/"
+
     missing_models = pit_crew.get_missing_models(
         model_set,
         model_path=model_path,
         cache_file_path=cache,
-        lower=True
+        lower=True,
+        priority_dir=include,
+        ign=ign
     )
 
     logger.info("\n== REQUESTED MODEL REPORT ==")
@@ -96,7 +134,8 @@ def download_models(input_yaml, model_path=None, cache=None):
     pprint(stringent_dict)
     print()
 
-    for downloadable_model in missing_models.get('downloadable', []):
+    missing_downloadables = missing_models.get('downloadable', [])
+    for key, downloadable_model in enumerate(missing_downloadables):
         model_name, author_names = downloadable_model
 
         if model_name in stringent_dict:
@@ -112,8 +151,16 @@ def download_models(input_yaml, model_path=None, cache=None):
                            "using first valid author '%s'" %
                            (model_name, author_name))
 
-        pit_crew.download_model(model_name, author_name, sync_names=True,
-                                download_path=model_path)
+        logger.info("Downloading model %s / %s : %s" %
+                    (key + 1, len(missing_downloadables), model_name))
+
+        if fuel_tools:
+            pit_crew.download_model_fuel_tools(
+                model_name, author_name,
+                sync_names=True, export_path=export_path)
+        else:
+            pit_crew.download_model(model_name, author_name, sync_names=True,
+                                    download_path=model_path, ign=ign)
 
     if missing_models.get('missing', []):
         logger.warning("\nMissing models (not in local or Fuel):")
@@ -122,7 +169,13 @@ def download_models(input_yaml, model_path=None, cache=None):
 
 def main():
     args = parser.parse_args()
-    download_models(args.INPUT_YAML, args.model_path, args.cache)
+    download_models(
+        args.INPUT_YAML,
+        args.model_path,
+        args.cache,
+        args.include,
+        args.fuel_tools,
+        args.export_path)
 
 
 if __name__ == "__main__":

--- a/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
+++ b/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
@@ -38,25 +38,18 @@ parser.add_argument("-m", "--model-path", type=str,
 parser.add_argument("-c", "--cache", type=str,
                     default="~/.pit_crew/model_cache.json",
                     help="Path to pit_crew model cache")
-parser.add_argument(
-    "-i",
-    "--include",
-    type=str,
-    help="Search this directory first for models. If -f flag is specified, \
-          then directory must follow ignition gazebo directory structure.")
-parser.add_argument(
-    "-f",
-    "--fuel_tools",
-    action='store_true',
-    help="Use ignition fuel tools to download models instead of http")
-parser.add_argument(
-    "-e",
-    "--export_path",
-    type=str,
-    default=None,
-    help="Export model downloaded using ignition fuel tools to a folder \
-                    with classic gazebo directory structure. Only relevant if \
-                    ignition fuel tools is used to download models.")
+parser.add_argument("-i", "--include", type=str,
+                    help="Search this directory first for models. "
+                         "If -f flag is specified, then directory must "
+                         "follow ignition gazebo directory structure.")
+parser.add_argument("-f", "--fuel-tools", action='store_true',
+                    help="Use ignition fuel tools to download models instead "
+                         "of http")
+parser.add_argument("-e", "--export-path", type=str, default=None,
+                    help="Export model downloaded using ignition fuel tools "
+                         "to a folder with classic gazebo directory structure."
+                         " Only relevant if ignition fuel tools is used to "
+                         "download models.")
 
 
 def get_crowdsim_models(input_filename):
@@ -113,7 +106,7 @@ def download_models(
     # the ignition gazebo directory structure
     ign = fuel_tools
     logging.info("\nUsing Ignition Fuel directory struture : %s\n" % (ign))
-    # Ignitional fuel tools can only download to this folder, so we set the
+    # Ignition fuel tools can only download to this folder, so we set the
     # model path to it
     if fuel_tools:
         model_path = "~/.ignition/fuel/"

--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -34,6 +34,7 @@ See Also:
 from collections import namedtuple
 import xml.etree.ElementTree as ET
 
+from urllib import parse
 import subprocess
 import requests
 import logging
@@ -619,17 +620,24 @@ def download_model_fuel_tools(model_name, author_name,
             "~/.ignition/fuel/fuel.ignitionrobotics.org"
         )
         # Command line
+        url_model_name = parse.quote(model_name)
         full_url = ("https://fuel.ignitionrobotics.org/1.0" +
-                    '/' + author_name + '/models' + '/' + model_name)
+                    '/' + author_name + '/models' + '/' + url_model_name)
         full_command = full_command = ("ign fuel download -u "
                                        + full_url + " -v 4")
         subprocess.call([full_command], shell=True)
 
-        extract_path = os.path.join(
+        extract_path_base = os.path.join(
             download_path,
             author_name.lower(),
-            "models",
+            "models")
+        extract_path = os.path.join(
+            extract_path_base,
             model_name.lower())
+
+        if " " in model_name:
+            os.rename(os.path.join(extract_path_base, url_model_name.lower()),
+                      extract_path)
 
         # Get the latest version downloaded by looking at the subdirectories
         # with the largest numbered name

--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -32,9 +32,9 @@ See Also:
 """
 
 from collections import namedtuple
-from pprint import pprint
 import xml.etree.ElementTree as ET
 
+import subprocess
 import requests
 import logging
 import zipfile
@@ -45,7 +45,6 @@ import sys
 import io
 import os
 import re
-import subprocess
 
 __all__ = [
     "swag",

--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -32,6 +32,7 @@ See Also:
 """
 
 from collections import namedtuple
+from pprint import pprint
 import xml.etree.ElementTree as ET
 
 import requests
@@ -44,6 +45,7 @@ import sys
 import io
 import os
 import re
+import subprocess
 
 __all__ = [
     "swag",
@@ -60,7 +62,9 @@ __all__ = [
     "build_and_update_cache",
     "init_logging",
     "PitCrewFormatter",
-    "ModelNames"
+    "ModelNames",
+    "download_model_fuel_tools",
+    "sync_sdf"
 ]
 
 # Init logger
@@ -98,7 +102,8 @@ def swag(print_swag=True):
 def get_missing_models(model_names, model_path=None,
                        config_file="model.config",
                        cache_file_path=None, update_cache=True, lower=True,
-                       use_dir_as_name=False, ign=False):
+                       use_dir_as_name=False, ign=False,
+                       priority_dir=None):
     """
     Classify models as missing, downloadable, or available from a model list.
 
@@ -122,6 +127,8 @@ def get_missing_models(model_names, model_path=None,
             name as its model_name. Defaults to False.
         ign (bool, optional): If True, will parse model directory as if it is
             following Ignition's directory structure. Defaults to False.
+        priority_dir (str, optional): Check this directory first to see if the
+            a model is there.
 
     Returns:
         dict: A dictionary of classified model names.
@@ -134,7 +141,7 @@ def get_missing_models(model_names, model_path=None,
                 and also missing from Fuel.
     """
     for key, model_name in enumerate(model_names):
-        if type(model_name) is ModelNames or type(model_name) is tuple:
+        if isinstance(model_name, ModelNames) or isinstance(model_name, tuple):
             assert len(model_name) == 2, \
                 "Invalid model name tuple given: %s!" % model_name
 
@@ -145,7 +152,20 @@ def get_missing_models(model_names, model_path=None,
         cache = load_cache(cache_file_path, lower=lower)
 
     fuel_models = get_model_to_author_dict(cache['model_cache'], lower=lower)
+    priority_models = {}
     local_models = {}
+
+    if priority_dir is not None:
+        logger.info("Will check '%s' directory first for models"
+                    % (priority_dir))
+        for priority_model in get_local_model_name_tuples(
+            priority_dir, config_file=config_file, lower=lower,
+            use_dir_as_name=use_dir_as_name, ign=ign
+        ):
+            if priority_model[0] in priority_models:
+                priority_models[priority_model[0]].append(priority_model[1])
+            else:
+                priority_models[priority_model[0]] = [[priority_model[1]]]
 
     for local_model in get_local_model_name_tuples(
         model_path, config_file=config_file, lower=lower,
@@ -162,13 +182,13 @@ def get_missing_models(model_names, model_path=None,
 
     for model in model_names:
         # Obtain model and author names
-        if type(model) is str:
+        if isinstance(model, str):
             model_name = model
             author_name = ""
-        elif type(model) is tuple:
+        elif isinstance(model, tuple):
             model_name = model[0]
             author_name = model[1]
-        elif type(model) is ModelNames:
+        elif isinstance(model, ModelNames):
             model_name = model.model_name
             author_name = model.author_name
 
@@ -176,13 +196,25 @@ def get_missing_models(model_names, model_path=None,
             model_name = model_name.lower()
             author_name = author_name.lower()
 
-        if model_name in local_models:
-            output['available'].append(model_name)
+        if model_name in priority_models and model_name in local_models:
+            logger.warning(
+                "Model %s found in both '%s'and '%s'! "
+                " Will use model in priority folder '%s'" %
+                (model_name, priority_dir, model_path, priority_dir))
 
+        if model_name in priority_models:
+            output['available'].append(model_name)
+            if author_name:
+                if author_name not in priority_models[model_name]:
+                    logger.warning("Model %s in local model directory"
+                                   " is not by the requested author %s!"
+                                   % (model_name, author_name))
+        elif model_name in local_models:
+            output['available'].append(model_name)
             if author_name:
                 if author_name not in local_models[model_name]:
-                    logger.warning("Model %s in local model directory is not "
-                                   "by the requested author %s!"
+                    logger.warning("Model %s in local model directory"
+                                   " is not by the requested author %s!"
                                    % (model_name, author_name))
         elif model_name in fuel_models:
             output['downloadable'].append((model_name,
@@ -406,7 +438,7 @@ def get_fuel_authors(model_name, cache_file_path=None, update_cache=True):
     else:
         cache = load_cache(cache_file_path)
 
-    if type(model_name) is ModelNames or type(model_name) is tuple:
+    if isinstance(model_name, ModelNames) or isinstance(model_name, tuple):
         assert len(model_name) == 2, "Invalid model name tuple given: %s!" \
             % model_name
         model_name = model_name[0]
@@ -424,10 +456,9 @@ def list_fuel_models(cache_file_path=None, update_cache=True, model_limit=-1,
     else:
         cache = load_cache(cache_file_path, lower=lower)
 
-    sorted_authors = list(
+    sorted_authors = sorted(
         get_author_to_model_dict(cache['model_cache'], lower=lower).items()
     )
-    sorted_authors.sort()
     print("\n[Models]\n")
 
     for (author_name, model_names) in sorted_authors:
@@ -547,88 +578,120 @@ def download_model(model_name, author_name, version="tip",
 
         logger.info("%s downloaded to: %s" % (model_name, extract_path))
 
-        try:
-            # Sync all instances of the model name in sdf to the folder name
-            if sync_names:
-                tree = ET.parse(os.path.join(extract_path, "model.sdf"))
-                sdf = tree.findall("model")[0]
-                old_name = sdf.attrib.get("name")
-
-                if old_name != model_name:
-                    # Sync name attribute
-                    sdf.attrib['name'] = model_name
-
-                    # Sync instances of name in child tags
-                    for uri in tree.findall('.//uri'):
-                        old_text = uri.text
-                        replace_str = re.sub("model://%s/" % old_name,
-                                             "model://%s/" % model_name,
-                                             uri.text,
-                                             flags=re.IGNORECASE)
-
-                        if old_text != replace_str:
-                            uri.text = replace_str
-                            logger.warning("Internal name reference for %s "
-                                           "changed from %s to %s"
-                                           % (model_name,
-                                              old_text,
-                                              replace_str))
-                    logger.warning("Synced SDF names for %s! "
-                                   "Changed from %s to %s"
-                                   % (model_name, old_name, model_name))
-
-                # NOTE(CH3): Sanitise malformed SDFs
-                # Replaces 'close-enough' names with the appropriate folder
-                # name.
-                #
-                # E.g.: If folder name is Lamp Post, but internal reference
-                #       uses lamp_post, replaces those with Lamp Post.
-                #
-                # This catches cases where the internal reference is not
-                # replaced because it is simply not the same as the sdf model
-                # name.
-                #
-                # (Usually in the case of http://models.gazebosim.org/ models)
-
-                # NOTE(CH3): Introduces the edge case where Lamp Post
-                # is interdependent on another model called lamp_post. But
-                # that case should be so rare, and so bad in a coding standard
-                # standpoint where it should more or less never occur.
-                for uri in tree.findall('.//uri'):
-                    old_text = uri.text
-                    regex_search_exp = re.sub("[ _]",
-                                              "[ _]",
-                                              old_name)
-
-                    replace_str = re.sub(
-                        "model://%s/" % regex_search_exp,
-                        "model://%s/" % model_name,
-                        uri.text,
-                        flags=re.IGNORECASE
-                    )
-
-                    if old_text != replace_str:
-                        uri.text = replace_str
-                        logger.warning("Sanitising name reference for %s. "
-                                       "Changed from %s to %s"
-                                       % (model_name,
-                                          old_text,
-                                          replace_str))
-
-                if old_name != model_name:
-                    logger.warning("Synced SDF names for %s! "
-                                   "Changed from %s to %s"
-                                   % (model_name, old_name, model_name))
-                tree.write(os.path.join(extract_path, "model.sdf"))
-
-        except Exception as e:
-            logger.error("Syncing of names for %s failed! %s"
-                         % (model_name, e))
+        if sync_names:
+            sync_sdf(model_name=model_name, extract_path=extract_path)
 
         return True, metadata_dict
     except Exception as e:
         logger.error("Could not download model '%s'! %s" % (model_name, e))
         return False, None
+
+
+def download_model_fuel_tools(model_name, author_name,
+                              sync_names=False, export_path=None,
+                              overwrite=True):
+    """
+    Fetch and download a model from Fuel using the official Fuel Tools API
+
+    Supports exporting the downloaded models into a directory with
+    Gazebo structure
+
+    Args:
+        model_name (str): Model name as listed on Fuel. Case insensitive.
+        author_name (str): Model Author/Owner as listed on Fuel. Case
+            insensitive.
+        sync_names (bool, optional): Change downloaded model.sdf model name to
+            match folder name. Defaults to False.
+        export_path (string, optional): If not none, then will export
+            downloaded models to specified directory with gazebo
+            directory structure.
+        overwrite (bool, optional) : Overwrite existing model files in the
+            export_path directory. Only revelant if export_path is defined.
+            Defaults to True.
+
+    Returns:
+        bool: True if successful. False otherwise.
+    """
+
+    try:
+        # Currently, ignition fuel download can only download to this folder.
+        # Fuel tools creates this folder if it does not yet exist
+        download_path = os.path.expanduser(
+            "~/.ignition/fuel/fuel.ignitionrobotics.org"
+        )
+        # Command line
+        full_url = ("https://fuel.ignitionrobotics.org/1.0" +
+                    '/' + author_name + '/models' + '/' + model_name)
+        full_command = full_command = ("ign fuel download -u "
+                                       + full_url + " -v 4")
+        subprocess.call([full_command], shell=True)
+
+        extract_path = os.path.join(
+            download_path,
+            author_name.lower(),
+            "models",
+            model_name.lower())
+
+        # Get the latest version downloaded by looking at the subdirectories
+        # with the largest numbered name
+        sub_dirs = []
+        for dirname, dirnames, filenames in os.walk(extract_path):
+            for subdirname in dirnames:
+                try:
+                    n = int(subdirname)
+                    sub_dirs.append(n)
+                except ValueError as e:
+                    logger.error(
+                        "Ignoring subdirectory %s "
+                        "which is not a version number" %
+                        (subdirname))
+                    pass
+            break
+        latest_ver = max(sub_dirs)
+        extract_path = os.path.join(extract_path, str(latest_ver))
+
+        if sync_names:
+            sync_sdf(model_name=model_name.lower(), extract_path=extract_path)
+
+        export_path = os.path.expanduser(export_path)
+        if export_path is not None:
+            # Make directory if missing
+            if not os.path.isdir(export_path):
+                os.makedirs(export_path, exist_ok=True)
+                logger.warning("Export path does not exist! Created: %s"
+                               % export_path)
+            # Model does not currently exist
+            if not os.path.isdir(os.path.join(export_path, model_name)):
+                export_path = os.path.join(export_path, model_name)
+                try:
+                    shutil.copytree(src=extract_path, dst=export_path)
+                    logger.info(
+                        "Exporting %s to %s" %
+                        (model_name, export_path))
+                except Exception as e:
+                    logger.error(
+                        "Could not export %s to %s" %
+                        (extract_path, export_path))
+            else:
+                if overwrite:
+                    export_path = os.path.join(export_path, model_name)
+                    logger.info("Overwriting model %s" % (export_path))
+                    try:
+                        shutil.rmtree(path=export_path)
+                        shutil.copytree(src=extract_path, dst=export_path)
+                    except Exception as e:
+                        logger.error(
+                            "Could not export %s to %s" %
+                            (extract_path, export_path))
+                else:
+                    logger.info(
+                        "Model %s already exists at %s" %
+                        (model_name, export_path))
+
+        return True
+    except Exception as e:
+        logger.error("Could not download model '%s'! %s" % (model_name, e))
+        return False
 
 
 def _construct_license(fuel_metadata_dict):
@@ -821,3 +884,82 @@ def init_logging():
     logger = logging.getLogger()
     logger.addHandler(handler)
     logger.setLevel(logging.INFO)
+
+
+def sync_sdf(model_name, extract_path):
+    # Sync all instances of the model name in sdf to the folder name
+    try:
+        tree = ET.parse(os.path.join(extract_path, "model.sdf"))
+        sdf = tree.findall("model")[0]
+        old_name = sdf.attrib.get("name")
+
+        if old_name != model_name:
+            # Sync name attribute
+            sdf.attrib['name'] = model_name
+
+            # Sync instances of name in child tags
+            for uri in tree.findall('.//uri'):
+                old_text = uri.text
+                replace_str = re.sub("model://%s/" % old_name,
+                                     "model://%s/" % model_name,
+                                     uri.text,
+                                     flags=re.IGNORECASE)
+
+                if old_text != replace_str:
+                    uri.text = replace_str
+                    logger.warning("Internal name reference for %s "
+                                   "changed from %s to %s"
+                                   % (model_name,
+                                       old_text,
+                                       replace_str))
+            logger.warning("Synced SDF names for %s! "
+                           "Changed from %s to %s"
+                           % (model_name, old_name, model_name))
+
+        # NOTE(CH3): Sanitise malformed SDFs
+        # Replaces 'close-enough' names with the appropriate folder
+        # name.
+        #
+        # E.g.: If folder name is Lamp Post, but internal reference
+        #       uses lamp_post, replaces those with Lamp Post.
+        #
+        # This catches cases where the internal reference is not
+        # replaced because it is simply not the same as the sdf model
+        # name.
+        #
+        # (Usually in the case of http://models.gazebosim.org/ models)
+
+        # NOTE(CH3): Introduces the edge case where Lamp Post
+        # is interdependent on another model called lamp_post. But
+        # that case should be so rare, and so bad in a coding standard
+        # standpoint where it should more or less never occur.
+        for uri in tree.findall('.//uri'):
+            old_text = uri.text
+            regex_search_exp = re.sub("[ _]",
+                                      "[ _]",
+                                      old_name)
+
+            replace_str = re.sub(
+                "model://%s/" % regex_search_exp,
+                "model://%s/" % model_name,
+                uri.text,
+                flags=re.IGNORECASE
+            )
+
+            if old_text != replace_str:
+                uri.text = replace_str
+                logger.warning("Sanitising name reference for %s. "
+                               "Changed from %s to %s"
+                               % (model_name,
+                                   old_text,
+                                   replace_str))
+
+        if old_name != model_name:
+            logger.warning("Synced SDF names for %s! "
+                           "Changed from %s to %s"
+                           % (model_name, old_name, model_name))
+        tree.write(os.path.join(extract_path, "model.sdf"))
+
+    except Exception as e:
+        logger.error("Syncing of names for %s failed! %s"
+                     % (model_name, e))


### PR DESCRIPTION
## New feature implementation

### Implemented feature

1. Try to make model downloading more transparent during the package build process
2. Add functionality to filter models based on the availability of it in certain locations
3. Use Ignition fuel tools for downloading models for both classic gazebo and ignition gazebo instead of GET requests

### Implementation description

1. Just added some additional logging statements. Transparency is difficult during build process as colcon build by default only prints outputs after a package has been build, unless explicit told [otherwise](https://colcon.readthedocs.io/en/released/reference/event-handler-arguments.html).
2. `-i` flag in `building_map_model_downloader.py` to specify which folder to look for models first.
3. `-f` flag in `building_map_model_downloader.py` to specify to use Ignition fuel tool to download models.
3.1 Models are downloaded to `~/.ignition/fuel/fuel.ignitionrobotics.org/`
3.2 If `-e` flag is specified, then the downloaded models will be exported to the specified directory with the classic gazebo directory structure.
