### PR TITLE
hotfix for #366, avoid exploding transform for 1 fudicual

### DIFF
--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -489,6 +489,8 @@ Building::Transform Building::compute_transform(
     }
   }
 
+  if (distances.empty())
+    return Building::Transform();
 
   // for now, we'll just compute the mean of the relative scale estimates.
   // we can do fancier statistics later, if needed.


### PR DESCRIPTION
## Bug fix

### Fixed bug

If only one fiducial was defined on a level, previously it would try to divide by zero :facepalm:  when aligning the levels. This trivial PR just recognizes this case and returns the (0, 0, 0) transform. Fixes #366 discussed in https://github.com/open-rmf/rmf/discussions/69
