### PR TITLE
First steps towards GeoJSON

### DIFF
--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -523,7 +523,7 @@ class Building:
 
         if 'generate_crs' not in self.params:
             print(f'cannot generate GeoJSON: map does not declare a CRS')
-            return None
+            return {}
 
         source_crs = self.params['generate_crs'].value
         wgs_transformer = Transformer.from_crs(source_crs, 'EPSG:4326')

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -574,7 +574,7 @@ class Building:
 
         j = {
             'site_name': self.name,
-            'coordinate_system': self.params['generate_crs'].value,
+            'preferred_crs': self.params['generate_crs'].value,
             'type': 'FeatureCollection',
             'features': features,
         }

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -1,4 +1,5 @@
 import fiona
+import gzip
 import json
 import math
 import numpy as np
@@ -500,7 +501,7 @@ class Building:
         with GeoPackage(gpkg_filename) as gpkg:
             gpkg.set_metadata(json.dumps(metadata))
 
-    def generate_geojson_file(self, filename):
+    def generate_geojson_file(self, filename, compress=False):
         print(f'generating GeoJSON in {filename}')
 
         if 'generate_crs' not in self.params:
@@ -578,5 +579,12 @@ class Building:
         }
 
         print(f'writing {len(features)} features...')
-        with open(filename, 'w') as f:
-            json.dump(j, f, indent=2, sort_keys=True)
+
+        if compress:
+            data_str = json.dumps(j, indent=2, sort_keys=True)
+            data_gzip = gzip.compress(bytes(data_str, 'utf-8'))
+            with open(filename, 'wb') as f:
+                f.write(data_gzip)
+        else:
+            with open(filename, 'w') as f:
+                json.dump(j, f, indent=2, sort_keys=True)

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -4,7 +4,9 @@ import json
 import math
 import numpy as np
 import os
-import pyproj.crs
+from pyproj import Transformer
+from pyproj.crs import CRS
+#import pyproj.crs
 import sqlite3
 import tempfile
 import yaml
@@ -525,6 +527,7 @@ class Building:
         for level_name, level in self.levels.items():
             level_idx = level_idx_table[level_name]
             for vertex in level.vertices:
+                # todo: project into WGS84
                 vertex_params = {}
                 for param_name, param_value in vertex.params.items():
                     vertex_params[param_name] = param_value.value
@@ -548,6 +551,8 @@ class Building:
                     lane_params[param_name] = param_value.value
                 v1 = level.vertices[lane.start_idx]
                 v2 = level.vertices[lane.end_idx]
