### PR TITLE
Add support for Cartesian Meters reference system and coordinate offset

### DIFF
--- a/rmf_building_map_tools/building_crowdsim/building_yaml_parse.py
+++ b/rmf_building_map_tools/building_crowdsim/building_yaml_parse.py
@@ -4,12 +4,13 @@ import os
 import copy
 
 from building_map.building import Building
+from building_map.coordinate_system import CoordinateSystem
 from building_map.level import Level
 
 
 class LevelWithHumanLanes (Level):
-    def __init__(self, yaml_node, name, graph_idx=9):
-        Level.__init__(self, yaml_node, name)
+    def __init__(self, yaml_node, name, coordinate_system, graph_idx=9):
+        Level.__init__(self, yaml_node, name, coordinate_system)
 
         # default graph_idx for human_lanes is 9
         self.current_graph_idx = graph_idx
@@ -54,6 +55,12 @@ class BuildingYamlParse:
         with open(self.building_file) as f:
             self.yaml_node = yaml.load(f, yaml.SafeLoader)
 
+        if 'coordinate_system' in self.yaml_node:
+            coordinate_system = \
+                CoordinateSystem[self.yaml_node['coordinate_system']]
+        else:
+            coordinate_system = CoordinateSystem.reference_image
+
         # human_lanes for navmesh
         self.levels_with_human_lanes = {}
         self.levels_name = []
@@ -61,7 +68,7 @@ class BuildingYamlParse:
             if 'human_lanes' not in level_yaml:
                 raise ValueError(f'expected human_lanes in level')
             self.levels_with_human_lanes[level_name] = LevelWithHumanLanes(
-                level_yaml, level_name)
+                level_yaml, level_name, coordinate_system)
             self.levels_name.append(level_name)
 
         # crowd_sim for configuration

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -175,7 +175,8 @@ class Building:
             elif self.coordinate_system == 'cartesian_meters':
                 if 'generate_crs' in self.params:
                     g['crs_name'] = self.params['generate_crs'].value
-                g['offset'] = [*self.global_transform.translation]
+                tx, ty = self.global_transform.x, self.global_transform.y
+                g['offset'] = [tx, ty]
 
             empty = True
             for level_name, level in self.levels.items():

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -112,7 +112,8 @@ class Building:
                 else:
                     transform = self.ref_level.transform
                 self.lifts[lift_name] = \
-                    Lift(lift_yaml, lift_name, transform, self.levels)
+                    Lift(lift_yaml, lift_name, transform, self.levels,
+                         self.coordinate_system)
 
         self.set_lift_vert_lists()
 

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -173,10 +173,10 @@ class Building:
             g['building_name'] = self.name
             g['levels'] = {}
 
-            if self.coordinate_system == CoordinateSystem.WEB_MERCATOR:
+            if self.coordinate_system == CoordinateSystem.web_mercator:
                 g['crs_name'] = self.global_transform.crs_name
                 g['offset'] = [*self.global_transform.offset]
-            elif self.coordinate_system == CoordinateSystem.CARTESIAN_METERS:
+            elif self.coordinate_system == CoordinateSystem.cartesian_meters:
                 if 'generate_crs' in self.params:
                     g['crs_name'] = self.params['generate_crs'].value
                 tx, ty = self.global_transform.x, self.global_transform.y
@@ -244,7 +244,7 @@ class Building:
                       {'name': vertex.name, 'x': str(vertex.x),
                        'y': str(vertex.y), 'level': level_name})
 
-        if self.coordinate_system == CoordinateSystem.WEB_MERCATOR:
+        if self.coordinate_system == CoordinateSystem.web_mercator:
             (tx, ty) = self.global_transform.x, self.global_transform.y
             offset_ele = SubElement(world, 'offset')
             offset_ele.text = f'{tx} {ty} 0 0 0 0'
@@ -252,7 +252,7 @@ class Building:
             crs_ele = SubElement(world, 'crs')
             crs_ele.text = self.global_transform.frame_name
 
-        elif self.coordinate_system == CoordinateSystem.CARTESIAN_METERS:
+        elif self.coordinate_system == CoordinateSystem.cartesian_meters:
             tx, ty = self.global_transform.x, self.global_transform.y
             offset_ele = SubElement(world, 'offset')
             offset_ele.text = f'{tx} {ty} 0 0 0 0'

