### PR TITLE
Feature: serve BuildingMap message when loading GeoJSON file in building_map_server

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: non-ros-deps
       run: |
         sudo apt-get update
-        sudo apt-get install -y git cmake wget libyaml-cpp-dev qt5-default libceres-dev libeigen3-dev python3-shapely python3-requests python3-yaml python3-pyproj python3-fiona
+        sudo apt-get install -y git cmake wget libyaml-cpp-dev qt5-default libceres-dev libeigen3-dev python3-shapely python3-requests python3-yaml python3-pyproj python3-fiona python3-rtree
 
     - name: build
       shell: bash

--- a/rmf_building_map_tools/building_crowdsim/building_yaml_parse.py
+++ b/rmf_building_map_tools/building_crowdsim/building_yaml_parse.py
@@ -10,7 +10,8 @@ from building_map.level import Level
 
 class LevelWithHumanLanes (Level):
     def __init__(self, yaml_node, name, coordinate_system, graph_idx=9):
-        Level.__init__(self, yaml_node, name, coordinate_system)
+        Level.__init__(self, name)
+        self.parse_yaml(yaml_node, coordinate_system)
 
         # default graph_idx for human_lanes is 9
         self.current_graph_idx = graph_idx

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -19,11 +19,20 @@ from .level import Level
 from .lift import Lift
 from .param_value import ParamValue
 from .passthrough_transform import PassthroughTransform
+from .vertex import Vertex
 from .web_mercator_transform import WebMercatorTransform
 
 
 class Building:
-    def __init__(self, yaml_node):
+    def __init__(self, data, data_format='yaml'):
+        if data_format == 'yaml':
+            self.parse_yaml(data)
+        elif data_format == 'geojson':
+            self.parse_geojson(data)
+        else:
+            raise ValueError(f'unknown data format: {data_format}')
+
+    def parse_yaml(self, yaml_node):
         if 'building_name' in yaml_node:
             self.name = yaml_node['building_name']
         else:
@@ -93,9 +102,9 @@ class Building:
         self.levels = {}
         self.model_counts = {}
         for level_name, level_yaml in yaml_node['levels'].items():
-            self.levels[level_name] = Level(
+            self.levels[level_name] = Level(level_name)
+            self.levels[level_name].parse_yaml(
                 level_yaml,
-                level_name,
                 self.coordinate_system,
                 self.model_counts,
                 self.global_transform)
@@ -125,6 +134,107 @@ class Building:
                          self.coordinate_system)
 
         self.set_lift_vert_lists()
