### PR TITLE
added scaling features to wall texture

### DIFF
--- a/rmf_building_map_tools/building_map/wall.py
+++ b/rmf_building_map_tools/building_map/wall.py
@@ -21,6 +21,9 @@ class Wall:
         self.texture_name = wall_params['texture_name']
         self.alpha = wall_params['alpha']  # val 0.0-1.0 transparency of wall
         self.pbr_textures = get_pbr_textures(wall_params)
+        self.texture_height = wall_params['texture_height']
+        self.texture_width = wall_params['texture_width']
+        self.texture_scale = wall_params['texture_scale']
 
         # Wall filtering according to wall_params
         for checked_wall in yaml_node:
@@ -118,15 +121,24 @@ class Wall:
                 f.write(f'v {v[0]:.4f} {v[1]:.4f} 0.000\n')
                 f.write(f'v {v[0]:.4f} {v[1]:.4f} {h:.4f}\n')
 
+            if texture_filename == 'default.png':
+                vt_h = 1.0
+                s = 1.0
+            else:
+                vt_h = h/(self.texture_height.value/self.texture_width.value)
+                s = self.texture_scale.value  # default is 1 --> img stretches to 1m in width
+                if s == 0:  # full wall (by height)
+                    s = vt_h
+
             for length in texture_lengths:
                 f.write(f'vt 0.000 0.000\n')
-                f.write(f'vt 0.000 1.000\n')
-                f.write(f'vt {length:.4f} 0.000\n')
-                f.write(f'vt {length:.4f} 1.000\n')
-                f.write(f'vt {(length + self.wall_thickness):.4f} 0.000\n')
-                f.write(f'vt {(length + self.wall_thickness):.4f} 1.000\n')
-                f.write(f'vt {(2*length + self.wall_thickness):.4f} 0.000\n')
-                f.write(f'vt {(2*length + self.wall_thickness):.4f} 1.000\n')
+                f.write(f'vt 0.000 {(vt_h/s):.4f}\n')
+                f.write(f'vt {(length/s):.4f} 0.000\n')
+                f.write(f'vt {(length/s):.4f} {(vt_h/s):.4f}\n')
+                f.write(f'vt {((length + self.wall_thickness)/s):.4f} 0.000\n')
+                f.write(f'vt {((length + self.wall_thickness)/s):.4f} {(vt_h/s):.4f}\n')
+                f.write(f'vt {((2*length + self.wall_thickness)/s):.4f} 0.000\n')
+                f.write(f'vt {((2*length + self.wall_thickness)/s):.4f} {(vt_h/s):.4f}\n')
 
             for norm in norms:
                 f.write(f'vn {norm[0]:.4f} {norm[1]:.4f} {norm[2]:.4f}\n')

--- a/rmf_traffic_editor/gui/edge.cpp
+++ b/rmf_traffic_editor/gui/edge.cpp
@@ -119,6 +119,9 @@ void Edge::create_required_parameters()
     create_param_if_needed("texture_name", Param::STRING,
       std::string("default"));
     create_param_if_needed("alpha", Param::DOUBLE, 1.0);
+    create_param_if_needed("texture_height", Param::DOUBLE, 2.5);
+    create_param_if_needed("texture_width", Param::DOUBLE, 1.0);
+    create_param_if_needed("texture_scale", Param::DOUBLE, 1.0);
   }
   else if (type == LANE)
   {


### PR DESCRIPTION
Signed-off-by: xiyuoh <ohxiyu@gmail.com>

## New feature implementation

### Implemented feature

This PR follows #343 to add scalability to downloaded textures from URL. 

### Implementation description

As mentioned in #342 the custom textures may be stretched in simulation as their height-to-width ratio may not be coherent with the wall dimensions (walls expect a 2.5m x 1m texture size). This feature implemented allows users to customize texture scales by adding parameters to define these scales.

Before implementation:
![Screenshot from 2021-08-17 16-31-04 (1)](https://user-images.githubusercontent.com/30265743/129697903-a63486c5-9a0b-448c-b4ba-afaf84eaf20b.png)
You can observe the texture stretching by comparing the wall and floor textures.

After implementation:
![Screenshot from 2021-08-17 16-41-52 (1)](https://user-images.githubusercontent.com/30265743/129698017-0d5c4bb5-95b9-4f89-856f-95b2c696176c.png)

The scaling is controlled by three parameters: `texture_height`, `texture_width` and `texture_scale`:
![SS2 (1)](https://user-images.githubusercontent.com/30265743/129702574-5aa50621-40d8-4efd-a2e5-a5f609ac9ae6.png)

- `texture_height` and `texture_width`: dimensions of the texture image. It does not need to be absolute as only their ratio will be calculated, i.e. for square textures, you can enter 1 for both parameters.
  But for images where the ratio may not be easy to compute, users can enter the absolute dimensions directly.
- `texture_scale`: how 'zoomed in' you want your texture to be (default is 1)
   For example, if you want your texture width to be 1m, enter 1. If you want your texture width to be 2m, enter 2. The height will be scaled accordingly.
   Special case: If you want your texture image to fit the full wall (texture height = wall height), enter 0.

See some examples below!

For `texture_scale = 2` with square textures
![Screenshot from 2021-08-17 16-30-28 (1)](https://user-images.githubusercontent.com/30265743/129699445-fff30f75-7399-44ba-9363-6afe55546f48.png)
![SS3 (1)](https://user-images.githubusercontent.com/30265743/129702534-6adb611e-99ce-4f6f-962c-95586b9e1d72.png)

For `texture_scale = 0` with complicated texture dimensions
![Screenshot from 2021-08-17 16-31-11 (1)](https://user-images.githubusercontent.com/30265743/129699500-c6d124a8-5627-4538-a547-26343b52fcce.png)
![SS1 (1)](https://user-images.githubusercontent.com/30265743/129702519-87c3ce87-1e4e-4174-8401-def08012dec6.png)

### Testing the PR

1. Open a map in `traffic_editor`
2. Add texture URLs and scaling parameters like the examples above
3. Launch the demo, or run `building_map_generator.py gazebo` on your yaml map and open the mesh files in gazebo.