--- a/rmf_building_map_tools/building_map/coordinate_system.py
+++ b/rmf_building_map_tools/building_map/coordinate_system.py
@@ -6,7 +6,7 @@ class CoordinateSystem(Enum):
     cartesian_meters = 3
 
     def y_flip_scalar(self):
-        if self.value == self.reference_image:
+        if self == CoordinateSystem.reference_image:
             return -1
         else:
             return 1

--- a/rmf_building_map_tools/building_map/coordinate_system.py
+++ b/rmf_building_map_tools/building_map/coordinate_system.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+class CoordinateSystem(Enum):
+    reference_image = 1
+    web_mercator = 2
+    cartesian_meters = 3
+
+    def y_flip_scalar(self):
+        if self.value == self.reference_image:
+            return -1
+        else:
+            return 1

--- a/rmf_building_map_tools/building_map/coordinate_system.py
+++ b/rmf_building_map_tools/building_map/coordinate_system.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class CoordinateSystem(Enum):
     reference_image = 1
     web_mercator = 2

--- a/rmf_building_map_tools/building_map/fiducial.py
+++ b/rmf_building_map_tools/building_map/fiducial.py
@@ -2,13 +2,17 @@ import math
 
 
 class Fiducial:
-    def __init__(self, yaml_node):
+    def __init__(self, yaml_node, coordinate_system):
         self.x = yaml_node[0]
-        self.y = -yaml_node[1]
+        self.y = yaml_node[1] * coordinate_system.y_flip_scalar()
         self.name = yaml_node[2]
 
-    def to_yaml(self):
-        return [self.x, -self.y, self.name]
+    def to_yaml(self, coordinate_system):
+        return [
+            self.x,
+            self.y * coordinate_system.y_flip_scalar(),
+            self.name
+        ]
 
     def distance(self, f):
         """ Calculate distance to another fiducial """

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -440,6 +440,9 @@ class Level:
                 dock_name = v1.params['dock_name'].value
                 dock_at_end = False
 
+            if 'speed_limit' in l.params:
+                p['speed_limit'] = l.params['speed_limit'].value
+
             if always_unidirectional and l.is_bidirectional():
                 # now flip things around and make the second link
                 forward_params = copy.deepcopy(p)

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -29,6 +29,7 @@ class Level:
         self,
         yaml_node,
         name,
+        coordinate_system,
         model_counts={},
         transform=None
     ):
@@ -46,12 +47,13 @@ class Level:
         self.fiducials = []
         if 'fiducials' in yaml_node:
             for fiducial_yaml in yaml_node['fiducials']:
-                self.fiducials.append(Fiducial(fiducial_yaml))
+                self.fiducials.append(
+                    Fiducial(fiducial_yaml, coordinate_system))
 
         self.vertices = []
         if 'vertices' in yaml_node and yaml_node['vertices']:
             for vertex_yaml in yaml_node['vertices']:
-                self.vertices.append(Vertex(vertex_yaml))
+                self.vertices.append(Vertex(vertex_yaml, coordinate_system))
 
         if transform is None:
             self.transform = Transform()
@@ -86,11 +88,15 @@ class Level:
                 name = model_yaml["name"]
                 if name not in model_counts:
                     model_counts[name] = 1
-                    self.models.append(Model(name, model_yaml))
+                    self.models.append(
+                        Model(name, model_yaml, coordinate_system))
                 else:
                     model_counts[name] += 1
                     self.models.append(
-                            Model(f'{name}_{model_counts[name]}', model_yaml))
+                        Model(
+                            f'{name}_{model_counts[name]}',
+                            model_yaml,
+                            coordinate_system))
 
         self.floors = []
         if 'floors' in yaml_node:
@@ -102,20 +108,20 @@ class Level:
             for hole_yaml in yaml_node['holes']:
                 self.holes.append(Hole(hole_yaml))
 
-    def to_yaml(self):
+    def to_yaml(self, coordinate_system):
         y = {}
         if self.drawing_name:
             y['drawing'] = {}
             y['drawing']['filename'] = self.drawing_name
         y['elevation'] = self.elevation
 
