### PR TITLE
flip layer images right-side up in cartesian meters mode

### DIFF
--- a/rmf_traffic_editor/gui/layer.cpp
+++ b/rmf_traffic_editor/gui/layer.cpp
@@ -143,7 +143,8 @@ YAML::Node Layer::to_yaml() const
 
 void Layer::draw(
   QGraphicsScene* scene,
-  const double level_meters_per_pixel)
+  const double level_meters_per_pixel,
+  const CoordinateSystem& coordinate_system)
 {
   if (!visible)
     return;
@@ -160,6 +161,9 @@ void Layer::draw(
   item->setScale(transform.scale() / level_meters_per_pixel);
 
   item->setRotation(-1.0 * transform.yaw() * 180.0 / M_PI);
+
+  if (!coordinate_system.is_y_flipped())
+    item->setTransform(item->transform().scale(1, -1));
 
   double origin_radius = 0.5 / level_meters_per_pixel;
   QPen origin_pen(color, origin_radius / 4.0, Qt::SolidLine, Qt::RoundCap);

--- a/rmf_traffic_editor/gui/layer.h
+++ b/rmf_traffic_editor/gui/layer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Open Source Robotics Foundation
+ * Copyright (C) 2019-2021 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
 #include <QPixmap>
 #include <yaml-cpp/yaml.h>
 
+#include "coordinate_system.h"
 #include "feature.hpp"
 #include "transform.hpp"
 
@@ -65,7 +66,8 @@ public:
 
   void draw(
     QGraphicsScene* scene,
-    const double level_meters_per_pixel);
+    const double level_meters_per_pixel,
+    const CoordinateSystem& coordinate_system);
 
   QColor color;
 

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -1126,7 +1126,7 @@ void Level::draw(
   draw_polygons(scene);
 
   for (auto& layer : layers)
-    layer.draw(scene, drawing_meters_per_pixel);
+    layer.draw(scene, drawing_meters_per_pixel, coordinate_system);
 
   if (rendering_options.show_models)
   {


### PR DESCRIPTION
Previously, when editing maps with `cartesian_meters` coordinate system, layer images would render upside-down. This PR fixes that. No change to maps with `reference_image` coordinate system. Tested on all demo maps (which are all `reference_image` based) and they all render as expected.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>