### PR TITLE
Use yaml-cpp CLoader and CDumper from Python for speed

### DIFF
--- a/rmf_building_map_tools/building_map/generator.py
+++ b/rmf_building_map_tools/building_map/generator.py
@@ -1,6 +1,5 @@
 import os
 import yaml
-from yaml import CLoader as Loader
 from xml.etree.ElementTree import tostring as ElementToString
 from .building import Building
 from .etree_utils import indent_etree
@@ -15,7 +14,7 @@ class Generator:
             raise FileNotFoundError(f'input file {input_filename} not found')
 
         with open(input_filename, 'r') as f:
-            y = yaml.load(f, Loader=Loader)
+            y = yaml.load(f, Loader=yaml.CLoader)
             return Building(y)
 
     def generate_sdf(
@@ -95,4 +94,4 @@ class Generator:
                     graph_data,
                     f,
                     default_flow_style=None,
-                    Dumper=CustomDumper)
+                    Dumper=yaml.CDumper)

--- a/rmf_building_map_tools/building_map/generator.py
+++ b/rmf_building_map_tools/building_map/generator.py
@@ -1,5 +1,6 @@
 import os
 import yaml
+from yaml import CLoader as Loader
 from xml.etree.ElementTree import tostring as ElementToString
 from .building import Building
 from .etree_utils import indent_etree
@@ -14,7 +15,7 @@ class Generator:
             raise FileNotFoundError(f'input file {input_filename} not found')
 
         with open(input_filename, 'r') as f:
-            y = yaml.safe_load(f)
+            y = yaml.load(f, Loader=Loader)
             return Building(y)
 
     def generate_sdf(

--- a/rmf_building_map_tools/building_map/generator.py
+++ b/rmf_building_map_tools/building_map/generator.py
@@ -79,10 +79,6 @@ class Generator:
         building = self.parse_editor_yaml(input_filename)
         nav_graphs = building.generate_nav_graphs()
 
-        class CustomDumper(yaml.Dumper):
-            def ignore_aliases(self, _):
-                return True
-
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
 

--- a/rmf_building_map_tools/package.xml
+++ b/rmf_building_map_tools/package.xml
@@ -13,6 +13,7 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>rmf_building_map_msgs</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>yaml-cpp</exec_depend>
 
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>python3-requests</exec_depend>


### PR DESCRIPTION
Use the `CLoader` and `CDumper` wrappers of `yaml-cpp` in `rmf_building_map_tools`. This gives significant speedup when loading/saving very large worlds with many thousands of vertices and lanes. Because `yaml-cpp` was already required for building `traffic-editor`, this is not a new dependency of RMF in general, we're just using it in more places now.