### PR TITLE
Feature: align vertices colinear

### DIFF
--- a/rmf_traffic_editor/gui/building.h
+++ b/rmf_traffic_editor/gui/building.h
@@ -172,12 +172,14 @@ public:
     std::vector<EditorModel>& editor_models,
     const RenderingOptions& rendering_options);
 
+  /*
   void mouse_select_press(
     const int level_idx,
     const double x,
     const double y,
     QGraphicsItem* graphics_item,
     const RenderingOptions& rendering_options);
+  */
 
   Polygon* get_selected_polygon(const int level_idx);
 

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -1623,7 +1623,8 @@ void Editor::mouse_select(
     p.x(),
     p.y(),
     item,
-    rendering_options);
+    rendering_options,
+    e->modifiers());
 
   // todo: figure out something smarter than this abomination
   selected_polygon = building.get_selected_polygon(level_idx);

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -337,6 +337,13 @@ Editor::Editor()
     QKeySequence(Qt::CTRL + Qt::Key_T));
   edit_menu->addSeparator();
 
+  edit_menu->addAction(
+    "Align &colinear",
+    this,
+    &Editor::edit_align_colinear,
+    QKeySequence(Qt::Key_Slash));
+  edit_menu->addSeparator();
+
   edit_menu->addAction("&Preferences...", this, &Editor::edit_preferences);
 
   // VIEW MENU
@@ -765,6 +772,16 @@ void Editor::edit_optimize_layer_transforms()
   printf("Editor::edit_optimize_layer_transforms()\n");
   if (level_idx < static_cast<int>(building.levels.size()))
     building.levels[level_idx].optimize_layer_transforms();
+  create_scene();
+}
+
+void Editor::edit_align_colinear()
+{
+  printf("Editor::edit_align_colinear()\n");
+  Level* level = active_level();
+  if (!level)
+    return;
+  level->align_colinear();
   create_scene();
 }
 

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -1102,11 +1102,12 @@ void Editor::update_property_editor()
     }
   }
 
-  for (const auto& v : building.levels[level_idx].vertices)
+  for (size_t i = 0; i < building.levels[level_idx].vertices.size(); i++)
   {
+    const Vertex& v = building.levels[level_idx].vertices[i];
     if (v.selected)
     {
-      populate_property_editor(v);
+      populate_property_editor(v, i);
       return;  // stop after finding the first one
     }
   }
@@ -1221,7 +1222,8 @@ void Editor::add_param_button_clicked()
     undo_stack.push(cmd);
     auto updated_id = cmd->get_vertex_updated();
     populate_property_editor(
-      building.levels[level_idx].vertices[updated_id]);
+      building.levels[level_idx].vertices[updated_id],
+      updated_id);
     setWindowModified(true);
   }
 }
@@ -1343,25 +1345,26 @@ void Editor::populate_property_editor(const Edge& edge)
   property_editor->blockSignals(false);  // re-enable callbacks
 }
 
