### PR TITLE
Fix issues with building map tools using Ignition tools

### DIFF
--- a/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
+++ b/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
@@ -109,7 +109,11 @@ def download_models(
     # Ignition fuel tools can only download to this folder, so we set the
     # model path to it
     if fuel_tools:
-        model_path = "~/.ignition/fuel/"
+        if export_path is not None:
+            model_path = export_path
+            ign = False
+        else:
+            model_path = "~/.ignition/fuel/"
 
     missing_models = pit_crew.get_missing_models(
         model_set,

--- a/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
+++ b/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
@@ -131,8 +131,8 @@ def download_models(
     for key, downloadable_model in enumerate(missing_downloadables):
         model_name, author_names = downloadable_model
 
-        if model_name in stringent_dict:
-            author_name = stringent_dict[model_name]
+        if model_name.lower() in stringent_dict:
+            author_name = stringent_dict[model_name.lower()]
             logger.info("\nDownloading %s by %s from Fuel"
                         % (model_name, author_name))
         else:

--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -192,6 +192,8 @@ def get_missing_models(model_names, model_path=None,
             model_name = model.model_name
             author_name = model.author_name
 
+        model_name_original = model_name
+
         if lower:
             model_name = model_name.lower()
             author_name = author_name.lower()
@@ -203,21 +205,21 @@ def get_missing_models(model_names, model_path=None,
                 (model_name, priority_dir, model_path, priority_dir))
 
         if model_name in priority_models:
-            output['available'].append(model_name)
+            output['available'].append(model_name_original)
             if author_name:
                 if author_name not in priority_models[model_name]:
                     logger.warning("Model %s in local model directory"
                                    " is not by the requested author %s!"
                                    % (model_name, author_name))
         elif model_name in local_models:
-            output['available'].append(model_name)
+            output['available'].append(model_name_original)
             if author_name:
                 if author_name not in local_models[model_name]:
                     logger.warning("Model %s in local model directory"
                                    " is not by the requested author %s!"
                                    % (model_name, author_name))
         elif model_name in fuel_models:
-            output['downloadable'].append((model_name,
+            output['downloadable'].append((model_name_original,
                                           fuel_models[model_name]))
 
             if author_name:
@@ -226,7 +228,7 @@ def get_missing_models(model_names, model_path=None,
                                    "by the requested author %s!"
                                    % (model_name, author_name))
         else:
-            output['missing'].append(model_name)
+            output['missing'].append(model_name_original)
 
     return output
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

1. #360. The folders downloaded by Ignition is always in lowercase, and so does the exported folders. This results in gazebo being unable to find the models.
2. #361 

### Fix applied
 
1. Commit 6fa825f. Have the exported folders follow the original name of the models as described in the `building.yaml` file.
2. Commit abe741b. If exporting models, automatically check the export path for missing models.