### PR TITLE
Improve behavior for Cartesian maps

### DIFF
--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -123,7 +123,7 @@ bool Building::load(const string& _filename)
   for (YAML::const_iterator it = yl.begin(); it != yl.end(); ++it)
   {
     Level level;
-    level.from_yaml(it->first.as<string>(), it->second);
+    level.from_yaml(it->first.as<string>(), it->second, coordinate_system);
     levels.push_back(level);
   }
 

--- a/rmf_traffic_editor/gui/coordinate_system.cpp
+++ b/rmf_traffic_editor/gui/coordinate_system.cpp
@@ -66,8 +66,18 @@ bool CoordinateSystem::is_y_flipped() const
 
 double CoordinateSystem::default_scale() const
 {
+  // Image-based maps are often somewhere around 5cm
+  // pixel cell size, since that's the common discretization
+  // of SLAM-based robot maps. Let's use that for the
+  // default scale (unless computed otherwise; hopefully
+  // the map provides a few proper measurements). However,
+  // for other coordinate systems, we should assume a
+  // scale of 1.0 so that the coordinates stay as specified
+  // and the UI tools work as expected in, for example,
+  // Cartesian-meters coordinate systems.
+
   if (value == CoordinateSystem::ReferenceImage)
-    return 0.05; // default robot grid cell size
+    return 0.05;
   else
     return 1.0;
 }

--- a/rmf_traffic_editor/gui/coordinate_system.cpp
+++ b/rmf_traffic_editor/gui/coordinate_system.cpp
@@ -63,3 +63,11 @@ bool CoordinateSystem::is_y_flipped() const
 {
   return value == ReferenceImage;
 }
+
+double CoordinateSystem::default_scale() const
+{
+  if (value == CoordinateSystem::ReferenceImage)
+    return 0.05; // default robot grid cell size
+  else
+    return 1.0;
+}

--- a/rmf_traffic_editor/gui/coordinate_system.h
+++ b/rmf_traffic_editor/gui/coordinate_system.h
@@ -38,6 +38,7 @@ public:
   std::string to_string();
   static CoordinateSystem from_string(const std::string& s);
   bool is_y_flipped() const;