+
+    def parse_geojson(self, json_node):
+        self.levels = {}
+        self.lifts = {}
+
+        if 'site_name' in json_node:
+            self.name = json_node['site_name']
+        else:
+            self.name = 'no_name'
+        print(f'name: {self.name}')
+
+        if 'features' not in json_node:
+            return
+
+        self.coordinate_system = CoordinateSystem.cartesian_meters
+        if 'suggested_offset_x' in json_node:
+            offset_x = json_node['suggested_offset_x']
+        else:
+            offset_x = 0
+
+        if 'suggested_offset_y' in json_node:
+            offset_y = json_node['suggested_offset_y']
+        else:
+            offset_y = 0
+
+        if 'preferred_crs' in json_node:
+            crs_name = json_node['preferred_crs']
+        else:
+            crs_name = ''  # todo: calculate based on UTM grid
+            print('CRS not specified. TODO: infer one.')
+            return
+
+        self.global_transform = \
+            PassthroughTransform(offset_x, offset_y, crs_name)
+
+        # project from WGS 84 to whatever is requested by this file
+        transformer = Transformer.from_crs('EPSG:4326', crs_name)
+
+        # Spin through all items and see how many levels we have.
+        # todo: encode level polygons and names in GeoJSON files.
+        # For now, just compute a bounding box and expand it a bit
+
+        for feature in json_node['features']:
+            if 'feature_type' not in feature:
+                continue
+            if feature['feature_type'] == 'rmf_vertex':
+                self.parse_geojson_vertex(feature, transformer)
+
+        self.transform_all_vertices()
+        for level_name, level in self.levels.items():
+            print(f'level {level_name} has {len(level.vertices)} vertices')
+
+    def parse_geojson_vertex(self, feature, transformer):
+        if 'geometry' not in feature:
+            return
+
+        geometry = feature['geometry']
+        if 'type' not in geometry:
+            return
+        if geometry['type'] != 'Point':
+            return
+        if 'coordinates' not in geometry:
+            return
+        lon = geometry['coordinates'][0]
+        lat = geometry['coordinates'][1]
+        y, x = transformer.transform(lat, lon)
+        x += offset_x
+        y += offset_y
+
+        level_idx = 0
+        vertex_name = ''
+        if 'properties' in feature:
+            props = feature['properties']
+            if 'level_idx' in props:
+                level_idx = props['level_idx']
+            if 'name' in props:
+                vertex_name = props['name']
+
+        # todo: look up the real level name somewhere
+        level_name = f'level_{level_idx}'
+
+        if level_name not in self.levels:
+            self.levels[level_name] = Level(level_name)
+            self.levels[level_name].bbox = [[x, y], [x, y]]
+
+        level = self.levels[level_name]
+
+        level.bbox[0][0] = min(level.bbox[0][0], x)
+        level.bbox[0][1] = min(level.bbox[0][1], y)
+        level.bbox[1][0] = max(level.bbox[1][0], x)
+        level.bbox[1][1] = max(level.bbox[1][1], y)
+
+        # todo: parse params from json properties
+        vertex_params = {}
+
+        level.vertices.append(
+            Vertex(
+                [x, y, 0, vertex_name, vertex_params],
+                self.coordinate_system
+            )
+        )
 
     def __str__(self):
         s = ''