+
+                # todo: project into WGS84
 
                 features.append({
                     'type': 'Feature',
@@ -573,7 +578,7 @@ class Building:
 
         j = {
             'site_name': self.name,
-            'coordinate_system': self.coordinate_system.name,
+            'coordinate_system': self.params['generate_crs'].value,
             'type': 'FeatureCollection',
             'features': features,
         }

--- a/rmf_building_map_tools/building_map_converter/building_map_converter.py
+++ b/rmf_building_map_tools/building_map_converter/building_map_converter.py
@@ -9,13 +9,19 @@ from building_map.building import Building
 def main():
     parser = argparse.ArgumentParser(
         prog='building_map_converter',
-        description='Combine .building.yaml files to/from GeoPackage'
+        description='Combine .building.yaml files to/from other formats'
     )
 
     parser.add_argument('INPUT_YAML', type=str,
                         help='building.yaml filename')
-    parser.add_argument('OUTPUT_GPKG', type=str,
-                        help='GeoPackage filename')
+    parser.add_argument('OUTPUT', type=str,
+                        help='output filename')
+    parser.add_argument('-f',
+                        '--format',
+                        type=str,
+                        default='geopackage',
+                        help='format: either geopackage or geojson')
+
 
     args = parser.parse_args()
 
@@ -26,7 +32,13 @@ def main():
         y = yaml.load(f, Loader=yaml.CLoader)
 
     b = Building(y)
-    b.generate_geopackage_file(args.OUTPUT_GPKG)
+
+    if args.format == 'geopackage':
+        b.generate_geopackage_file(args.OUTPUT)
+    elif args.format == 'geojson':
+        b.generate_geojson_file(args.OUTPUT)
+    else:
+        raise ValueError(f'unknown format: {args.format}')
 
 
 if __name__ == '__main__':

--- a/rmf_building_map_tools/building_map_converter/building_map_converter.py
+++ b/rmf_building_map_tools/building_map_converter/building_map_converter.py
@@ -16,12 +16,6 @@ def main():
                         help='building.yaml filename')
     parser.add_argument('OUTPUT', type=str,
                         help='output filename')
-    parser.add_argument('-f',
-                        '--format',
-                        type=str,
-                        default='geopackage',
-                        help='format: either geopackage or geojson')
-
 
     args = parser.parse_args()
 
@@ -33,12 +27,14 @@ def main():
 
     b = Building(y)
 
-    if args.format == 'geopackage':
+    if args.OUTPUT.endswith('.gpkg'):
         b.generate_geopackage_file(args.OUTPUT)
-    elif args.format == 'geojson':
+    elif args.OUTPUT.endswith('.geojson'):
         b.generate_geojson_file(args.OUTPUT)
+    elif args.OUTPUT.endswith('.geojson.gz'):
+        b.generate_geojson_file(args.OUTPUT, True)
     else:
-        raise ValueError(f'unknown format: {args.format}')
+        raise ValueError(f'unknown filename suffix: {args.OUTPUT}')
 
 
 if __name__ == '__main__':

--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -94,7 +94,7 @@ class BuildingMapServer(Node):
         self.site_map_msg = SiteMap()
         uncompressed = building.generate_geojson()
         if 'features' in uncompressed and len(uncompressed['features']):
-            data_str = json.dumps(uncompressed)
+            data_str = json.dumps(uncompressed, sort_keys=True)
             data_gzip = gzip.compress(bytes(data_str, 'utf-8'))
 
             self.get_logger().info(f'compressed GeoJSON: {len(data_gzip)} B')

--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -47,6 +47,10 @@ class BuildingMapServer(Node):
             self.load_building_yaml_map(map_path)
         elif map_path.endswith('.gpkg'):
             self.load_geopackage(map_path)
+        elif map_path.endswith('.geojson'):
+            self.load_geojson(map_path)
+        elif map_path.endswith('.geojson.gz'):
+            self.load_geojson(map_path, True)
         else:
             self.get_logger().fatal('unknown filename suffix')
             sys.exit(1)
@@ -98,6 +102,22 @@ class BuildingMapServer(Node):
 
         self.map_msg = BuildingMap()
         # todo: populate the BuildingMap from the GeoPackage. For now we
+        # will leave it empty...
+
+    def load_geojson(self, map_path, compressed=False):
+        self.site_map_msg = SiteMap()
+        if compressed:
+            self.site_map_msg.encoding = SiteMap.MAP_DATA_GEOJSON_GZ
+        else:
+            self.site_map_msg.encoding = SiteMap.MAP_DATA_GEOJSON
+
+        with open(map_path, 'rb') as f:
+            self.site_map_msg.data = f.read()
+
+        self.get_logger().info(f'read {len(self.site_map_msg.data)} bytes')
+
+        self.map_msg = BuildingMap()
+        # todo: populate the BuildingMap from the GeoJSON. For now we
         # will leave it empty...
 
     def level_msg(self, level):

--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -1,4 +1,6 @@
 import errno
+import gzip
+import json
 import math
 import os
 import sys
@@ -90,8 +92,16 @@ class BuildingMapServer(Node):
             self.map_msg.lifts.append(self.lift_msg(lift_data))
 
         self.site_map_msg = SiteMap()
-        self.site_map_msg.encoding = SiteMap.MAP_DATA_GPKG
-        self.site_map_msg.data = building.generate_geopackage()
+        uncompressed = building.generate_geojson()
+        if 'features' in uncompressed and len(uncompressed['features']):
+            data_str = json.dumps(uncompressed)
+            data_gzip = gzip.compress(bytes(data_str, 'utf-8'))
+
+            self.get_logger().info(f'compressed GeoJSON: {len(data_gzip)} B')
+            self.site_map_msg.encoding = SiteMap.MAP_DATA_GEOJSON_GZ
+            self.site_map_msg.data = data_gzip
+        else:
+            self.get_logger().info(f'unable to generate GeoJSON for this map.')
 
     def load_geopackage(self, map_path):
         with open(map_path, 'rb') as f:


### PR DESCRIPTION
Beginnings of GeoJSON support. This goes all the way back to #6 , almost exactly two years ago! This PR adds the following as a first step towards using GeoJSON more broadly in RMF:
 * `building_map_server` will generate a compressed GeoJSON on-the-fly when starting up with a `.building.yaml` file, serving it on a separate `/site_map` topic, so that we can start to develop tools that use GeoJSON without breaking the existing `/map` topic.
 * `building_map_converter` program uses the same functionality in the `building_map` Python package to convert `.building.yaml` files to either `.geojson` or `.geojson.gz`.
 * This PR only converts the minimum amount of content from `.building.yaml` to `.geojson`: just vertices and lanes. Will add more as the POC develops.

We tried GeoPackage for a few weeks, but found that the SQLite3 format was a bit of a headache to deal with, because it has to be written to a tempfile and then opened from disk, at least if you're using the standard `libsqlite3`. The binary SQLite3 format also means that text diffs are impossible without configuring a custom diff tool (which can be done, but is just "one more thing" to set up). GeoJSON is looking promising at the moment for our needs.