+  double default_scale() const;
 };
 
 #endif

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -1120,7 +1120,7 @@ void Level::draw(
     const double w = x_meters / drawing_meters_per_pixel;
     const double h = y_meters / drawing_meters_per_pixel;
     scene->setSceneRect(QRectF(0, 0, w, h));
-    scene->addRect(0, 0, w, h, QPen(), Qt::white);
+    scene->addRect(0, 0, w, h, Qt::NoPen, Qt::white);
   }
 
   draw_polygons(scene);

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -44,7 +44,8 @@ Level::~Level()
 
 bool Level::from_yaml(
   const std::string& _name,
-  const YAML::Node& _data)
+  const YAML::Node& _data,
+  const CoordinateSystem& coordinate_system)
 {
   printf("parsing level [%s]\n", _name.c_str());
   name = _name;
@@ -67,7 +68,7 @@ bool Level::from_yaml(
   {
     x_meters = _data["x_meters"].as<double>();
     y_meters = _data["y_meters"].as<double>();
-    drawing_meters_per_pixel = 0.05;  // something reasonable
+    drawing_meters_per_pixel = coordinate_system.default_scale();
     drawing_width = x_meters / drawing_meters_per_pixel;
     drawing_height = y_meters / drawing_meters_per_pixel;
   }
@@ -75,7 +76,7 @@ bool Level::from_yaml(
   {
     x_meters = 100.0;
     y_meters = 100.0;
-    drawing_meters_per_pixel = 0.05;
+    drawing_meters_per_pixel = coordinate_system.default_scale();
     drawing_width = x_meters / drawing_meters_per_pixel;
     drawing_height = y_meters / drawing_meters_per_pixel;
   }
@@ -1850,7 +1851,7 @@ void Level::mouse_select_press(
   const RenderingOptions& rendering_options,
   const Qt::KeyboardModifiers& modifiers)
 {
-  printf("Level::mouse_select_press()\n");
+  printf("Level::mouse_select_press(%.3f, %.3f)\n", x, y);
 
   if (!(modifiers & Qt::ShiftModifier))
     clear_selection();
@@ -2074,7 +2075,8 @@ void Level::set_selected_line_item(
   const double x2 = line_item->line().x2();
   const double y2 = line_item->line().y2();
 
-
+  double min_edge_dist = 1e9;
+  Edge* min_edge = nullptr;
   // find if any of our lanes match those vertices
   for (auto& edge : edges)
   {
@@ -2093,12 +2095,19 @@ void Level::set_selected_line_item(
     const double v1_dist = std::sqrt(dx1*dx1 + dy1*dy1);
     const double v2_dist = std::sqrt(dx2*dx2 + dy2*dy2);
 
-    const double thresh = 10.0;  // it should be really tiny if it matches
-    if (v1_dist < thresh && v2_dist < thresh)
+    const double max_dist = (v1_dist > v2_dist ? v1_dist : v2_dist);
+    if (max_dist < min_edge_dist)
     {
-      edge.selected = true;
-      return;  // stop after first one is found, don't select multiple
+      min_edge_dist = max_dist;
+      min_edge = &edge;
     }
+  }
+
+  const double thresh = 10.0;  // should be really tiny if it matches
+  if (min_edge_dist < thresh && min_edge != nullptr)
+  {
+    min_edge->selected = true;
+    return;
   }
 
   // see if the constraint index is stored in the QGraphicsItem

--- a/rmf_traffic_editor/gui/level.h
+++ b/rmf_traffic_editor/gui/level.h
@@ -88,7 +88,10 @@ public:
 
   QPixmap floorplan_pixmap;
 
-  bool from_yaml(const std::string& name, const YAML::Node& data);
+  bool from_yaml(
+    const std::string& name,
+    const YAML::Node& data,
+    const CoordinateSystem& coordinate_system);
   YAML::Node to_yaml() const;
 
   const Feature* find_feature(const QUuid& id) const;

--- a/rmf_traffic_editor/gui/vertex.cpp
+++ b/rmf_traffic_editor/gui/vertex.cpp
@@ -149,6 +149,8 @@ void Vertex::draw(
     pixmap_item->setPos(
       x + icon_ring_radius * cos(icon_bearing),
       y - icon_ring_radius * sin(icon_bearing));
+    if (!coordinate_system.is_y_flipped())
+      pixmap_item->setTransform(pixmap_item->transform().scale(1, -1));
     pixmap_item->setToolTip("This vertex is a holding point");
   }
 
@@ -166,6 +168,8 @@ void Vertex::draw(
     pixmap_item->setPos(
       x + icon_ring_radius * cos(icon_bearing),
       y - icon_ring_radius * sin(icon_bearing));
+    if (!coordinate_system.is_y_flipped())
+      pixmap_item->setTransform(pixmap_item->transform().scale(1, -1));
     pixmap_item->setToolTip("This vertex is a parking point");
 
     /*
@@ -206,6 +210,8 @@ void Vertex::draw(
     pixmap_item->setPos(
       x + icon_ring_radius * cos(icon_bearing),
       y - icon_ring_radius * sin(icon_bearing));
+    if (!coordinate_system.is_y_flipped())
+      pixmap_item->setTransform(pixmap_item->transform().scale(1, -1));
     pixmap_item->setToolTip("This vertex is a charger");
   }
 
@@ -237,6 +243,8 @@ void Vertex::draw(
     pixmap_item->setPos(
       x + icon_ring_radius * cos(icon_bearing),
       y - icon_ring_radius * sin(icon_bearing));
+    if (!coordinate_system.is_y_flipped())
+      pixmap_item->setTransform(pixmap_item->transform().scale(1, -1));
     pixmap_item->setToolTip(("Vertex is " + icon_name).c_str());
   }
 


### PR DESCRIPTION
Because Cartesian maps have 1-meter units, we need to compute
a better default scale for them. Previously it was always using
a default scale of 0.05.

Somewhat related, also fix the edge-select implementation so it
spins through all edges in the map rather than just selecting
the first edge within 10 units... that was OK when we were always
using pixel-based maps, but now that meter-based maps are in use,
it was just choosing the first edge that was within 10 meters of
the click, which was a lot of edges and felt somewhat random.