### PR TITLE
Feature/map generator using global coordinates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: non-ros-deps
       run: |
         sudo apt-get update
-        sudo apt-get install -y git cmake wget libyaml-cpp-dev qt5-default libceres-dev libeigen3-dev python3-shapely python3-requests python3-yaml
+        sudo apt-get install -y git cmake wget libyaml-cpp-dev qt5-default libceres-dev libeigen3-dev python3-shapely python3-requests python3-yaml python3-pyproj
 
     - name: build
       shell: bash

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -17,6 +17,12 @@ class Building:
             self.name = yaml_node['name']
         print(f'building name: {self.name}')
 
+        if 'coordinate_system' in yaml_node:
+            self.coordinate_system = yaml_node['coordinate_system']
+        else:
+            self.coordinate_system = 'reference_image'
+        print(f'coordinate system: {self.coordinate_system}')
+
         self.levels = {}
         self.model_counts = {}
         for level_name, level_yaml in yaml_node['levels'].items():

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -175,6 +175,16 @@ class Building:
                       {'name': vertex.name, 'x': str(vertex.x),
                        'y': str(vertex.y), 'level': level_name})
 
+        for level_name, level in self.levels.items():
+            if type(level.transform).__name__ == 'WebMercatorTransform':
+                offset = level.transform.offset
+                offset_ele = SubElement(world, 'offset')
+                offset_ele.text = f'{offset[0]} {offset[1]} 0 0 0 0'
+
+                crs_ele = SubElement(world, 'crs')
+                crs_ele.text = level.transform.crs_name
+                break
+
         gui_ele = world.find('gui')
         c = self.center()
         camera_pose = f'{c[0]} {c[1]-20} 10 0 0.6 1.57'

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -29,7 +29,8 @@ class Building:
             self.levels[level_name] = Level(
                 level_yaml,
                 level_name,
-                self.model_counts)
+                self.model_counts,
+                self.coordinate_system)
 
         if 'reference_level_name' in yaml_node:
             self.reference_level_name = yaml_node['reference_level_name']
@@ -37,7 +38,9 @@ class Building:
             self.reference_level_name = next(iter(self.levels))
         self.ref_level = self.levels[self.reference_level_name]  # save typing
 
-        self.calculate_level_offsets_and_scales()
+        # we only need to calculate offsets/scales if we're in pixel space
+        if self.coordinate_system == 'reference_image':
+            self.calculate_level_offsets_and_scales()
 
         self.transform_all_vertices()
 

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -22,7 +22,6 @@ from .doors.double_swing_door import DoubleSwingDoor
 from .doors.double_sliding_door import DoubleSlidingDoor
 
 from .transform import Transform
-from .web_mercator_transform import WebMercatorTransform
 
 
 class Level:
@@ -31,7 +30,7 @@ class Level:
         yaml_node,
         name,
         model_counts={},
-        coordinate_system='reference_image'
+        transform=None
     ):
         self.name = name
         print(f'parsing level {name}')
@@ -54,15 +53,10 @@ class Level:
             for vertex_yaml in yaml_node['vertices']:
                 self.vertices.append(Vertex(vertex_yaml))
 
-        if coordinate_system == 'reference_image':
+        if transform is None:
             self.transform = Transform()
-        elif coordinate_system == 'web_mercator':
-            self.transform = WebMercatorTransform()
-            for v in self.vertices:
-                if v.name == 'origin':
-                    self.transform.set_offset(
-                        self.transform.transform_point((v.x, v.y)))
-                    break
+        else:
+            self.transform = transform
 
         self.transformed_vertices = []  # will be calculated in a later pass
 

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -49,15 +49,20 @@ class Level:
             for fiducial_yaml in yaml_node['fiducials']:
                 self.fiducials.append(Fiducial(fiducial_yaml))
 
-        if coordinate_system == 'reference_image':
-            self.transform = Transform()
-        elif coordinate_system == 'web_mercator':
-            self.transform = WebMercatorTransform()
-
         self.vertices = []
         if 'vertices' in yaml_node and yaml_node['vertices']:
             for vertex_yaml in yaml_node['vertices']:
                 self.vertices.append(Vertex(vertex_yaml))
