### PR TITLE
resolve build error on some systems with size_t namespace

### DIFF
--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -235,7 +235,7 @@ int Building::find_nearest_vertex_index(
 {
   double min_dist = 1e100;
   int min_index = -1;
-  for (size_t i = 0; i < levels[level_index].vertices.size(); i++)
+  for (std::size_t i = 0; i < levels[level_index].vertices.size(); i++)
   {
     const Vertex& v = levels[level_index].vertices[i];
     const double dx = x - v.x;
@@ -364,7 +364,7 @@ void Building::draw_lifts(QGraphicsScene* scene, const int level_idx)
   {
     // find the level index referenced by the lift
     int reference_floor_idx = -1;
-    for (size_t i = 0; i < levels.size(); i++)
+    for (std::size_t i = 0; i < levels.size(); i++)
     {
       if (levels[i].name == lift.reference_floor_name)
       {
@@ -397,7 +397,7 @@ bool Building::transform_between_levels(
 {
   int from_level_idx = -1;
   int to_level_idx = -1;
-  for (size_t i = 0; i < levels.size(); i++)
+  for (std::size_t i = 0; i < levels.size(); i++)
   {
     if (levels[i].name == from_level_name)
       from_level_idx = i;
@@ -478,9 +478,9 @@ Building::Transform Building::compute_transform(
 
   // calculate the distances between each fiducial on their levels
   vector<std::pair<double, double>> distances;
-  for (size_t f0_idx = 0; f0_idx < fiducials.size(); f0_idx++)
+  for (std::size_t f0_idx = 0; f0_idx < fiducials.size(); f0_idx++)
   {
-    for (size_t f1_idx = f0_idx + 1; f1_idx < fiducials.size(); f1_idx++)
+    for (std::size_t f1_idx = f0_idx + 1; f1_idx < fiducials.size(); f1_idx++)
     {
       distances.push_back(
         make_pair(
@@ -495,7 +495,7 @@ Building::Transform Building::compute_transform(
   // for now, we'll just compute the mean of the relative scale estimates.
   // we can do fancier statistics later, if needed.
   double relative_scale_sum = 0;
-  for (size_t i = 0; i < distances.size(); i++)
+  for (std::size_t i = 0; i < distances.size(); i++)
     relative_scale_sum += distances[i].second / distances[i].first;
   const double scale = relative_scale_sum / distances.size();
 
@@ -557,9 +557,9 @@ void Building::calculate_all_transforms()
     return;// let's not crash
 
   clear_transform_cache();
-  for (size_t i = 0; i < levels.size(); i++)
+  for (std::size_t i = 0; i < levels.size(); i++)
   {
-    for (size_t j = 0; j < levels.size(); j++)
+    for (std::size_t j = 0; j < levels.size(); j++)
     {
       get_transform(i, j);
     }
@@ -583,7 +583,7 @@ int Building::get_reference_level_idx()
 {
   if (reference_level_name.empty())
     return 0;
-  for (size_t i = 0; i < levels.size(); i++)
+  for (std::size_t i = 0; i < levels.size(); i++)
   {
     if (levels[i].name == reference_level_name)
       return static_cast<int>(i);
@@ -641,7 +641,7 @@ bool Building::set_filename(const std::string& _fn)
 
   const string no_suffix(_fn.substr(0, _fn.size() - suffix.size()));
 
-  const size_t last_slash_pos = no_suffix.rfind('/', no_suffix.size());
+  const std::size_t last_slash_pos = no_suffix.rfind('/', no_suffix.size());
 
   const string stem(
     (last_slash_pos == string::npos) ?
@@ -700,7 +700,7 @@ void Building::draw(
 
 Polygon* Building::get_selected_polygon(const int level_idx)
 {
-  for (size_t i = 0; i < levels[level_idx].polygons.size(); i++)
+  for (std::size_t i = 0; i < levels[level_idx].polygons.size(); i++)
   {
     if (levels[level_idx].polygons[i].selected)
       return &levels[level_idx].polygons[i];// abomination

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -563,7 +563,7 @@ void Editor::restore_previous_viewport()
   {
     const std::string level_name =
       settings.value(preferences_keys::level_name).toString().toStdString();
-    for (size_t i = 0; i < building.levels.size(); i++)
+    for (std::size_t i = 0; i < building.levels.size(); i++)
     {
       if (building.levels[i].name == level_name)
       {
@@ -1251,7 +1251,7 @@ void Editor::layer_edit_button_clicked(const int row_idx)
 void Editor::sanity_check()
 {
   // do some checks on the building and pop up errors if we find them
-  for (size_t i = 0; i < building.levels.size(); i++)
+  for (std::size_t i = 0; i < building.levels.size(); i++)
   {
     if (!building.levels[i].are_layer_names_unique())
     {

--- a/rmf_traffic_editor/gui/layer.cpp
+++ b/rmf_traffic_editor/gui/layer.cpp
@@ -210,7 +210,7 @@ void Layer::remove_feature(QUuid feature_id)
 {
   int index_to_remove = -1;
 
-  for (size_t i = 0; i < features.size(); i++)
+  for (std::size_t i = 0; i < features.size(); i++)
   {
     if (feature_id == features[i].id())
       index_to_remove = i;
@@ -254,7 +254,7 @@ const Feature* Layer::find_feature(
   double min_dist = 1e9;
   const Feature* min_feature = nullptr;
 
-  for (size_t i = 0; i < features.size(); i++)
+  for (std::size_t i = 0; i < features.size(); i++)
   {
     const Feature& f = features[i];
     const double dx = layer_pixel.x() - f.x();
@@ -324,7 +324,7 @@ void Layer::populate_property_editor(QTableWidget* property_editor) const
 {
   property_editor->blockSignals(true);
   property_editor->setRowCount(transform_strings.size());
-  for (size_t i = 0; i < transform_strings.size(); i++)
+  for (std::size_t i = 0; i < transform_strings.size(); i++)
   {
     QTableWidgetItem* label_item = new QTableWidgetItem(
       QString::fromStdString(transform_strings[i].first));

--- a/rmf_traffic_editor/gui/layer_table.cpp
+++ b/rmf_traffic_editor/gui/layer_table.cpp
@@ -53,7 +53,7 @@ void LayerTable::update(
     level.get_drawing_visible(),
     layer_idx == 0);
 
-  for (size_t i = 0; i < level.layers.size(); i++)
+  for (std::size_t i = 0; i < level.layers.size(); i++)
   {
     set_row(
       level,

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -449,12 +449,12 @@ bool Level::delete_selected()
   }
 
   // if a feature is selected, refuse to delete it if it's in a constraint
-  for (size_t i = 0; i < floorplan_features.size(); i++)
+  for (std::size_t i = 0; i < floorplan_features.size(); i++)
   {
     if (!floorplan_features[i].selected())
       continue;
 
-    for (size_t j = 0; j < constraints.size(); j++)
+    for (std::size_t j = 0; j < constraints.size(); j++)
     {
       if (constraints[j].includes_id(floorplan_features[i].id()))
         return false;
@@ -464,15 +464,15 @@ bool Level::delete_selected()
     return true;
   }
 
-  for (size_t layer_idx = 0; layer_idx < layers.size(); layer_idx++)
+  for (std::size_t layer_idx = 0; layer_idx < layers.size(); layer_idx++)
   {
     Layer& layer = layers[layer_idx];
-    for (size_t i = 0; i < layer.features.size(); i++)
+    for (std::size_t i = 0; i < layer.features.size(); i++)
     {
       if (!layer.features[i].selected())
         continue;
 
-      for (size_t j = 0; j < constraints.size(); j++)
+      for (std::size_t j = 0; j < constraints.size(); j++)
       {
         if (constraints[j].includes_id(layer.features[i].id()))
           return false;
@@ -489,7 +489,7 @@ bool Level::delete_selected()
 void Level::get_selected_items(
   std::vector<Level::SelectedItem>& items)
 {
-  for (size_t i = 0; i < edges.size(); i++)
+  for (std::size_t i = 0; i < edges.size(); i++)
   {
     if (edges[i].selected)
     {
@@ -499,7 +499,7 @@ void Level::get_selected_items(
     }
   }
 
-  for (size_t i = 0; i < models.size(); i++)
+  for (std::size_t i = 0; i < models.size(); i++)
   {
     if (models[i].selected)
     {
@@ -509,7 +509,7 @@ void Level::get_selected_items(
     }
   }
 
-  for (size_t i = 0; i < vertices.size(); i++)
+  for (std::size_t i = 0; i < vertices.size(); i++)
   {
     if (vertices[i].selected)
     {
@@ -519,7 +519,7 @@ void Level::get_selected_items(
     }
   }
 
-  for (size_t i = 0; i < fiducials.size(); i++)
+  for (std::size_t i = 0; i < fiducials.size(); i++)
   {
     if (fiducials[i].selected)
     {
@@ -529,7 +529,7 @@ void Level::get_selected_items(
     }
   }
 
-  for (size_t i = 0; i < polygons.size(); i++)
+  for (std::size_t i = 0; i < polygons.size(); i++)
   {
     if (polygons[i].selected)
     {
@@ -539,7 +539,7 @@ void Level::get_selected_items(
     }
   }
 
-  for (size_t i = 0; i < floorplan_features.size(); i++)
+  for (std::size_t i = 0; i < floorplan_features.size(); i++)
   {
     if (floorplan_features[i].selected())
     {
@@ -550,9 +550,9 @@ void Level::get_selected_items(
     }
   }
 
-  for (size_t layer_idx = 0; layer_idx < layers.size(); layer_idx++)
+  for (std::size_t layer_idx = 0; layer_idx < layers.size(); layer_idx++)
   {
-    for (size_t i = 0; i < layers[layer_idx].features.size(); i++)
+    for (std::size_t i = 0; i < layers[layer_idx].features.size(); i++)
     {
       if (layers[layer_idx].features[i].selected())
       {
@@ -564,7 +564,7 @@ void Level::get_selected_items(
     }
   }
 
-  for (size_t i = 0; i < constraints.size(); i++)
+  for (std::size_t i = 0; i < constraints.size(); i++)
   {
     if (constraints[i].selected())
     {
@@ -1141,7 +1141,7 @@ void Level::draw(
       drawing_meters_per_pixel);
   }
 
-  for (size_t i = 0; i < constraints.size(); i++)
+  for (std::size_t i = 0; i < constraints.size(); i++)
     draw_constraint(scene, constraints[i], i);
 }
 
@@ -1173,7 +1173,7 @@ void Level::remove_feature(const int layer_idx, QUuid feature_id)
   {
     int index_to_remove = -1;
 
-    for (size_t i = 0; i < floorplan_features.size(); i++)
+    for (std::size_t i = 0; i < floorplan_features.size(); i++)
     {
       if (feature_id == floorplan_features[i].id())
         index_to_remove = i;
@@ -1387,12 +1387,12 @@ Polygon::EdgeDragPolygon Level::polygon_edge_drag_press(
   int min_idx = 0;
   double min_dist = 1.0e9;
 
-  for (size_t v0_idx = 0; v0_idx < polygon->vertices.size(); v0_idx++)
+  for (std::size_t v0_idx = 0; v0_idx < polygon->vertices.size(); v0_idx++)
   {
-    const size_t v1_idx =
+    const std::size_t v1_idx =
       v0_idx < polygon->vertices.size() - 1 ? v0_idx + 1 : 0;
-    const size_t v0 = polygon->vertices[v0_idx];
-    const size_t v1 = polygon->vertices[v1_idx];
+    const std::size_t v0 = polygon->vertices[v0_idx];
+    const std::size_t v1 = polygon->vertices[v1_idx];
 
     const double x0 = vertices[v0].x;
     const double y0 = vertices[v0].y;
@@ -1416,7 +1416,7 @@ Polygon::EdgeDragPolygon Level::polygon_edge_drag_press(
 
   // create the mouse motion polygon and insert a new edge
   QVector<QPointF> polygon_vertices;
-  for (size_t i = 0; i < polygon->vertices.size(); i++)
+  for (std::size_t i = 0; i < polygon->vertices.size(); i++)
   {
     const int v_idx = polygon->vertices[i];
     const Vertex& v = vertices[v_idx];
@@ -1452,9 +1452,9 @@ void Level::add_vertex(const double x, const double y)
   vertices.push_back(Vertex(x, y));
 }
 
-size_t Level::get_vertex_by_id(QUuid vertex_id)
+std::size_t Level::get_vertex_by_id(QUuid vertex_id)
 {
-  for (size_t i = 0; i < vertices.size(); i++)
+  for (std::size_t i = 0; i < vertices.size(); i++)
   {
     if (vertices[i].uuid == vertex_id)
     {
@@ -1469,9 +1469,9 @@ bool Level::are_layer_names_unique()
   // Just do the trivial n^2 approach for now, if we ever have a zillion
   // layers, we can do something more sophisticated.
 
-  for (size_t i = 0; i < layers.size(); i++)
+  for (std::size_t i = 0; i < layers.size(); i++)
   {
-    for (size_t j = i + 1; j < layers.size(); j++)
+    for (std::size_t j = i + 1; j < layers.size(); j++)
     {
       if (layers[i].name == layers[j].name)
       {
@@ -1491,14 +1491,14 @@ bool Level::are_layer_names_unique()
 
 const Feature* Level::find_feature(const QUuid& id) const
 {
-  for (size_t i = 0; i < floorplan_features.size(); i++)
+  for (std::size_t i = 0; i < floorplan_features.size(); i++)
   {
     if (floorplan_features[i].id() == id)
       return &floorplan_features[i];
   }
-  for (size_t layer_idx = 0; layer_idx < layers.size(); layer_idx++)
+  for (std::size_t layer_idx = 0; layer_idx < layers.size(); layer_idx++)
   {
-    for (size_t i = 0; i < layers[layer_idx].features.size(); i++)
+    for (std::size_t i = 0; i < layers[layer_idx].features.size(); i++)
     {
       if (layers[layer_idx].features[i].id() == id)
         return &layers[layer_idx].features[i];
@@ -1509,7 +1509,7 @@ const Feature* Level::find_feature(const QUuid& id) const
 
 const Feature* Level::find_feature(const double x, const double y) const
 {
-  for (size_t layer_idx = 0; layer_idx < layers.size(); layer_idx++)
+  for (std::size_t layer_idx = 0; layer_idx < layers.size(); layer_idx++)
   {
     if (!layers[layer_idx].visible)
       continue;
@@ -1524,7 +1524,7 @@ const Feature* Level::find_feature(const double x, const double y) const
   double min_dist = 1e9;
   const Feature* min_feature = nullptr;
 
-  for (size_t i = 0; i < floorplan_features.size(); i++)
+  for (std::size_t i = 0; i < floorplan_features.size(); i++)
   {
     const Feature& f = floorplan_features[i];
     const double dx = x - f.x();
@@ -1557,7 +1557,7 @@ void Level::remove_constraint(const QUuid& a, const QUuid& b)
   const Constraint c(a, b);
   int index_to_remove = -1;
 
-  for (size_t i = 0; i < constraints.size(); i++)
+  for (std::size_t i = 0; i < constraints.size(); i++)
   {
     if (constraints[i] == c)
     {
@@ -1574,7 +1574,7 @@ void Level::remove_constraint(const QUuid& a, const QUuid& b)
 
 bool Level::get_feature_point(const QUuid& id, QPointF& point) const
 {
-  for (size_t i = 0; i < floorplan_features.size(); i++)
+  for (std::size_t i = 0; i < floorplan_features.size(); i++)
   {
     if (floorplan_features[i].id() == id)
     {
@@ -1582,9 +1582,9 @@ bool Level::get_feature_point(const QUuid& id, QPointF& point) const
       return true;
     }
   }
-  for (size_t layer_idx = 0; layer_idx < layers.size(); layer_idx++)
+  for (std::size_t layer_idx = 0; layer_idx < layers.size(); layer_idx++)
   {
-    for (size_t i = 0; i < layers[layer_idx].features.size(); i++)
+    for (std::size_t i = 0; i < layers[layer_idx].features.size(); i++)
     {
       const Layer& layer = layers[layer_idx];
       if (layer.features[i].id() == id)
@@ -1696,7 +1696,7 @@ void Level::optimize_layer_transforms()
 {
   printf("level %s optimizing layer transforms...\n", name.c_str());
 
-  for (size_t i = 0; i < layers.size(); i++)
+  for (std::size_t i = 0; i < layers.size(); i++)
   {
     ceres::Problem problem;
 
@@ -1871,7 +1871,7 @@ Level::NearestItem Level::nearest_items(const double x, const double y)
 {
   NearestItem ni;
 
-  for (size_t i = 0; i < vertices.size(); i++)
+  for (std::size_t i = 0; i < vertices.size(); i++)
   {
     const Vertex& p = vertices[i];
     const double dx = x - p.x;
@@ -1885,7 +1885,7 @@ Level::NearestItem Level::nearest_items(const double x, const double y)
   }
 
   // search the floorplan features
-  for (size_t i = 0; i < floorplan_features.size(); i++)
+  for (std::size_t i = 0; i < floorplan_features.size(); i++)
   {
     const Feature& f = floorplan_features[i];
     const double dx = x - f.x();
@@ -1900,10 +1900,10 @@ Level::NearestItem Level::nearest_items(const double x, const double y)
   }
 
   // now search all "other" layer features
-  for (size_t layer_idx = 0; layer_idx < layers.size(); layer_idx++)
+  for (std::size_t layer_idx = 0; layer_idx < layers.size(); layer_idx++)
   {
     const Layer& layer = layers[layer_idx];
-    for (size_t i = 0; i < layer.features.size(); i++)
+    for (std::size_t i = 0; i < layer.features.size(); i++)
     {
       const Feature& f = layer.features[i];
 
@@ -1923,7 +1923,7 @@ Level::NearestItem Level::nearest_items(const double x, const double y)
     }
   }
 
-  for (size_t i = 0; i < fiducials.size(); i++)
+  for (std::size_t i = 0; i < fiducials.size(); i++)
   {
     const Fiducial& f = fiducials[i];
     const double dx = x - f.x;
@@ -1936,7 +1936,7 @@ Level::NearestItem Level::nearest_items(const double x, const double y)
     }
   }
 
-  for (size_t i = 0; i < models.size(); i++)
+  for (std::size_t i = 0; i < models.size(); i++)
   {
     const Model& m = models[i];
     const double dx = x - m.state.x;
@@ -1962,7 +1962,7 @@ int Level::nearest_item_index_if_within_distance(
   int min_index = -1;
   if (item_type == VERTEX)
   {
-    for (size_t i = 0; i < vertices.size(); i++)
+    for (std::size_t i = 0; i < vertices.size(); i++)
     {
       const Vertex& p = vertices[i];
       const double dx = x - p.x;
@@ -1977,7 +1977,7 @@ int Level::nearest_item_index_if_within_distance(
   }
   else if (item_type == FIDUCIAL)
   {
-    for (size_t i = 0; i < fiducials.size(); i++)
+    for (std::size_t i = 0; i < fiducials.size(); i++)
     {
       const Fiducial& f = fiducials[i];
       const double dx = x - f.x;
@@ -1992,7 +1992,7 @@ int Level::nearest_item_index_if_within_distance(
   }
   else if (item_type == MODEL)
   {
-    for (size_t i = 0; i < models.size(); i++)
+    for (std::size_t i = 0; i < models.size(); i++)
     {
       const Model& m = models[i];
       const double dx = x - m.state.x;
@@ -2075,7 +2075,7 @@ void Level::set_selected_containing_polygon(
   // holes are "higher" in our Z-stack (to make them clickable), so first
   // we need to make a list of all polygons that contain this point.
   vector<Polygon*> containing_polygons;
-  for (size_t i = 0; i < polygons.size(); i++)
+  for (std::size_t i = 0; i < polygons.size(); i++)
   {
     Polygon& polygon = polygons[i];
     QVector<QPointF> polygon_vertices;
@@ -2110,11 +2110,11 @@ void Level::set_selected_containing_polygon(
 void Level::compute_layer_transforms()
 {
   printf("Level::compute_layer_transforms()\n");
-  for (size_t i = 0; i < layers.size(); i++)
+  for (std::size_t i = 0; i < layers.size(); i++)
     compute_layer_transform(i);
 }
 
-void Level::compute_layer_transform(const size_t layer_idx)
+void Level::compute_layer_transform(const std::size_t layer_idx)
 {
   printf("Level::compute_layer_transform(%d)\n", static_cast<int>(layer_idx));
   if (layer_idx >= layers.size())

--- a/rmf_traffic_editor/gui/level.h
+++ b/rmf_traffic_editor/gui/level.h
@@ -62,7 +62,7 @@ public:
     const double y);
 
   void add_vertex(const double x, const double y);
-  size_t get_vertex_by_id(QUuid vertex_id);
+  std::size_t get_vertex_by_id(QUuid vertex_id);
 
   std::string drawing_filename;
   int drawing_width = 0;
@@ -175,7 +175,7 @@ public:
   void optimize_layer_transforms();
 
   void compute_layer_transforms();
-  void compute_layer_transform(const size_t layer_idx);
+  void compute_layer_transform(const std::size_t layer_idx);
 
 private:
   double point_to_line_segment_distance(

--- a/rmf_traffic_editor/gui/level_dialog.cpp
+++ b/rmf_traffic_editor/gui/level_dialog.cpp
@@ -184,7 +184,7 @@ void LevelDialog::ok_button_clicked()
   auto original_name = building_level.name;
   building_level.name = name_line_edit->text().toStdString();
   building_level.elevation = elevation_line_edit->text().toDouble();
-  for (size_t i = 0; i < building.lifts.size(); i ++)
+  for (std::size_t i = 0; i < building.lifts.size(); i ++)
   {
     if (original_name != building_level.name)
     {

--- a/rmf_traffic_editor/gui/level_table.cpp
+++ b/rmf_traffic_editor/gui/level_table.cpp
@@ -38,7 +38,7 @@ void LevelTable::update(Building& building)
   setRowCount(1 + building.levels.size());
   const int reference_level_idx = building.get_reference_level_idx();
 
-  for (size_t i = 0; i < building.levels.size(); i++)
+  for (std::size_t i = 0; i < building.levels.size(); i++)
   {
     QTableWidgetItem* name_item =
       new QTableWidgetItem(QString::fromStdString(building.levels[i].name));

--- a/rmf_traffic_editor/gui/lift_dialog.cpp
+++ b/rmf_traffic_editor/gui/lift_dialog.cpp
@@ -423,7 +423,7 @@ void LiftDialog::update_lift_wps()
   QPointF to_point;
 
   bool found = false;
-  for (size_t level_idx = 0; level_idx < _level_names.size(); level_idx++)
+  for (std::size_t level_idx = 0; level_idx < _level_names.size(); level_idx++)
   {
     const std::string level_name = _level_names[level_idx].toStdString();
     // Vertices will only be generated on levels that the lift is serving (has
@@ -461,7 +461,7 @@ void LiftDialog::update_lift_wps()
 void LiftDialog::update_door_table()
 {
   _door_table->setRowCount(1 + _lift.doors.size());
-  for (size_t i = 0; i < _lift.doors.size(); i++)
+  for (std::size_t i = 0; i < _lift.doors.size(); i++)
   {
     const LiftDoor& door = _lift.doors[i];  // save some typing
     set_door_cell(i, 0, QString::fromStdString(door.name));
@@ -520,7 +520,7 @@ void LiftDialog::update_level_table()
 {
   _level_table->setColumnCount(1 + static_cast<int>(_lift.doors.size()));
   _level_table->setHorizontalHeaderItem(0, new QTableWidgetItem("Level"));
-  for (size_t door_idx = 0; door_idx < _lift.doors.size(); door_idx++)
+  for (std::size_t door_idx = 0; door_idx < _lift.doors.size(); door_idx++)
   {
     _level_table->setHorizontalHeaderItem(
       door_idx + 1,
@@ -529,14 +529,14 @@ void LiftDialog::update_level_table()
   }
   //blockSignals(true);
   _level_table->setRowCount(_level_names.size());
-  for (size_t level_idx = 0; level_idx < _level_names.size(); level_idx++)
+  for (std::size_t level_idx = 0; level_idx < _level_names.size(); level_idx++)
   {
     const QString& level_name = _level_names[level_idx];
     QTableWidgetItem* name_item = new QTableWidgetItem(level_name);
     name_item->setFlags(name_item->flags() & ~Qt::ItemIsEditable);
     _level_table->setItem(level_idx, 0, name_item);
 
-    for (size_t door_idx = 0; door_idx < _lift.doors.size(); door_idx++)
+    for (std::size_t door_idx = 0; door_idx < _lift.doors.size(); door_idx++)
     {
       QCheckBox* checkbox = new QCheckBox;
       checkbox->setStyleSheet("margin-left: 50%; margin-right: 50%");

--- a/rmf_traffic_editor/gui/lift_table.cpp
+++ b/rmf_traffic_editor/gui/lift_table.cpp
@@ -34,7 +34,7 @@ void LiftTable::update(Building& building)
 {
   blockSignals(true);
   setRowCount(1 + building.lifts.size());
-  for (size_t i = 0; i < building.lifts.size(); i++)
+  for (std::size_t i = 0; i < building.lifts.size(); i++)
   {
     setItem(
       i,

--- a/rmf_traffic_editor/gui/model.cpp
+++ b/rmf_traffic_editor/gui/model.cpp
@@ -156,7 +156,7 @@ void Model::draw(
       {
         // Get ending token
         std::string ending_token;
-        size_t delimiter_index = editor_model.name.find("/");
+        std::size_t delimiter_index = editor_model.name.find("/");
 
         if (delimiter_index != std::string::npos)
         {

--- a/rmf_traffic_editor/gui/model_dialog.cpp
+++ b/rmf_traffic_editor/gui/model_dialog.cpp
@@ -117,8 +117,8 @@ void ModelDialog::model_name_line_edited(const QString& text)
   // scroll the list box to the first thing
   const std::string user_text_lower(text.toLower().toStdString());
   // could become super fancy but for now let's just do linear search...
-  size_t closest_idx = 0;
-  for (size_t i = 0; i < _editor_models.size(); i++)
+  std::size_t closest_idx = 0;
+  for (std::size_t i = 0; i < _editor_models.size(); i++)
   {
     if (user_text_lower < _editor_models[i].name_lowercase)
     {

--- a/rmf_traffic_editor/gui/multi_select_combo_box.cpp
+++ b/rmf_traffic_editor/gui/multi_select_combo_box.cpp
@@ -17,7 +17,7 @@ void MultiSelectComboBox::build_list()
     }
   );
 
-  for (size_t i = 0; i < selections.size(); i++)
+  for (std::size_t i = 0; i < selections.size(); i++)
   {
     QListWidgetItem* pListItem = new QListWidgetItem(pListWidget);
     pListWidget->addItem(pListItem);
@@ -44,10 +44,10 @@ void MultiSelectComboBox::build_list()
 void MultiSelectComboBox::box_checked(int /*state*/)
 {
   blockSignals(true);
-  size_t list_count = pListWidget->count();
+  std::size_t list_count = pListWidget->count();
   selectedText.clear();
 
-  for (size_t i = 0; i < list_count; i++)
+  for (std::size_t i = 0; i < list_count; i++)
   {
     QListWidgetItem* pItem = pListWidget->item(i);
     QCheckBox* pCheckBox = static_cast<QCheckBox*>(pListWidget->itemWidget(

--- a/rmf_traffic_editor/gui/rendering_options.cpp
+++ b/rmf_traffic_editor/gui/rendering_options.cpp
@@ -19,6 +19,6 @@
 
 RenderingOptions::RenderingOptions()
 {
-  for (size_t i = 0; i < show_building_lanes.size(); i++)
+  for (std::size_t i = 0; i < show_building_lanes.size(); i++)
     show_building_lanes[i] = true;
 }

--- a/rmf_traffic_editor/gui/traffic_table.cpp
+++ b/rmf_traffic_editor/gui/traffic_table.cpp
@@ -39,10 +39,10 @@ void TrafficTable::update(RenderingOptions& opts)
 {
   blockSignals(true);
 
-  const size_t num_lanes = opts.show_building_lanes.size();
+  const std::size_t num_lanes = opts.show_building_lanes.size();
   setRowCount(num_lanes);
 
-  for (size_t i = 0; i < num_lanes; i++)
+  for (std::size_t i = 0; i < num_lanes; i++)
   {
     QCheckBox* checkbox = new QCheckBox;
     checkbox->setChecked(opts.show_building_lanes[i]);

--- a/rmf_traffic_editor/gui/yaml_utils.cpp
+++ b/rmf_traffic_editor/gui/yaml_utils.cpp
@@ -46,7 +46,7 @@ void yaml_utils::write_node(
     case YAML::NodeType::Sequence:
     {
       emitter << YAML::BeginSeq;
-      for (size_t i = 0; i < node.size(); i++)
+      for (std::size_t i = 0; i < node.size(); i++)
         write_node(node[i], emitter);
       emitter << YAML::EndSeq;
       break;
@@ -60,7 +60,7 @@ void yaml_utils::write_node(
       for (YAML::const_iterator it = node.begin(); it != node.end(); ++it)
         keys.push_back(it->first.as<string>());
       std::sort(keys.begin(), keys.end());
-      for (size_t i = 0; i < keys.size(); i++)
+      for (std::size_t i = 0; i < keys.size(); i++)
       {
         emitter << YAML::Key << keys[i] << YAML::Value;
         write_node(node[keys[i]], emitter);


### PR DESCRIPTION
On some systems and some compilers, apparently the cascade of includes in some files in traffic-editor does not include `size_t` outside the `std` namespace, for some files. This PR just adds `std::` in front of all uses of `size_t` so that the code is more portable.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>