-        y['fiducials'] = [f.to_yaml() for f in self.fiducials]
-        y['vertices'] = [v.to_yaml() for v in self.vertices]
+        y['fiducials'] = [f.to_yaml(coordinate_system) for f in self.fiducials]
+        y['vertices'] = [v.to_yaml(coordinate_system) for v in self.vertices]
         y['measurements'] = [e.to_yaml() for e in self.meas]
         y['lanes'] = [e.to_yaml() for e in self.lanes]
         y['walls'] = [e.to_yaml() for e in self.walls]
         y['doors'] = [e.to_yaml() for e in self.doors]
-        y['models'] = [m.to_yaml() for m in self.models]
+        y['models'] = [m.to_yaml(coordinate_system) for m in self.models]
         y['floors'] = [f.to_yaml() for f in self.floors]
         y['holes'] = [h.to_yaml() for h in self.holes]
         return y

--- a/rmf_building_map_tools/building_map/lift.py
+++ b/rmf_building_map_tools/building_map/lift.py
@@ -211,7 +211,7 @@ class LiftDoor:
 
 
 class Lift:
-    def __init__(self, yaml_node, name, transform, levels):
+    def __init__(self, yaml_node, name, transform, levels, coordinate_system):
         self.name = name
         print(f'parsing lift {name}')
 
@@ -249,7 +249,10 @@ class Lift:
         if 'plugins' in yaml_node:
             self.plugins = bool(yaml_node['plugins'])
 
-        self.raw_pos = (float(yaml_node['x']), -float(yaml_node['y']))
+        self.raw_pos = (
+            float(yaml_node['x']),
+            float(yaml_node['y'] * coordinate_system.y_flip_scalar())
+        )
         self.x, self.y = transform.transform_point(self.raw_pos)
         self.cabin_height = 2.5
         self.wall_thickness = 0.05
@@ -298,7 +301,7 @@ class Lift:
             self.end_points[side] += [left, right]
             self.end_points[side].sort()
 
-    def to_yaml(self):
+    def to_yaml(self, coordinate_system):
         y = {}
         y['depth'] = self.depth
         y['width'] = self.width
@@ -312,7 +315,7 @@ class Lift:
             y['reference_floor_name'] = self.reference_floor_name
         y['plugins'] = self.plugins
         y['x'] = self.raw_pos[0]
-        y['y'] = -self.raw_pos[1]  # invert back to image coords
+        y['y'] = self.raw_pos[1] * coordinate_system.y_flip_scalar()
         y['level_doors'] = {}
         print(self.level_doors)
         for level_name, door_names in self.level_doors.items():

--- a/rmf_building_map_tools/building_map/model.py
+++ b/rmf_building_map_tools/building_map/model.py
@@ -2,11 +2,11 @@ from xml.etree.ElementTree import SubElement
 
 
 class Model:
-    def __init__(self, name, yaml_node):
+    def __init__(self, name, yaml_node, coordinate_system):
         self.name = name
         self.model_name = yaml_node['model_name']
         self.x = yaml_node['x']
-        self.y = -yaml_node['y']
+        self.y = yaml_node['y'] * coordinate_system.y_flip_scalar()
         self.z = 0.0
         if 'z' in yaml_node:
             self.z = yaml_node['z']
@@ -30,10 +30,10 @@ class Model:
 
         self.yaw = yaml_node['yaw']
 
-    def to_yaml(self):
+    def to_yaml(self, coordinate_system):
         y = {}
         y['x'] = self.x
-        y['y'] = -self.y  # invert it back for the file format...
+        y['y'] = self.y * coordinate_system.y_flip_scalar()
         y['z'] = self.z
         y['model_name'] = self.model_name
         y['name'] = self.name

--- a/rmf_building_map_tools/building_map/passthrough_transform.py
+++ b/rmf_building_map_tools/building_map/passthrough_transform.py
@@ -1,0 +1,10 @@
+class PassthroughTransform:
+    """This class stores a 2D translation, but doesn't apply it."""
+
+    def __init__(self, x, y, frame_name):
+        self.x = x
+        self.y = y
+        self.frame_name = frame_name
+
+    def transform_point(self, p):
+        return p

