### PR TITLE
fix crowdsim map generation when there are no robots

### DIFF
--- a/rmf_building_map_tools/building_crowdsim/config/configfile_generator.py
+++ b/rmf_building_map_tools/building_crowdsim/config/configfile_generator.py
@@ -73,7 +73,9 @@ class ConfigFileGenerator:
             for item in self.crowd_sim_yaml['agent_groups']:
                 cur_group = AgentGroup()
                 cur_group.load_from_yaml(item)
-                self.scene_file.sub_elements.append(cur_group)
+                cur_generator = cur_group.sub_elements[-1]
+                if len(cur_generator.sub_elements) != 0:
+                    self.scene_file.sub_elements.append(cur_group)
 
         write_xml_file(
             self.scene_file.output_xml_element(),

--- a/rmf_building_map_tools/building_crowdsim/config/configfile_generator.py
+++ b/rmf_building_map_tools/building_crowdsim/config/configfile_generator.py
@@ -73,8 +73,7 @@ class ConfigFileGenerator:
             for item in self.crowd_sim_yaml['agent_groups']:
                 cur_group = AgentGroup()
                 cur_group.load_from_yaml(item)
-                cur_generator = cur_group.sub_elements[-1]
-                if len(cur_generator.sub_elements) != 0:
+                if cur_group.sub_elements[-1].is_valid():
                     self.scene_file.sub_elements.append(cur_group)
 
         write_xml_file(


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

Fixed bug #375: `building_crowdsim.py` unable to generate the required files for crowd simulation when no robot is added to the map due to a `ValueError` where the AgentGroup element fails its validity check

### Fix applied

Added a condition in `configfile_generator.py` to only append AgentGroup to the scene file when there are robots in the map, denoted by length of the AgentGroup sub-elements.

Code can be tested by running `building_crowdsim.py` with a `.building.yaml` file with no robots added