+
+        if coordinate_system == 'reference_image':
+            self.transform = Transform()
+        elif coordinate_system == 'web_mercator':
+            self.transform = WebMercatorTransform()
+            for v in self.vertices:
+                if v.name == 'origin':
+                    self.transform.set_offset(
+                        self.transform.transform_point((v.x, v.y)))
+                    break
 
         self.transformed_vertices = []  # will be calculated in a later pass
 

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -15,16 +15,18 @@ from .wall import Wall
 from .hole import Hole
 from .model import Model
 from .param_value import ParamValue
-from .transform import Transform
 from .vertex import Vertex
 from .doors.swing_door import SwingDoor
 from .doors.sliding_door import SlidingDoor
 from .doors.double_swing_door import DoubleSwingDoor
 from .doors.double_sliding_door import DoubleSlidingDoor
 
+from .transform import Transform
+from .web_mercator_transform import WebMercatorTransform
+
 
 class Level:
-    def __init__(self, yaml_node, name, model_counts={}):
+    def __init__(self, yaml_node, name, model_counts={}, coordinate_system='reference_image'):
         self.name = name
         print(f'parsing level {name}')
 
@@ -41,7 +43,10 @@ class Level:
             for fiducial_yaml in yaml_node['fiducials']:
                 self.fiducials.append(Fiducial(fiducial_yaml))
 
-        self.transform = Transform()
+        if coordinate_system == 'reference_image':
+            self.transform = Transform()
+        elif coordinate_system == 'web_mercator':
+            self.transform = WebMercatorTransform()
 
         self.vertices = []
         if 'vertices' in yaml_node and yaml_node['vertices']:

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -26,7 +26,13 @@ from .web_mercator_transform import WebMercatorTransform
 
 
 class Level:
-    def __init__(self, yaml_node, name, model_counts={}, coordinate_system='reference_image'):
+    def __init__(
+        self,
+        yaml_node,
+        name,
+        model_counts={},
+        coordinate_system='reference_image'
+    ):
         self.name = name
         print(f'parsing level {name}')
 

--- a/rmf_building_map_tools/building_map/wall.py
+++ b/rmf_building_map_tools/building_map/wall.py
@@ -191,7 +191,7 @@ class Wall:
             f.write('Ke 0.0 0.0 0.0\n')  # emissive
             f.write('Ns 50.0\n')  # specular highlight, 0..100 (?)
             f.write('Ni 1.0\n')  # no idea what this is
-            f.write(f'd {self.alpha}\n')  # alpha
+            f.write(f'd {self.alpha.value}\n')  # alpha
             f.write('illum 2\n')  # illumination model (enum)
             f.write(f'map_Kd {texture_filename}\n')
 

--- a/rmf_building_map_tools/building_map/wall.py
+++ b/rmf_building_map_tools/building_map/wall.py
@@ -114,6 +114,16 @@ class Wall:
                 # need to scale the texture coordinates currently.
                 texture_lengths.append(wlen)
 
+            """
+            Instead of having potentially-huge wall vertex values,
+            let's instead translate them all towards the origin
+            and then push the entire wall OBJ to its final location
+            so that Gazebo/Ignition "Move To" command is useful.
+            """
+
+            self.wall_mesh_offsets = np.min(wall_verts, axis=0)
+            wall_verts = wall_verts - self.wall_mesh_offsets
+
             for v in wall_verts:
                 f.write(f'v {v[0]:.4f} {v[1]:.4f} 0.000\n')
                 f.write(f'v {v[0]:.4f} {v[1]:.4f} {h:.4f}\n')
@@ -241,5 +251,11 @@ class Wall:
                 visual_ele, model_name, f'wall_{wall_cnt}',
                 self.texture_name.value, f'{model_path}/meshes',
                 self.pbr_textures)
+
         self.generate_wall_visual_mesh(model_name, model_path,
                                        texture_filename)
+
+        pose_ele = SubElement(link_ele, 'pose')
+        link_x = self.wall_mesh_offsets[0]
+        link_y = self.wall_mesh_offsets[1]
+        pose_ele.text = f'{link_x} {link_y} 0 0 0 0'

--- a/rmf_building_map_tools/building_map/web_mercator_transform.py
+++ b/rmf_building_map_tools/building_map/web_mercator_transform.py
@@ -6,9 +6,10 @@ import math
 class WebMercatorTransform:
     """Transforms between Web Mercator points and transverse mercator planes"""
 
-    def __init__(self):
+    def __init__(self, crs_name):
         # crs_4326 = CRS.from_epsg(4326)  # also known as WGS84...