--- a/rmf_building_map_tools/building_map/vertex.py
+++ b/rmf_building_map_tools/building_map/vertex.py
@@ -2,9 +2,9 @@ from .param_value import ParamValue
 
 
 class Vertex:
-    def __init__(self, yaml_node):
+    def __init__(self, yaml_node, coordinate_system):
         self.x = float(yaml_node[0])
-        self.y = float(-yaml_node[1])
+        self.y = float(yaml_node[1]) * coordinate_system.y_flip_scalar()
         self.z = float(yaml_node[2])  # currently always 0
         self.name = yaml_node[3]
 
@@ -16,8 +16,14 @@ class Vertex:
     def xy(self):
         return (self.x, self.y)
 
-    def to_yaml(self):
-        y = [self.x, -self.y, self.z, self.name, {}]
+    def to_yaml(self, coordinate_system):
+        y = [
+            self.x,
+            self.y * coordinate_system.y_flip_scalar(),
+            self.z,
+            self.name,
+            {}
+        ]
         for param_name, param_value in self.params.items():
             y[4][param_name] = param_value.to_yaml()
         return y

--- a/rmf_building_map_tools/building_map/web_mercator_transform.py
+++ b/rmf_building_map_tools/building_map/web_mercator_transform.py
@@ -26,6 +26,7 @@ class WebMercatorTransform:
         meters_east = R * math.pi * (p[0] - 128) / 128
         # because our legacy code is all in image coordinates, the Y coord
         # is negated... this step will flip it back
+        # TODO: revisit this now that loading is not always flipped...
         meters_north = R * math.pi * (128 + p[1]) / 128
 
         (lat, lon) = \

--- a/rmf_building_map_tools/setup.cfg
+++ b/rmf_building_map_tools/setup.cfg
@@ -1,7 +1,7 @@
 [develop]
-script-dir=$base/lib/rmf_building_map_tools
+script_dir=$base/lib/rmf_building_map_tools
 [install]
-install-scripts=$base/lib/rmf_building_map_tools
+install_scripts=$base/lib/rmf_building_map_tools
 
 [options]
 tests_require = pytest

--- a/rmf_traffic_editor/CMakeLists.txt
+++ b/rmf_traffic_editor/CMakeLists.txt
@@ -52,6 +52,7 @@ set(gui_sources
   gui/building.cpp
   gui/building_dialog.cpp
   gui/constraint.cpp
+  gui/coordinate_system.cpp
   gui/feature.cpp
   gui/edge.cpp
   gui/editor.cpp

--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -38,7 +38,8 @@ using std::shared_ptr;
 
 
 Building::Building()
-: name("building")
+: name("building"),
+  coordinate_system(CoordinateSystem::Legacy)
 {
 }
 
@@ -88,6 +89,11 @@ bool Building::load(const string& _filename)
 
   if (y["name"])
     name = y["name"].as<string>();
+
+  if (y["coordinate_system"])
+    coordinate_system =
+      CoordinateSystem::from_string(
+        y["coordinate_system"].as<string>());
 
   if (y["reference_level_name"])
     reference_level_name = y["reference_level_name"].as<string>();
@@ -154,6 +160,19 @@ bool Building::load(const string& _filename)
     }
   }
 
+  /*
+  // load the parameters
+  if (y["parameters"] && y["parameters"].IsMap())
+  {
+    for (YAML::const_iterator it = data[2].begin(); it != data[2].end(); ++it)
+    {
+      Param p;
+      p.from_yaml(it->second);
+      params[it->first.as<string>()] = p;
+    }
+  }
+  */
+
   calculate_all_transforms();
   return true;
 }
@@ -164,6 +183,8 @@ bool Building::save()
 
   YAML::Node y;
   y["name"] = name;
+
+  y["coordinate_system"] = coordinate_system.to_string();
 
   if (!reference_level_name.empty())
     y["reference_level_name"] = reference_level_name;

--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -92,8 +92,7 @@ bool Building::load(const string& _filename)
 
   if (y["coordinate_system"])
     coordinate_system =
-      CoordinateSystem::from_string(
-        y["coordinate_system"].as<string>());
+      CoordinateSystem::from_string(y["coordinate_system"].as<string>());
 
   if (y["reference_level_name"])
     reference_level_name = y["reference_level_name"].as<string>();

