### PR TITLE
Fix crash when level has no floors

### DIFF
--- a/rmf_building_map_tools/building_map/material_utils.py
+++ b/rmf_building_map_tools/building_map/material_utils.py
@@ -20,6 +20,9 @@ def get_pbr_textures(params):
 def copy_texture(texture_name, dest_path):
     texture_filename = f'{texture_name}.png'
     texture_path_dest = f'{dest_path}/{texture_filename}'
+    # Create the destination path if it does not exist
+    if not os.path.exists(dest_path):
+        os.makedirs(dest_path)
     # If the texture name is a URL fetch it
     result = urlparse(texture_name)
     texture_is_url = all([result.scheme, result.netloc, result.path])


### PR DESCRIPTION
## Bug fix

### Fixed bug

Closes #369, `building_map` crashing when there is no floor because of a `FileNotFound` error.  

### Fix applied

When there is no floor, the floor generation function will be called and the script will go straight into wall generation. The issue was that the `meshes` folder might not have been created, it is done [here](https://github.com/open-rmf/rmf_traffic_editor/blob/main/rmf_building_map_tools/building_map/wall.py#L41-L43), however the `generate_wall_visual_mesh` function is called after the `add_pbr_material` which assumes that the folder exists.
The quick fix is to add a check in the [copy_texture](https://github.com/open-rmf/rmf_traffic_editor/blob/7043bffcdcc89e652b95985e8b1a519c08663d30/rmf_building_map_tools/building_map/material_utils.py#L20) function (called by `add_pbr_material`) for directory existence, and create it if it is not found.