### PR TITLE
fix whitespace issue in download chain

### DIFF
--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -638,6 +638,8 @@ def download_model_fuel_tools(model_name, author_name,
             model_name.lower())
 
         if " " in model_name:
+            if os.path.isdir(extract_path):
+                shutil.rmtree(extract_path)
             os.rename(os.path.join(extract_path_base, url_model_name.lower()),
                       extract_path)
 


### PR DESCRIPTION
Addresses https://github.com/open-rmf/rmf_traffic_editor/issues/386

Current implementation:

* downloads model to ~/.ignition folder, with whitespaces in names parsed as "%20"
* checks if there is whitespace in the model name
* If whitespace exists, rename "%20"-formatted name to whitespace name

the rename step fails when a model already exists with the whitespace name, which happens if the model was already downloaded in another demos package. This affects the export step involving the copy of the model from ~/.ignition folder to the workspace install folder.

PR is a quick fix targeting the rename step by ensuring any pre-existing model folder is removed, thus avoiding this failure. In the long term, it might be worth stripping whitespaces in fuel itself?