@@ -551,7 +661,7 @@ class Building:
                     properties[param_name] = param_value.value
                 features.append({
                     'type': 'Feature',
-                    'feature_type': 'nav_vertex',
+                    'feature_type': 'rmf_vertex',
                     'geometry': {
                         'type': 'Point',
                         'coordinates': [lon, lat],

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -184,7 +184,9 @@ class Building:
 
         self.transform_all_vertices()
         for level_name, level in self.levels.items():
-            print(f'level {level_name} has {len(level.vertices)} vertices')
+            print(f'level {level_name}:')
+            print(f'  bbox: {level.bbox}')
+            print(f'  {len(level.vertices)} vertices')
 
     def parse_geojson_vertex(self, feature, transformer):
         if 'geometry' not in feature:
@@ -200,8 +202,6 @@ class Building:
         lon = geometry['coordinates'][0]
         lat = geometry['coordinates'][1]
         y, x = transformer.transform(lat, lon)
-        x += offset_x
-        y += offset_y
 
         level_idx = 0
         vertex_name = ''
@@ -216,8 +216,10 @@ class Building:
         level_name = f'level_{level_idx}'
 
         if level_name not in self.levels:
-            self.levels[level_name] = Level(level_name)
-            self.levels[level_name].bbox = [[x, y], [x, y]]
+            level = Level(level_name)
+            level.bbox = [[x, y], [x, y]]
+            level.transform = self.global_transform
+            self.levels[level_name] = level
 
         level = self.levels[level_name]
 
@@ -682,7 +684,7 @@ class Building:
 
                 features.append({
                     'type': 'Feature',
-                    'feature_type': 'nav_lane',
+                    'feature_type': 'rmf_lane',
                     'geometry': {
                         'type': 'LineString',
                         'coordinates': [

--- a/rmf_building_map_tools/building_map/edge.py
+++ b/rmf_building_map_tools/building_map/edge.py
@@ -3,7 +3,12 @@ from .param_value import ParamValue
 
 
 class Edge:
-    def __init__(self, yaml_node):
+    def __init__(self):
+        self.start_idx = None
+        self.end_idx = None
+        self.params = {}
+
+    def parse_yaml(self, yaml_node):
         self.start_idx = int(yaml_node[0])
         self.end_idx = int(yaml_node[1])
         self.params = {}

--- a/rmf_building_map_tools/building_map/edge_type.py
+++ b/rmf_building_map_tools/building_map/edge_type.py
@@ -2,5 +2,5 @@ from enum import Enum
 
 
 class EdgeType(Enum):
-    LANE=1
-    WALL=2
+    LANE = 1
+    WALL = 2

--- a/rmf_building_map_tools/building_map/edge_type.py
+++ b/rmf_building_map_tools/building_map/edge_type.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class EdgeType(Enum):
+    LANE=1
+    WALL=2

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -25,15 +25,30 @@ from .transform import Transform
 
 
 class Level:
-    def __init__(
+    def __init__(self, name):
+        self.name = name
+        self.drawing_name = None
+        self.elevation = 0.0
+        self.fiducials = []
+        self.vertices = []
+        self.transformed_vertices = []  # will be calculated in a later pass
+        self.lift_vert_lists = {}  # will be calculated in a later pass
+        self.meas = []
+        self.lanes = []
+        self.walls = []
+        self.doors = []
+        self.models = []
+        self.floors = []
+        self.holes = []
+        self.transform = Transform()
+
+    def parse_yaml(
         self,
         yaml_node,
-        name,
         coordinate_system,
         model_counts={},
         transform=None
     ):
-        self.name = name
         print(f'parsing level {name}')
 
         self.drawing_name = None

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -6,9 +6,11 @@ import numpy as np
 
 from xml.etree.ElementTree import ElementTree, Element, SubElement
 from .etree_utils import indent_etree
+import rtree
 
 from ament_index_python.packages import get_package_share_directory
 from .edge import Edge
+from .edge_type import EdgeType
 from .fiducial import Fiducial
 from .floor import Floor
 from .wall import Wall
@@ -41,6 +43,7 @@ class Level:
         self.floors = []
         self.holes = []
         self.transform = Transform()
+        self.vertices_index = None
 
     def parse_yaml(
         self,
@@ -177,8 +180,40 @@ class Level:
     def parse_edge_sequence(self, sequence_yaml):
         edges = []
         for edge_yaml in sequence_yaml:
-            edges.append(Edge(edge_yaml))
+            edge = Edge()
+            edge.parse_yaml(edge_yaml)
+            edges.append(edge)
         return edges
+
+    def nearest_vertex_index(self, p):
+        return next(self.vertices_index.nearest((p[0], p[1], p[0], p[1]), 1))
+
+    def build_spatial_index(self):
+        self.vertices_index = rtree.index.Index()
+        for i, v in enumerate(self.vertices):
+            self.vertices_index.insert(i, (v.x, v.y, v.x, v.y))
+
+    def add_edge_from_coords(self, edge_type, p1, p2, props):
+        edge = Edge()
+        edge.start_idx = self.nearest_vertex_index(p1)
+        edge.end_idx = self.nearest_vertex_index(p2)
+
+        if edge_type == EdgeType.LANE:
+            edge.params['graph_idx'] = ParamValue([
+                ParamValue.INT,
+                props.get('graph_idx', 0)
+            ])
+            edge.params['is_bidirectional'] = ParamValue([
+                ParamValue.BOOL,
+                props.get('is_bidirectional', False)
+            ])
+            edge.params['speed_limit'] = ParamValue([
+                ParamValue.DOUBLE,
+                props.get('speed_limit', 0.0)
+            ])
+            self.lanes.append(edge)
+        else:
+            raise ValueError('unknown edge type!')
 
     def generate_walls(self, model_ele, model_name, model_path):
         wall_params_list = []

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -49,7 +49,7 @@ class Level:
         model_counts={},
         transform=None
     ):
-        print(f'parsing level {name}')
+        print(f'parsing level {self.name}')
 
         self.drawing_name = None
         if 'drawing' in yaml_node:

--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -162,7 +162,7 @@ class BuildingMapServer(Node):
             else:
                 self.get_logger().error(f'unable to open image: {image_path}')
 
-        if (len(level.doors)):
+        if len(level.doors):
             for door in level.doors:
                 door_msg = Door()
                 door_msg.name = door.params['name'].value
@@ -194,6 +194,7 @@ class BuildingMapServer(Node):
                 continue  # empty graph :(
             graph_msg = Graph()
             graph_msg.name = str(i)  # todo: someday, string names...
+            print(f"graph {i} has {len(g['vertices'])} vertices")
             for v in g['vertices']:
                 gn = GraphNode()
                 gn.x = v[0]
@@ -223,6 +224,7 @@ class BuildingMapServer(Node):
                         gn.params.append(p)
 
                 graph_msg.vertices.append(gn)
+
             for l in g['lanes']:
                 ge = GraphEdge()
                 ge.v1_idx = l[0]

--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -46,7 +46,7 @@ class BuildingMapServer(Node):
         self.map_dir = os.path.dirname(map_path)  # for calculating image paths
 
         if map_path.endswith('.building.yaml'):
-            self.load_building_yaml_map(map_path)
+            self.load_building_yaml(map_path)
         elif map_path.endswith('.gpkg'):
             self.load_geopackage(map_path)
         elif map_path.endswith('.geojson'):
@@ -80,16 +80,11 @@ class BuildingMapServer(Node):
             'ready to serve map: "{}"  Ctrl+C to exit...'.format(
                 self.map_msg.name))
 
-    def load_building_yaml_map(self, map_path):
+    def load_building_yaml(self, map_path):
         with open(map_path, 'r') as f:
-            building = Building(yaml.load(f, Loader=yaml.CLoader))
+            building = Building(yaml.load(f, Loader=yaml.CLoader), 'yaml')
 
-        self.map_msg = BuildingMap()
-        self.map_msg.name = building.name
-        for _, level_data in building.levels.items():
-            self.map_msg.levels.append(self.level_msg(level_data))
-        for _, lift_data in building.lifts.items():
-            self.map_msg.lifts.append(self.lift_msg(lift_data))
+        self.create_map_msg(building)
 
         self.site_map_msg = SiteMap()
         uncompressed = building.generate_geojson()
@@ -103,6 +98,14 @@ class BuildingMapServer(Node):
         else:
             self.get_logger().info(f'unable to generate GeoJSON for this map.')
 
+    def create_map_msg(self, building):
+        self.map_msg = BuildingMap()
+        self.map_msg.name = building.name
+        for _, level_data in building.levels.items():
+            self.map_msg.levels.append(self.level_msg(level_data))
+        for _, lift_data in building.lifts.items():
+            self.map_msg.lifts.append(self.lift_msg(lift_data))
+
     def load_geopackage(self, map_path):
         with open(map_path, 'rb') as f:
             self.site_map_msg = SiteMap()
@@ -110,25 +113,29 @@ class BuildingMapServer(Node):
             self.site_map_msg.data = f.read()
         self.get_logger().info(f'read {len(self.site_map_msg.data)} byte GPKG')
 
-        self.map_msg = BuildingMap()
         # todo: populate the BuildingMap from the GeoPackage. For now we
         # will leave it empty...
 
     def load_geojson(self, map_path, compressed=False):
         self.site_map_msg = SiteMap()
-        if compressed:
-            self.site_map_msg.encoding = SiteMap.MAP_DATA_GEOJSON_GZ
-        else:
-            self.site_map_msg.encoding = SiteMap.MAP_DATA_GEOJSON
 
         with open(map_path, 'rb') as f:
-            self.site_map_msg.data = f.read()
+            json_bytes = f.read()
 
+        self.site_map_msg.data = json_bytes
         self.get_logger().info(f'read {len(self.site_map_msg.data)} bytes')
 
-        self.map_msg = BuildingMap()
-        # todo: populate the BuildingMap from the GeoJSON. For now we
-        # will leave it empty...
+        if compressed:
+            self.site_map_msg.encoding = SiteMap.MAP_DATA_GEOJSON_GZ
+            json_str = gzip.decompress(json_bytes)
+            self.get_logger().info(f'decompressed to {len(json_str)} bytes')
+            json_node = json.loads(json_str)
+        else:
+            self.site_map_msg.encoding = SiteMap.MAP_DATA_GEOJSON
+            json_node = json.loads(json_bytes.decode('utf-8'))
+
+        building = Building(json_node, 'geojson')
+        self.create_map_msg(building)
 
     def level_msg(self, level):
         msg = Level()

--- a/rmf_building_map_tools/package.xml
+++ b/rmf_building_map_tools/package.xml
@@ -14,6 +14,7 @@
   <exec_depend>python3-fiona</exec_depend>
   <exec_depend>python3-pyproj</exec_depend>
   <exec_depend>python3-requests</exec_depend>
+  <exec_depend>python3-rtree</exec_depend>
   <exec_depend>python3-shapely</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rclpy</exec_depend>

--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -134,7 +134,7 @@ bool Building::load(const string& _filename)
   // now that all images are loaded, we can calculate scale for annotated
   // measurement lanes
   for (auto& level : levels)
-    level.calculate_scale();
+    level.calculate_scale(coordinate_system);
 
   lifts.clear();
   if (y["lifts"] && y["lifts"].IsMap())

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -585,7 +585,7 @@ void Level::get_selected_items(
   }
 }
 
-void Level::calculate_scale()
+void Level::calculate_scale(const CoordinateSystem& coordinate_system)
 {
   // for now, just calculate the mean of the scale estimates
   double scale_sum = 0.0;
@@ -613,7 +613,7 @@ void Level::calculate_scale()
       scale_count, drawing_meters_per_pixel);
   }
   else
-    drawing_meters_per_pixel = 0.05;// default to something reasonable
+    drawing_meters_per_pixel = coordinate_system.default_scale();
 
   if (drawing_width && drawing_height && drawing_meters_per_pixel > 0.0)
   {

--- a/rmf_traffic_editor/gui/level.h
+++ b/rmf_traffic_editor/gui/level.h
@@ -150,7 +150,7 @@ public:
 
   bool can_delete_current_selection();
   bool delete_selected();
-  void calculate_scale();
+  void calculate_scale(const CoordinateSystem& coordinate_system);
   void clear_selection();
 
   void get_selected_items(std::vector<SelectedItem>& selected_items);

--- a/rmf_traffic_editor/gui/level_dialog.cpp
+++ b/rmf_traffic_editor/gui/level_dialog.cpp
@@ -225,7 +225,7 @@ void LevelDialog::ok_button_clicked()
   building_level.flattened_y_offset =
     flattened_y_offset_line_edit->text().toDouble();
 
-  building_level.calculate_scale();
+  building_level.calculate_scale(building.coordinate_system);
   accept();
 }
 


### PR DESCRIPTION
Moving towards parsing and serving GeoJSON maps in `building_map_server` by creating the existing `BuildingMap` messages and serving them on `/map` as well as serving the GeoJSON on `/site_map`

This is slightly tricky because to avoid cross-referencing field ID's everywhere in the GeoJSON, instead we build an RTree of the `Point` features, and then use this to quickly identify the vertices that are the endpoints of each of the lanes, which are defined as `LineString` features.

Also fix a bug where Cartesian maps required a dummy unit-length measurement to render reasonably in Traffic Editor I. Now it sets a scale of `1.0` for Cartesian maps when scaling lane widths in the GUI.

"Nothing should have changed" in the behavior of existing reference-image based maps. Will build and test on the existing `rmf_demos` to be sure.