-        self.crs_name = 'EPSG:3414'  # todo: either set explicitly or calculate
+        print(f'WebMercatorTransform({crs_name})')
+        self.crs_name = crs_name
         self.offset = (0, 0)
         self.web_mercator_to_wgs84 = \
             Transformer.from_crs("EPSG:3857", "EPSG:4326")

--- a/rmf_building_map_tools/building_map/web_mercator_transform.py
+++ b/rmf_building_map_tools/building_map/web_mercator_transform.py
@@ -1,0 +1,36 @@
+from pyproj import Transformer
+from pyproj import CRS
+import math
+
+
+class WebMercatorTransform:
+    """Transforms between Web Mercator points and transverse mercator planes"""
+
+    def __init__(self):
+        #crs_4326 = CRS.from_epsg(4326)  # also known as WGS84...
+        self.web_mercator_to_wgs84 = Transformer.from_crs("EPSG:3857", "EPSG:4326")
+        self.web_mercator_to_svy21 = Transformer.from_crs("EPSG:3857", "EPSG:3414")
+
+    def transform_point(self, p):
+        # first convert from "Web Mercator" (256, 256) scale to meters
+
+        R = 6378137  # wgs84 equatorial radius
+        meters_east = R * math.pi * (p[0] - 128) / 128
+        # because our legacy code is all in image coordinates, the Y coord
+        # is negated... this step will flip it back
+        meters_north = R * math.pi * (128 + p[1]) / 128
+
+        (lat, lon) = self.web_mercator_to_wgs84.transform(meters_east, meters_north)
+        print(f'web mercator to wgs84: ({p[0]}, {p[1]}) = ({lat}, {lon})')
+
+        # now we need to choose a TM plane. In the future we should be more
+        # generic, but for now let's start by using SVY21
+        (svy21_northing, svy21_easting) = self.web_mercator_to_svy21.transform(meters_east, meters_north)
+        print(f'web mercator to svy21: ({p[0]}, {p[1]}) = ({svy21_easting}, {svy21_northing})')
+
+        #crs_svy21 = CRS.from_epsg(3414)
+        #svy21_false_easting = crs_svy21.to_dict()['x_0']
+        #svy21_false_northing = crs_svy21.to_dict()['y_0']
+        #print(f'offset: {svy21_false_easting}, {svy21_false_northing}')
+
+        return (svy21_easting, svy21_northing)

--- a/rmf_building_map_tools/building_map/web_mercator_transform.py
+++ b/rmf_building_map_tools/building_map/web_mercator_transform.py
@@ -7,9 +7,11 @@ class WebMercatorTransform:
     """Transforms between Web Mercator points and transverse mercator planes"""
 
     def __init__(self):
-        #crs_4326 = CRS.from_epsg(4326)  # also known as WGS84...
-        self.web_mercator_to_wgs84 = Transformer.from_crs("EPSG:3857", "EPSG:4326")
-        self.web_mercator_to_svy21 = Transformer.from_crs("EPSG:3857", "EPSG:3414")
+        # crs_4326 = CRS.from_epsg(4326)  # also known as WGS84...
+        self.web_mercator_to_wgs84 = \
+            Transformer.from_crs("EPSG:3857", "EPSG:4326")
+        self.web_mercator_to_svy21 = \
+            Transformer.from_crs("EPSG:3857", "EPSG:3414")
 
     def transform_point(self, p):
         # first convert from "Web Mercator" (256, 256) scale to meters
@@ -20,17 +22,17 @@ class WebMercatorTransform:
         # is negated... this step will flip it back
         meters_north = R * math.pi * (128 + p[1]) / 128
 
-        (lat, lon) = self.web_mercator_to_wgs84.transform(meters_east, meters_north)
-        print(f'web mercator to wgs84: ({p[0]}, {p[1]}) = ({lat}, {lon})')
+        (lat, lon) = \
+            self.web_mercator_to_wgs84.transform(meters_east, meters_north)
 
         # now we need to choose a TM plane. In the future we should be more
         # generic, but for now let's start by using SVY21
-        (svy21_northing, svy21_easting) = self.web_mercator_to_svy21.transform(meters_east, meters_north)
-        print(f'web mercator to svy21: ({p[0]}, {p[1]}) = ({svy21_easting}, {svy21_northing})')
+        (svy21_northing, svy21_easting) = \
+            self.web_mercator_to_svy21.transform(meters_east, meters_north)
 