--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -729,7 +729,13 @@ void Building::draw(
     return;
   }
 
-  levels[level_idx].draw(scene, editor_models, rendering_options, graphs);
+  levels[level_idx].draw(
+    scene,
+    editor_models,
+    rendering_options,
+    graphs,
+    coordinate_system);
+
   draw_lifts(scene, level_idx);
 }
 

--- a/rmf_traffic_editor/gui/building.h
+++ b/rmf_traffic_editor/gui/building.h
@@ -29,6 +29,7 @@ class QGraphicsScene;
 #include <QGraphicsLineItem>
 #include <QPointF>
 
+#include "coordinate_system.h"
 #include "graph.h"
 #include "level.h"
 #include "lift.h"
@@ -46,6 +47,7 @@ public:
   std::vector<Level> levels;
   std::vector<Lift> lifts;
   std::vector<Graph> graphs;
+  CoordinateSystem coordinate_system;
 
   mutable crowd_sim::CrowdSimImplPtr crowd_sim_impl;
 

--- a/rmf_traffic_editor/gui/coordinate_system.cpp
+++ b/rmf_traffic_editor/gui/coordinate_system.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2019-2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "coordinate_system.h"
+
+CoordinateSystem::CoordinateSystem()
+: value(CoordinateSystem::Undefined)
+{
+}
+
+CoordinateSystem::CoordinateSystem(const CoordinateSystem::Value& _value)
+: value(_value)
+{
+}
+
+CoordinateSystem::~CoordinateSystem()
+{
+}
+
+std::string CoordinateSystem::to_string()
+{
+  switch (value)
+  {
+    case Legacy: return "legacy";
+    case WebMercator: return "web_mercator";
+    case CartesianMeters: return "cartesian_meters";
+
+    case Undefined:
+    default:
+      return "undefined";
+  }
+}
+
+CoordinateSystem CoordinateSystem::from_string(const std::string& s)
+{
+  CoordinateSystem cs;
+  if (s == "legacy")
+    cs.value = Legacy;
+  else if (s == "web_mercator")
+    cs.value = WebMercator;
+  else if (s == "cartesian_meters")
+    cs.value = CartesianMeters;
+  else
+    cs.value = Undefined;
+  return cs;
+}
+
+bool CoordinateSystem::is_y_flipped()
+{
+  return cs.value == Legacy;
+}

--- a/rmf_traffic_editor/gui/coordinate_system.cpp
+++ b/rmf_traffic_editor/gui/coordinate_system.cpp
@@ -59,7 +59,7 @@ CoordinateSystem CoordinateSystem::from_string(const std::string& s)
   return cs;
 }
 
-bool CoordinateSystem::is_y_flipped()
+bool CoordinateSystem::is_y_flipped() const
 {
   return value == Legacy;
 }

--- a/rmf_traffic_editor/gui/coordinate_system.cpp
+++ b/rmf_traffic_editor/gui/coordinate_system.cpp
@@ -61,5 +61,5 @@ CoordinateSystem CoordinateSystem::from_string(const std::string& s)
 
 bool CoordinateSystem::is_y_flipped()
 {
-  return cs.value == Legacy;
+  return value == Legacy;
 }

--- a/rmf_traffic_editor/gui/coordinate_system.h
+++ b/rmf_traffic_editor/gui/coordinate_system.h
@@ -37,7 +37,7 @@ public:
 
   std::string to_string();
   static CoordinateSystem from_string(const std::string& s);
-  bool is_y_flipped();
+  bool is_y_flipped() const;
 };
 
 #endif

