### PR TITLE
Feature/graph names and widths

### DIFF
--- a/rmf_traffic_editor/CMakeLists.txt
+++ b/rmf_traffic_editor/CMakeLists.txt
@@ -57,6 +57,7 @@ set(gui_sources
   gui/editor.cpp
   gui/editor_model.cpp
   gui/fiducial.cpp
+  gui/graph.cpp
   gui/layer.cpp
   gui/layer_dialog.cpp
   gui/layer_table.cpp

--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -143,6 +143,17 @@ bool Building::load(const string& _filename)
     }
   }
 
+  if (y["graphs"] && y["graphs"].IsMap())
+  {
+    const YAML::Node& g_map = y["graphs"];
+    for (YAML::const_iterator it = g_map.begin(); it != g_map.end(); ++it)
+    {
+      Graph graph;
+      graph.from_yaml(it->first.as<int>(), it->second);
+      graphs.push_back(graph);
+    }
+  }
+
   calculate_all_transforms();
   return true;
 }
@@ -169,6 +180,10 @@ bool Building::save()
 
   if (crowd_sim_impl)
     y["crowd_sim"] = crowd_sim_impl->to_yaml();
+
+  y["graphs"] = YAML::Node(YAML::NodeType::Map);
+  for (const auto& graph : graphs)
+    y["graphs"][graph.idx] = graph.to_yaml();
 
   YAML::Emitter emitter;
   yaml_utils::write_node(y, emitter);
@@ -694,7 +709,7 @@ void Building::draw(
     return;
   }
 
-  levels[level_idx].draw(scene, editor_models, rendering_options);
+  levels[level_idx].draw(scene, editor_models, rendering_options, graphs);
   draw_lifts(scene, level_idx);
 }
 

--- a/rmf_traffic_editor/gui/building.h
+++ b/rmf_traffic_editor/gui/building.h
@@ -29,6 +29,7 @@ class QGraphicsScene;
 #include <QGraphicsLineItem>
 #include <QPointF>
 
+#include "graph.h"
 #include "level.h"
 #include "lift.h"
 #include <traffic_editor/crowd_sim/crowd_sim_impl.h>
@@ -44,6 +45,7 @@ public:
   std::string reference_level_name;
   std::vector<Level> levels;
   std::vector<Lift> lifts;
+  std::vector<Graph> graphs;
 
   mutable crowd_sim::CrowdSimImplPtr crowd_sim_impl;
 

--- a/rmf_traffic_editor/gui/graph.cpp
+++ b/rmf_traffic_editor/gui/graph.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "graph.h"
+using std::string;
+
+Graph::Graph()
+{
+}
+
+Graph::~Graph()
+{
+}
+
+bool Graph::from_yaml(const int _idx, const YAML::Node& data)
+{
+  if (!data.IsMap())
+    throw std::runtime_error("Graph::from_yaml() expected a map");
+  idx = _idx;
+  //idx = std::stoi(idx_str);
+
+  if (data["name"])
+    name = data["name"].as<string>();
+
+  if (data["default_lane_width"])
+    default_lane_width = data["default_lane_width"].as<double>();
+
+  return true;
+}
+
+YAML::Node Graph::to_yaml() const
+{
+  YAML::Node data;
+  data["name"] = name;
+  data["default_lane_width"] = default_lane_width;
+  return data;
+}

