### PR TITLE
added support for ceilings with texture

### DIFF
--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -236,6 +236,7 @@ class Level:
 
     def generate_floors(self, world_ele, model_name, model_path):
         i = 0
+        j = 0
         for floor in self.floors:
             i += 1
             floor.generate(
@@ -246,6 +247,16 @@ class Level:
                 self.transformed_vertices,
                 self.holes,
                 self.lift_vert_lists)
+            if floor.has_ceiling():
+                j += 1
+                floor.generate_ceiling(
+                    world_ele,
+                    j,
+                    model_name,
+                    model_path,
+                    self.transformed_vertices,
+                    self.holes,
+                    self.lift_vert_lists)
 
     def write_sdf(self, model_name, model_path):
         sdf_ele = Element('sdf', {'version': '1.7'})

--- a/rmf_traffic_editor/gui/polygon.cpp
+++ b/rmf_traffic_editor/gui/polygon.cpp
@@ -119,6 +119,12 @@ void Polygon::create_required_parameters()
       std::string("blue_linoleum"));
     create_param_if_needed("texture_scale", Param::DOUBLE, 1.0);
     create_param_if_needed("texture_rotation", Param::DOUBLE, 0.0);
+    create_param_if_needed("indoor", Param::INT, 0);
+    create_param_if_needed(
+      "ceiling_texture",
+      Param::STRING,
+      std::string("blue_linoleum"));
+    create_param_if_needed("ceiling_scale", Param::DOUBLE, 1.0);
   }
 }
 


### PR DESCRIPTION
Signed-off-by: xiyuoh <ohxiyu@gmail.com>

## New feature implementation

### Implemented feature

This PR follows #343 to add ceilings with texture to simulation environments. The ceiling is generated by writing an additional OBJ file to the meshes. 

### Implementation description

Additional floor parameters are now available in the traffic-editor GUI for users to customise their environments:
- `indoor`: enter 1 or 0 to indicate whether the environment is indoors. If 1, a polygon with the same shape as the floor space will be added.
- `ceiling_texture`: applies texture to ceiling from URLs
- `ceiling_scale`: applies scaling to ceiling texture

Implemented ceilings are only visible from within the indoor space; from the bird-eye view, users can still see the interior of the environment without the ceilings blocking.

Example:
![Screenshot from 2021-08-20 12-07-09](https://user-images.githubusercontent.com/30265743/130187943-7b8175fe-1a1b-4960-9b1e-25ef1c55c646.png)
![Screenshot from 2021-08-20 14-10-07](https://user-images.githubusercontent.com/30265743/130188104-329bc51a-8af2-459d-aec7-b40721e462da.png)