--- a/rmf_traffic_editor/gui/coordinate_system.h
+++ b/rmf_traffic_editor/gui/coordinate_system.h
@@ -23,7 +23,8 @@
 class CoordinateSystem
 {
 public:
-  enum Value {
+  enum Value
+  {
     Undefined,
     Legacy,
     WebMercator,

--- a/rmf_traffic_editor/gui/coordinate_system.h
+++ b/rmf_traffic_editor/gui/coordinate_system.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019-2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef COORDINATE_SYSTEM_H
+#define COORDINATE_SYSTEM_H
+
+#include <string>
+
+class CoordinateSystem
+{
+public:
+  enum Value {
+    Undefined,
+    Legacy,
+    WebMercator,
+    CartesianMeters
+  } value;
+
+  CoordinateSystem();
+  CoordinateSystem(const CoordinateSystem::Value& _value);
+  ~CoordinateSystem();
+
+  std::string to_string();
+  static CoordinateSystem from_string(const std::string& s);
+  bool is_y_flipped();
+};
+
+#endif

--- a/rmf_traffic_editor/gui/edge.cpp
+++ b/rmf_traffic_editor/gui/edge.cpp
@@ -131,6 +131,7 @@ void Edge::create_required_parameters()
     create_param_if_needed("demo_mock_floor_name", Param::STRING,
       std::string());
     create_param_if_needed("demo_mock_lift_name", Param::STRING, std::string());
+    create_param_if_needed("speed_limit", Param::DOUBLE, 0.0);
   }
   else if (type == DOOR)
   {

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -612,7 +612,7 @@ void Editor::restore_previous_viewport()
     viewport_center_y,
     viewport_scale);
 
-  double y_flip = building.coordinate_system.is_y_flipped() : 1 : -1;
+  double y_flip = building.coordinate_system.is_y_flipped() ? 1 : -1;
 
   QTransform t;
   t.scale(viewport_scale, y_flip * viewport_scale);

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -157,7 +157,8 @@ Editor::Editor()
         create_scene();
 
         QTransform t;
-        t.scale(scale, scale);
+        double y_flip = building.coordinate_system.is_y_flipped() ? 1 : -1;
+        t.scale(scale, y_flip * scale);
         map_view->setTransform(t);
         map_view->centerOn(p_transformed);
       }
@@ -611,8 +612,10 @@ void Editor::restore_previous_viewport()
     viewport_center_y,
     viewport_scale);
 
+  double y_flip = building.coordinate_system.is_y_flipped() : 1 : -1;
+
   QTransform t;
-  t.scale(viewport_scale, viewport_scale);
+  t.scale(viewport_scale, y_flip * viewport_scale);
   map_view->setTransform(t);
   map_view->centerOn(QPointF(viewport_center_x, viewport_center_y));
 }
