### PR TITLE
Add speed limit to navgraph

### DIFF
--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -416,6 +416,10 @@ class Level:
             if l.orientation():
                 p['orientation_constraint'] = l.orientation()
 
+            if 'speed_limit' in l.params and \
+                    l.params['speed_limit'].value > 0.0:
+                p['speed_limit'] = l.params['speed_limit'].value
+
             if 'demo_mock_floor_name' in l.params and \
                     l.params['demo_mock_floor_name'].value:
                 p['demo_mock_floor_name'] = \


### PR DESCRIPTION
Part of https://github.com/open-rmf/rmf_traffic/issues/43

Writes the lane level speed limit to the exported navgraph to be used in downstream nodes.
It is also implemented in the larger PR #396 but that might take a bit of iteration and testing to get in while this is a more straightforward fix.