### PR TITLE
Minor tweak to how empty crowd_sim and lift structures are serialized in YAML

### DIFF
--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -164,6 +164,8 @@ bool Building::save()
   y["lifts"] = YAML::Node(YAML::NodeType::Map);
   for (const auto& lift : lifts)
     y["lifts"][lift.name] = lift.to_yaml();
+  if (lifts.empty())
+    y["lifts"].SetStyle(YAML::EmitterStyle::Flow);
 
   if (crowd_sim_impl)
     y["crowd_sim"] = crowd_sim_impl->to_yaml();

--- a/rmf_traffic_editor/gui/crowd_sim/crowd_sim_impl.cpp
+++ b/rmf_traffic_editor/gui/crowd_sim/crowd_sim_impl.cpp
@@ -96,6 +96,8 @@ YAML::Node CrowdSimImplementation::to_yaml()
   {
     top_node["goal_sets"].push_back(goal_set.to_yaml());
   }
+  if (!_goal_sets.size())
+    top_node["goal_sets"].SetStyle(YAML::EmitterStyle::Flow);
 
   top_node["agent_profiles"] = YAML::Node(YAML::NodeType::Sequence);
   for (auto profile : _agent_profiles)
@@ -108,6 +110,8 @@ YAML::Node CrowdSimImplementation::to_yaml()
   {
     top_node["transitions"].push_back(transition.to_yaml());
   }
+  if (!_transitions.size())
+    top_node["transitions"].SetStyle(YAML::EmitterStyle::Flow);
 
   top_node["obstacle_set"] = _output_obstacle_node();
 
@@ -122,6 +126,8 @@ YAML::Node CrowdSimImplementation::to_yaml()
   {
     top_node["model_types"].push_back(model_type.to_yaml());
   }
+  if (!_model_types.size())
+    top_node["model_types"].SetStyle(YAML::EmitterStyle::Flow);
 
   return top_node;
 }


### PR DESCRIPTION
This is a trivial PR that explicitly sets how whitespace (carriage returns and indents) are handled for a few places when serializing the `crowd_sim` data structure in YAML. The two forms are equivalent; this just causes `yaml-cpp` to generate whitespace in the same way that the JavaScript `yaml` library generates it when the emitter comes upon an empty sequence nested inside a block-style map. Otherwise, the two implementations (C++ and JavaScript) would generate whitespace diffs each time they saved each other's files.

Similarly, for empty lift maps (i.e. building models that do not have lifts), this PR forces a flow-style empty map `{}` to be generated in `yaml-cpp`, to force the whitespace to be generated identically by the `yaml-cpp` and JavaScript `yaml` libraries.