-void Editor::populate_property_editor(const Vertex& vertex)
+void Editor::populate_property_editor(const Vertex& vertex, const int index)
 {
   const Level& level = building.levels[level_idx];
   const double scale = level.drawing_meters_per_pixel;
 
   property_editor->blockSignals(true);  // otherwise we get tons of callbacks
-  property_editor->setRowCount(5 + vertex.params.size());
+  property_editor->setRowCount(6 + vertex.params.size());
 
-  property_editor_set_row(0, "x (pixels)", vertex.x, 3, true);
-  property_editor_set_row(1, "y (pixels)", vertex.y, 3, true);
-  property_editor_set_row(2, "x (m)", vertex.x * scale);
-  property_editor_set_row(3, "y (m)", -1.0 * vertex.y * scale);
+  property_editor_set_row(0, "index", index);
+  property_editor_set_row(1, "x (pixels)", vertex.x, 3, true);
+  property_editor_set_row(2, "y (pixels)", vertex.y, 3, true);
+  property_editor_set_row(3, "x (m)", vertex.x * scale);
+  property_editor_set_row(4, "y (m)", -1.0 * vertex.y * scale);
   property_editor_set_row(
-    4,
+    5,
     "name",
     QString::fromStdString(vertex.name),
     true);
 
-  int row = 5;
+  int row = 6;
   for (const auto& param : vertex.params)
   {
     property_editor_set_row(

--- a/rmf_traffic_editor/gui/editor.h
+++ b/rmf_traffic_editor/gui/editor.h
@@ -216,7 +216,7 @@ private:
   void clear_property_editor();
   void populate_property_editor(const Edge& edge);
   void populate_property_editor(const Model& model);
-  void populate_property_editor(const Vertex& vertex);
+  void populate_property_editor(const Vertex& vertex, const int index);
   void populate_property_editor(const Feature& feature);
   void populate_property_editor(const Fiducial& fiducial);
   void populate_property_editor(const Polygon& polygon);

--- a/rmf_traffic_editor/gui/editor.h
+++ b/rmf_traffic_editor/gui/editor.h
@@ -143,6 +143,7 @@ private:
   void edit_project_properties();
   void edit_rotate_all_models();
   void edit_optimize_layer_transforms();
+  void edit_align_colinear();
 
   void level_add();
   void level_edit();

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -1801,9 +1801,11 @@ void Level::mouse_select_press(
   const double x,
   const double y,
   QGraphicsItem* graphics_item,
-  const RenderingOptions& rendering_options)
+  const RenderingOptions& rendering_options,
+  const Qt::KeyboardModifiers& modifiers)
 {
-  clear_selection();
+  if (!(modifiers & Qt::ShiftModifier))
+    clear_selection();
 
   const NearestItem ni = nearest_items(x, y);
 

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -2244,6 +2244,12 @@ void Level::align_colinear()
     }
   }
 
+  if (chain.empty())
+  {
+    printf("could not find starting point of chain :(\n");
+    return;
+  }
+
   // keep expanding the last endpoint
   while (true)
   {

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -2215,27 +2215,6 @@ void Level::align_colinear()
           sv.connected_vertex_indices.push_back(start_idx);
       }
 
-      // sort the connected vertices by edge length
-      // to try to be somewhat more "as expected" if loops
-      // are involved.
-      std::sort(
-        sv.connected_vertex_indices.begin(),
-        sv.connected_vertex_indices.end(),
-        [this, i](int v1_idx, int v2_idx) {
-          const Vertex& v = vertices[i];
-          const Vertex& v1 = vertices[v1_idx];
-          const Vertex& v2 = vertices[v2_idx];
-          
-          const double d1x = v.x - v1.x;
-          const double d1y = v.y - v1.y;
-          const double dist_v1 = sqrt(d1x * d1x + d1y * d1y);
-
-          const double d2x = v.x - v2.x;
-          const double d2y = v.y - v2.y;
-          const double dist_v2 = sqrt(d2x * d2x + d2y * d2y);
-          return dist_v1 < dist_v2;
-        });
-
       selected_vertices.push_back(sv);
     }
   }
@@ -2320,6 +2299,32 @@ void Level::align_colinear()
     if (chain_complete)
       break;
   }