@@ -794,8 +797,10 @@ void Editor::view_models()
 void Editor::zoom_reset()
 {
   const double viewport_scale = 1.0;
+  const double y_flip = building.coordinate_system.is_y_flipped() ? 1 : -1;
+
   QTransform t;
-  t.scale(viewport_scale, viewport_scale);
+  t.scale(viewport_scale, y_flip * viewport_scale);
   map_view->setTransform(t);
 }
 

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -649,24 +649,22 @@ void Level::draw_lane(
     lane_width_meters = graph_default_width;
 
   const double lane_pen_width = lane_width_meters / drawing_meters_per_pixel;
-
-  const QPen arrow_pen(
-    QBrush(QColor::fromRgbF(0.0, 0.0, 0.0, 0.5)),
-    lane_pen_width / 8);
-
-  // dimensions for the direction indicators along this path
-  const double arrow_w = lane_pen_width / 2.5;  // width of arrowheads
-  const double arrow_l = lane_pen_width / 2.5;  // length of arrowheads
-  const double arrow_spacing = lane_pen_width / 2.0;
-
   const double norm_x = dx / len;
   const double norm_y = dy / len;
 
   // only draw arrows if it's a unidirectional lane. We used to draw
   // arrows in both directions for bidirectional, but it was messy.
-
   if (!edge.is_bidirectional())
   {
+    const QPen arrow_pen(
+      QBrush(QColor::fromRgbF(0.0, 0.0, 0.0, 0.5)),
+      lane_pen_width / 8);
+
+    // dimensions for the direction indicators along this path
+    const double arrow_w = lane_pen_width / 2.5;  // width of arrowheads
+    const double arrow_l = lane_pen_width / 2.5;  // length of arrowheads
+    const double arrow_spacing = lane_pen_width * 4.0;
+
     for (double d = 0.0; d < len; d += arrow_spacing)
     {
       // first calculate the center vertex of this arrowhead

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -1091,7 +1091,8 @@ void Level::draw(
   QGraphicsScene* scene,
   vector<EditorModel>& editor_models,
   const RenderingOptions& rendering_options,
-  const vector<Graph>& graphs)
+  const vector<Graph>& graphs,
+  const CoordinateSystem& coordinate_system)
 {
   if (drawing_filename.size() && _drawing_visible)
   {
@@ -1161,7 +1162,8 @@ void Level::draw(
     v.draw(
       scene,
       vertex_radius / drawing_meters_per_pixel,
-      vertex_name_font);
+      vertex_name_font,
+      coordinate_system);
 
   for (const auto& f : fiducials)
     f.draw(scene, drawing_meters_per_pixel);

--- a/rmf_traffic_editor/gui/level.h
+++ b/rmf_traffic_editor/gui/level.h
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "constraint.hpp"
+#include "coordinate_system.h"
 #include "edge.h"
 #include "editor_model.h"
 #include "feature.hpp"
@@ -163,7 +164,8 @@ public:
     QGraphicsScene* scene,
     std::vector<EditorModel>& editor_models,
     const RenderingOptions& rendering_options,
-    const std::vector<Graph>& graphs);
+    const std::vector<Graph>& graphs,
+    const CoordinateSystem& coordinate_system);
 
   void clear_scene();
 

--- a/rmf_traffic_editor/gui/vertex.cpp
+++ b/rmf_traffic_editor/gui/vertex.cpp
@@ -103,7 +103,8 @@ YAML::Node Vertex::to_yaml() const
 void Vertex::draw(
   QGraphicsScene* scene,
   const double radius,
-  const QFont& font) const
+  const QFont& font,
+  const CoordinateSystem& coordinate_system) const
 {
   QPen vertex_pen(Qt::black);
   vertex_pen.setWidthF(radius / 2.0);
@@ -243,7 +244,19 @@ void Vertex::draw(
       QString::fromStdString(name),
       font);
     text_item->setBrush(selected ? selected_color : vertex_color);
-    text_item->setPos(x, y - 1 + radius);
+
+    if (coordinate_system.is_y_flipped())
+    {
+      // default screen coordinates: +Y=down. Nothing special needed.
+      text_item->setPos(x, y - 1 + radius);
+    }
+    else
+    {
+      // if Y is not flipped, this means we have +Y=up, so we have to
+      // flip the text, because Qt's default is for +Y=down screen coords
+      text_item->setTransform(QTransform::fromScale(1.0, -1.0));
+      text_item->setPos(x, y + 1 + radius);
+    }
   }
 }
 

--- a/rmf_traffic_editor/gui/vertex.h
+++ b/rmf_traffic_editor/gui/vertex.h
@@ -26,6 +26,7 @@
 
 #include <QColor>
 
+#include "coordinate_system.h"
 #include "param.h"
 
 class QGraphicsScene;
@@ -54,7 +55,8 @@ public:
   void draw(
     QGraphicsScene* scene,
     const double radius,
-    const QFont& font) const;
+    const QFont& font,
+    const CoordinateSystem& coordinate_system) const;
 
   bool is_parking_point() const;
   bool is_holding_point() const;


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This PR (mainly done by @codebot ) introduces a new `CoordinateSystem` object in `rmf_building_map_tools` that is mainly used to implement a Cartesian System with matching x-y coordinate conventions (where the Y axis is flipped compared to the usual image coordinates).
It also introduces an offset field that can be set in projects to report to downstream packages that all the coordinates should be offset by a certain constant.
This is especially useful when cartesian systems in global coordinates, such as [EPGS:3414/SVY21](https://epsg.io/3414) are used, since they can have large offsets.

The offset field is currently not published by `building_map_server` because there is no support in the top level [BuildingMap message](https://github.com/open-rmf/rmf_building_map_msgs/blob/main/rmf_building_map_msgs/msg/BuildingMap.msg) for parameter fields.
A new message is being worked on, together with a matching publisher in [rmf_building_map_msgs #3](https://github.com/open-rmf/rmf_building_map_msgs/pull/3) and the [feature/sitemap_server branch](https://github.com/open-rmf/rmf_traffic_editor/tree/feature/sitemap_server) in this repo to expose information on the coordinate system to downstream users.