--- a/rmf_traffic_editor/gui/graph.h
+++ b/rmf_traffic_editor/gui/graph.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef TRAFFIC_EDITOR_GRAPH_H
+#define TRAFFIC_EDITOR_GRAPH_H
+
+#include <string>
+
+#include <yaml-cpp/yaml.h>
+
+class Graph
+{
+public:
+  Graph();
+  ~Graph();
+
+  int idx = 0;
+  std::string name;
+  double default_lane_width = 1.0;
+
+  bool from_yaml(const int _idx, const YAML::Node& data);
+  YAML::Node to_yaml() const;
+};
+
+#endif

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -67,7 +67,7 @@ bool Level::from_yaml(
   {
     x_meters = _data["x_meters"].as<double>();
     y_meters = _data["y_meters"].as<double>();
-    drawing_meters_per_pixel = 0.05;  // something reasonable
+    drawing_meters_per_pixel = 1.0;
     drawing_width = x_meters / drawing_meters_per_pixel;
     drawing_height = y_meters / drawing_meters_per_pixel;
   }

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -67,7 +67,7 @@ bool Level::from_yaml(
   {
     x_meters = _data["x_meters"].as<double>();
     y_meters = _data["y_meters"].as<double>();
-    drawing_meters_per_pixel = 1.0;
+    drawing_meters_per_pixel = 0.05;  // something reasonable
     drawing_width = x_meters / drawing_meters_per_pixel;
     drawing_height = y_meters / drawing_meters_per_pixel;
   }

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -1150,10 +1150,18 @@ void Level::draw(
     }
   }
 
+  QFont vertex_name_font("Helvetica");
+  double vertex_name_font_size =
+    vertex_radius / drawing_meters_per_pixel * 1.5;
+  if (vertex_name_font_size < 1.0)
+    vertex_name_font_size = 1.0;
+  vertex_name_font.setPointSizeF(vertex_name_font_size);
+
   for (const auto& v : vertices)
     v.draw(
       scene,
-      vertex_radius / drawing_meters_per_pixel);
+      vertex_radius / drawing_meters_per_pixel,
+      vertex_name_font);
 
   for (const auto& f : fiducials)
     f.draw(scene, drawing_meters_per_pixel);

--- a/rmf_traffic_editor/gui/level.h
+++ b/rmf_traffic_editor/gui/level.h
@@ -26,6 +26,7 @@
 #include "editor_model.h"
 #include "feature.hpp"
 #include "fiducial.h"
+#include "graph.h"
 #include "layer.h"
 #include "model.h"
 #include "polygon.h"
@@ -161,7 +162,8 @@ public:
   void draw(
     QGraphicsScene* scene,
     std::vector<EditorModel>& editor_models,
-    const RenderingOptions& rendering_options);
+    const RenderingOptions& rendering_options,
+    const std::vector<Graph>& graphs);
 
   void clear_scene();
 
@@ -203,7 +205,8 @@ private:
   void draw_lane(
     QGraphicsScene* scene,
     const Edge& edge,
-    const RenderingOptions& rendering_options) const;
+    const RenderingOptions& rendering_options,
+    const std::vector<Graph>& graphs) const;
 
   void draw_wall(QGraphicsScene* scene, const Edge& edge) const;
   void draw_meas(QGraphicsScene* scene, const Edge& edge) const;

--- a/rmf_traffic_editor/gui/vertex.cpp
+++ b/rmf_traffic_editor/gui/vertex.cpp
@@ -102,7 +102,8 @@ YAML::Node Vertex::to_yaml() const
 
 void Vertex::draw(
   QGraphicsScene* scene,
-  const double radius) const
+  const double radius,
+  const QFont& font) const
 {
   QPen vertex_pen(Qt::black);
   vertex_pen.setWidthF(radius / 2.0);
@@ -240,9 +241,9 @@ void Vertex::draw(
   {
     QGraphicsSimpleTextItem* text_item = scene->addSimpleText(
       QString::fromStdString(name),
-      QFont("Helvetica", 6));
+      font);
     text_item->setBrush(selected ? selected_color : vertex_color);
-    text_item->setPos(x, y + radius);
+    text_item->setPos(x, y - 1 + radius);
   }
 }
 

--- a/rmf_traffic_editor/gui/vertex.h
+++ b/rmf_traffic_editor/gui/vertex.h
@@ -53,7 +53,8 @@ public:
 
   void draw(
     QGraphicsScene* scene,
-    const double radius) const;
+    const double radius,
+    const QFont& font) const;
 
   bool is_parking_point() const;
   bool is_holding_point() const;


### PR DESCRIPTION
## Top-level graph parameters in YAML

Working towards #378 , this PR provides a new `graphs` top-level dict in the YAML files. Entries in this dict can map graphs (currently only identified by their integer ID) to human-readable names. Graphs can also have a default lane width, to avoid having to set lane width on each individual lane segment. This `graphs` top-level dict is optional; there will be no change when viewing or saving existing files. Adding GUI widgets to add or edit these parameters will come in a subsequent PR; for now, you can hand-edit the YAML.

## Better font scaling for vertex names

Previously, vertex names were rendered with a hard-coded font size. This made them seem too-small or too-large depending on the map scale. The `Level::draw()` function now computes a reasonable font size and reuses it for each `Vertex::draw()` call; previously it was creating a hard-coded font and throwing it away after rendering each vertex, which was slow when rendering very large maps.