-        #crs_svy21 = CRS.from_epsg(3414)
-        #svy21_false_easting = crs_svy21.to_dict()['x_0']
-        #svy21_false_northing = crs_svy21.to_dict()['y_0']
-        #print(f'offset: {svy21_false_easting}, {svy21_false_northing}')
+        # crs_svy21 = CRS.from_epsg(3414)
+        # svy21_false_easting = crs_svy21.to_dict()['x_0']
+        # svy21_false_northing = crs_svy21.to_dict()['y_0']
+        # print(f'offset: {svy21_false_easting}, {svy21_false_northing}')
 
         return (svy21_easting, svy21_northing)

--- a/rmf_building_map_tools/building_map/web_mercator_transform.py
+++ b/rmf_building_map_tools/building_map/web_mercator_transform.py
@@ -8,10 +8,15 @@ class WebMercatorTransform:
 
     def __init__(self):
         # crs_4326 = CRS.from_epsg(4326)  # also known as WGS84...
+        self.crs_name = 'EPSG:3414'  # todo: either set explicitly or calculate
+        self.offset = (0, 0)
         self.web_mercator_to_wgs84 = \
             Transformer.from_crs("EPSG:3857", "EPSG:4326")
-        self.web_mercator_to_svy21 = \
-            Transformer.from_crs("EPSG:3857", "EPSG:3414")
+        self.web_mercator_to_tm = \
+            Transformer.from_crs("EPSG:3857", self.crs_name)
+
+    def set_offset(self, new_offset):
+        self.offset = new_offset
 
     def transform_point(self, p):
         # first convert from "Web Mercator" (256, 256) scale to meters
@@ -27,12 +32,15 @@ class WebMercatorTransform:
 
         # now we need to choose a TM plane. In the future we should be more
         # generic, but for now let's start by using SVY21
-        (svy21_northing, svy21_easting) = \
-            self.web_mercator_to_svy21.transform(meters_east, meters_north)
+        (tm_northing, tm_easting) = \
+            self.web_mercator_to_tm.transform(meters_east, meters_north)
 
-        # crs_svy21 = CRS.from_epsg(3414)
-        # svy21_false_easting = crs_svy21.to_dict()['x_0']
-        # svy21_false_northing = crs_svy21.to_dict()['y_0']
-        # print(f'offset: {svy21_false_easting}, {svy21_false_northing}')
+        # crs_tm = CRS.from_epsg(3414)
+        # tm_false_easting = crs_tm.to_dict()['x_0']
+        # tm_false_northing = crs_tm.to_dict()['y_0']
+        # print(f'offset: {tm_false_easting}, {tm_false_northing}')
 
-        return (svy21_easting, svy21_northing)
+        tm_easting -= self.offset[0]
+        tm_northing -= self.offset[1]
+
+        return (tm_easting, tm_northing)

--- a/rmf_building_map_tools/package.xml
+++ b/rmf_building_map_tools/package.xml
@@ -17,6 +17,7 @@
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>python3-requests</exec_depend>
   <exec_depend>python3-shapely</exec_depend>
+  <exec_depend>python3-pyproj</exec_depend>
 
   <test_depend>python3-pytest</test_depend>
 


### PR DESCRIPTION
## New feature implementation

This PR adds a new root-level field to the `.building.yaml` file format, called `coordinate_system`. If that field is not defined, or if it's set to `reference_image`, everything works as before. If that field is set to `web_mercator`, then the generators will treat the coordinates in the file as if they are Web Mercator global coordinates ranging from [0..256, 0..256] as defined in this document, and implemented in lots of online map systems: https://developers.google.com/maps/documentation/javascript/coordinates

If it sees a `coordinate_system` of `web_mercator`, then it will look for a top-level param called `generate_crs` which must be the name of a frame to transform the nav graph and simulation world into, such as a locally-useful transverse mercator frame. This PR also introduces an optional top-level `generate_origin_vertex` param, which can override the default `origin` name for a vertex that it tries to find to define the (0, 0) point in the generated nav graphs and simulation worlds. This is important for global navigation because typical TM frame values are many kilometers, which makes the orbit controls in the simulator and rviz very touchy and it's easy to fly off into the abyss. The origin offset used in the nav graph and simulation world is saved in the generated YAML and XML/SDF so that downstream consumers can "translate it back" in order to communicate with other systems using the "true" frame (without offset).

The real math is done with the PyProj library, which implements basically every coordinate frame ever. It's awesome.