+
+  printf("  chain before sorting:");
+  for (const SelectedVertex& sv : chain)
+    printf(" %zu", sv.index);
+  printf("\n");
+
+  // sort the chain vertices by distance from the starting vertex
+  const SelectedVertex starting_vertex = chain[0];
+  std::sort(
+    chain.begin() + 1,
+    chain.end(),
+    [this, starting_vertex](SelectedVertex sv1, SelectedVertex sv2)
+    {
+      const Vertex& v = vertices[starting_vertex.index];
+      const Vertex& v1 = vertices[sv1.index];
+      const Vertex& v2 = vertices[sv2.index];
+
+      const double d1x = v.x - v1.x;
+      const double d1y = v.y - v1.y;
+      const double dist_v1 = sqrt(d1x * d1x + d1y * d1y);
+
+      const double d2x = v.x - v2.x;
+      const double d2y = v.y - v2.y;
+      const double dist_v2 = sqrt(d2x * d2x + d2y * d2y);
+      return dist_v1 < dist_v2;
+    });
 
   printf("  chain:");
   for (const SelectedVertex& sv : chain)

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -2188,19 +2188,23 @@ void Level::compute_layer_transform(const size_t layer_idx)
 
 void Level::align_colinear()
 {
-  struct SelectedVertex {
+  struct SelectedVertex
+  {
     size_t index;
     vector<size_t> connected_vertex_indices;
   };
 
   // build up a vector of selected vertex indices
   vector<SelectedVertex> selected_vertices;
-  for (size_t i = 0; i < vertices.size(); i++) {
-    if (vertices[i].selected) {
+  for (size_t i = 0; i < vertices.size(); i++)
+  {
+    if (vertices[i].selected)
+    {
       SelectedVertex sv;
       sv.index = i;
 
-      for (size_t j = 0; j < edges.size(); j++) {
+      for (size_t j = 0; j < edges.size(); j++)
+      {
         const size_t start_idx = static_cast<size_t>(edges[j].start_idx);
         const size_t end_idx = static_cast<size_t>(edges[j].end_idx);
         if (start_idx == i && vertices[end_idx].selected)
@@ -2214,14 +2218,16 @@ void Level::align_colinear()
   }
 
   printf("align_colinear() vertices:\n");
-  for (const SelectedVertex& sv : selected_vertices) {
+  for (const SelectedVertex& sv : selected_vertices)
+  {
     printf("  %zu:", sv.index);
     for (const size_t i : sv.connected_vertex_indices)
       printf(" %zu", i);
     printf("\n");
   }
 
-  if (selected_vertices.size() < 3) {
+  if (selected_vertices.size() < 3)
+  {
     printf("%zu vertices were selected; >= 3 required for colinear align!\n",
       selected_vertices.size());
     return;
@@ -2229,32 +2235,38 @@ void Level::align_colinear()
 
   // start at one endpoint and go down the chain
   vector<SelectedVertex> chain;
-  for (size_t i = 0; i < selected_vertices.size(); i++) {
-    if (selected_vertices[i].connected_vertex_indices.size() == 1) {
+  for (size_t i = 0; i < selected_vertices.size(); i++)
+  {
+    if (selected_vertices[i].connected_vertex_indices.size() == 1)
+    {
       chain.push_back(selected_vertices[i]);
       break;
     }
   }
+
   // keep expanding the last endpoint
-  while (true) {
-    //const SelectedVertex& sv = chain.back();
-    // see if the last vertex in the chain
+  while (true)
+  {
     bool chain_complete = true;
-    for (size_t i = 0; i < chain.back().connected_vertex_indices.size(); i++) {
+    for (size_t i = 0; i < chain.back().connected_vertex_indices.size(); i++)
+    {
       const size_t test_vertex_idx = chain.back().connected_vertex_indices[i];
       // see if this is a new vertex to add to the chain
       bool found = false;
-      for (size_t j = 0; j < chain.size() - 1; j++) {
-        if (chain[j].index == test_vertex_idx) {
+      for (size_t j = 0; j < chain.size() - 1; j++)
+      {
+        if (chain[j].index == test_vertex_idx)
+        {
           found = true;
           break;
         }
       }
 
-      if (!found) {
-        //chain.push_back(chain.back().connected_vertex_indices[i]);
+      if (!found)
+      {
         printf("  adding vertex %zu to chain\n", test_vertex_idx);
-        for (size_t j = 0; j < selected_vertices.size(); j++) {
+        for (size_t j = 0; j < selected_vertices.size(); j++)
+        {
           if (selected_vertices[j].index == test_vertex_idx)
             chain.push_back(selected_vertices[j]);
         }
@@ -2271,7 +2283,8 @@ void Level::align_colinear()
     printf(" %zu", sv.index);
   printf("\n");
 
-  if (chain.size() < 3) {
+  if (chain.size() < 3)
+  {
     printf("could not find a connected chain of >= 3 vertices!\n");
     return;
   }
@@ -2283,7 +2296,8 @@ void Level::align_colinear()
   // compute unit vector pointing from v1 to v2
   const double line_length =
     sqrt((v2.x - v1.x) * (v2.x - v1.x) + (v2.y - v1.y) * (v2.y - v1.y));
-  if (line_length < 0.001) {
+  if (line_length < 0.001)
+  {
     printf("ill-defined line! bailing to avoid numerical blowups\n");
     return;
   }
@@ -2294,7 +2308,8 @@ void Level::align_colinear()
     v1.x, v1.y, v2.x, v2.y, ux, uy);
 
   // project intermediate vertices onto this line
-  for (size_t i = 1; i < chain.size() - 1; i++) {
+  for (size_t i = 1; i < chain.size() - 1; i++)
+  {
     Vertex& v = vertices[chain[i].index];
     const double t = ((v1.x - v.x) * ux) + ((v1.y - v.y) * uy);
     v.x = v1.x - t * ux;

--- a/rmf_traffic_editor/gui/level.h
+++ b/rmf_traffic_editor/gui/level.h
@@ -178,6 +178,8 @@ public:
   void compute_layer_transforms();
   void compute_layer_transform(const size_t layer_idx);
 
+  void align_colinear();
+
 private:
   double point_to_line_segment_distance(
     const double x,

--- a/rmf_traffic_editor/gui/level.h
+++ b/rmf_traffic_editor/gui/level.h
@@ -128,7 +128,8 @@ public:
     const double x,
     const double y,
     QGraphicsItem* graphics_item,
-    const RenderingOptions& rendering_options);
+    const RenderingOptions& rendering_options,
+    const Qt::KeyboardModifiers& modifiers);
 
   struct SelectedItem
   {


### PR DESCRIPTION
### Implemented feature

This PR adds multiple vertex selection by holding down SHIFT and clicking vertices to add them to the current selection. All selected vertices will all be rendered as red. You can clear the current selection by pressing the Escape key, as before.

When multiple vertices are selected that are directly connected by edges, you can press the slash key `/` or use the new menu item `Edit->Align Colinear`, and it will attempt to compute an orthogonal projection of all intermediate vertices onto the line between the first and last vertices in the selected chain.

### Implementation description

There are probably corner cases that are not handled correctly, but at least it seems to work in the few situations that I've tried so far.