### PR TITLE
Handle simulation offsets for models and cameras

### DIFF
--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -454,7 +454,8 @@ class Building:
 
         gui_ele = world.find('gui')
         c = self.center()
-        camera_pose = f'{c[0]} {c[1]-20} 10 0 0.6 1.57'
+        # Transforming camera to account for offsets
+        camera_pose = f'{c[0] - self.global_transform.x} {c[1]-20 - self.global_transform.y} 10 0 0.6 1.57'
         # add floor-toggle GUI plugin parameters
         if 'gazebo' in options:
             camera_pose_ele = gui_ele.find('camera').find('pose')

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -455,7 +455,8 @@ class Building:
         gui_ele = world.find('gui')
         c = self.center()
         # Transforming camera to account for offsets
-        camera_pose = f'{c[0] - self.global_transform.x} {c[1]-20 - self.global_transform.y} 10 0 0.6 1.57'
+        camera_pose = f'{c[0] - self.global_transform.x}  \
+        {c[1]-20 - self.global_transform.y} 10 0 0.6 1.57'
         # add floor-toggle GUI plugin parameters
         if 'gazebo' in options:
             camera_pose_ele = gui_ele.find('camera').find('pose')

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -454,9 +454,13 @@ class Building:
 
         gui_ele = world.find('gui')
         c = self.center()
-        # Transforming camera to account for offsets
-        camera_pose = f'{c[0] - self.global_transform.x}  \
-        {c[1]-20 - self.global_transform.y} 10 0 0.6 1.57'
+        # Transforming camera to account for offsets if
+        # not in reference_image mode
+        if self.global_transform:
+            camera_pose = f'{c[0] - self.global_transform.x}  \
+            {c[1]-20 - self.global_transform.y} 10 0 0.6 1.57'
+        else:
+            camera_pose = f'{c[0]} {c[1]-20} 10 0 0.6 1.57'
         # add floor-toggle GUI plugin parameters
         if 'gazebo' in options:
             camera_pose_ele = gui_ele.find('camera').find('pose')

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -107,15 +107,14 @@ class Level:
                 if name not in model_counts:
                     model_counts[name] = 1
                     self.models.append(
-                        Model(name, model_yaml,
-                              coordinate_system, self.transform))
+                        Model(name, model_yaml, coordinate_system))
                 else:
                     model_counts[name] += 1
                     self.models.append(
                         Model(
                             f'{name}_{model_counts[name]}',
                             model_yaml,
-                            coordinate_system, self.transform))
+                            coordinate_system))
 
         self.floors = []
         if 'floors' in yaml_node:
@@ -245,7 +244,8 @@ class Level:
         for model in self.models:
             model.generate(
                 world_ele,
-                self.elevation)
+                self.elevation,
+                self.transform)
 
         # sniff around in our vertices and spawn robots if requested
         for vertex_idx, vertex in enumerate(self.vertices):

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -107,14 +107,15 @@ class Level:
                 if name not in model_counts:
                     model_counts[name] = 1
                     self.models.append(
-                        Model(name, model_yaml, coordinate_system))
+                        Model(name, model_yaml,
+                              coordinate_system, self.transform))
                 else:
                     model_counts[name] += 1
                     self.models.append(
                         Model(
                             f'{name}_{model_counts[name]}',
                             model_yaml,
-                            coordinate_system))
+                            coordinate_system, self.transform))
 
         self.floors = []
         if 'floors' in yaml_node:
@@ -244,7 +245,6 @@ class Level:
         for model in self.models:
             model.generate(
                 world_ele,
-                self.transform,
                 self.elevation)
 
         # sniff around in our vertices and spawn robots if requested

--- a/rmf_building_map_tools/building_map/model.py
+++ b/rmf_building_map_tools/building_map/model.py
@@ -5,8 +5,8 @@ class Model:
     def __init__(self, name, yaml_node, coordinate_system):
         self.name = name
         self.model_name = yaml_node['model_name']
-        self.lat = yaml_node['lat']
-        self.lon = yaml_node['lon'] * coordinate_system.y_flip_scalar()
+        self.x = yaml_node['x']
+        self.y = yaml_node['y'] * coordinate_system.y_flip_scalar()
         self.z = 0.0
         if 'z' in yaml_node:
             self.z = yaml_node['z']
@@ -32,8 +32,8 @@ class Model:
 
     def to_yaml(self, coordinate_system):
         y = {}
-        y['lat'] = self.lat
-        y['lon'] = self.lon * coordinate_system.y_flip_scalar()
+        y['x'] = self.x
+        y['y'] = self.y * coordinate_system.y_flip_scalar()
         y['z'] = self.z
         y['model_name'] = self.model_name
         y['name'] = self.name
@@ -48,7 +48,7 @@ class Model:
         uri_ele = SubElement(include_ele, 'uri')
         uri_ele.text = f'model://{self.model_name}'
         pose_ele = SubElement(include_ele, 'pose')
-        x, y = transform.transform_point((self.lat, self.lon))
+        x, y = transform.transform_point((self.x, self.y))
         model_x = x - transform.x
         model_y = y - transform.y
 

--- a/rmf_building_map_tools/building_map/model.py
+++ b/rmf_building_map_tools/building_map/model.py
@@ -6,9 +6,12 @@ class Model:
         self.name = name
         self.model_name = yaml_node['model_name']
         self.x, self.y = transform.transform_point(
-            (yaml_node['x'] - transform.x,
-             yaml_node['y'] * coordinate_system.y_flip_scalar() - transform.y)
+            (yaml_node['x'],
+             yaml_node['y'] * coordinate_system.y_flip_scalar())
         )
+        self.x = self.x - transform.x
+        self.y = self.y - transform.y
+
         self.z = 0.0
         if 'z' in yaml_node:
             self.z = yaml_node['z']

--- a/rmf_building_map_tools/building_map/model.py
+++ b/rmf_building_map_tools/building_map/model.py
@@ -5,8 +5,8 @@ class Model:
     def __init__(self, name, yaml_node, coordinate_system):
         self.name = name
         self.model_name = yaml_node['model_name']
-        self.x = yaml_node['x']
-        self.y = yaml_node['y'] * coordinate_system.y_flip_scalar()
+        self.lat = yaml_node['lat']
+        self.lon = yaml_node['lon'] * coordinate_system.y_flip_scalar()
         self.z = 0.0
         if 'z' in yaml_node:
             self.z = yaml_node['z']
@@ -32,8 +32,8 @@ class Model:
 
     def to_yaml(self, coordinate_system):
         y = {}
-        y['x'] = self.x
-        y['y'] = self.y * coordinate_system.y_flip_scalar()
+        y['lat'] = self.lat
+        y['lon'] = self.lon * coordinate_system.y_flip_scalar()
         y['z'] = self.z
         y['model_name'] = self.model_name
         y['name'] = self.name
@@ -48,10 +48,13 @@ class Model:
         uri_ele = SubElement(include_ele, 'uri')
         uri_ele.text = f'model://{self.model_name}'
         pose_ele = SubElement(include_ele, 'pose')
-        x, y = transform.transform_point((self.x, self.y))
+        x, y = transform.transform_point((self.lat, self.lon))
+        model_x = x - transform.x
+        model_y = y - transform.y
+
         z = self.z + elevation
-        yaw = self.yaw + transform.rotation
-        pose_ele.text = f'{x} {y} {z} 0 0 {yaw}'
+        yaw = self.yaw
+        pose_ele.text = f'{model_x} {model_y} {z} 0 0 {yaw}'
 
         static_ele = SubElement(include_ele, 'static')
         static_ele.text = str(self.static)

--- a/rmf_building_map_tools/building_map/passthrough_transform.py
+++ b/rmf_building_map_tools/building_map/passthrough_transform.py
@@ -4,6 +4,7 @@ class PassthroughTransform:
     def __init__(self, x, y, frame_name):
         self.x = x
         self.y = y
+        self.rotation = 0
         self.frame_name = frame_name
 
     def transform_point(self, p):

--- a/rmf_building_map_tools/building_map/wgs84_transform.py
+++ b/rmf_building_map_tools/building_map/wgs84_transform.py
@@ -11,6 +11,7 @@ class WGS84Transform:
         self.crs_name = crs_name
         self.x = offset[0]
         self.y = offset[1]
+        self.rotation = 0
         self.wgs84_to_tm = \
             Transformer.from_crs("EPSG:4326", self.crs_name)
 

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -570,10 +570,10 @@ bool Editor::load_building(const QString& filename)
   {
     // use the EPSG 3857 extents: "projected-meters"
     scene->setSceneRect(QRectF(
-        -M_PI * CoordinateSystem::WGS84_A * map_view->PRESCALAR,
-        M_PI * CoordinateSystem::WGS84_A * map_view->PRESCALAR,
-        2. * M_PI * CoordinateSystem::WGS84_A * map_view->PRESCALAR,
-        -2. * M_PI * CoordinateSystem::WGS84_A * map_view->PRESCALAR));
+        -M_PI * CoordinateSystem::WGS84_A,
+        M_PI * CoordinateSystem::WGS84_A,
+        2. * M_PI * CoordinateSystem::WGS84_A,
+        -2. * M_PI * CoordinateSystem::WGS84_A));
   }
   else if (!building.levels.empty())
   {

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -652,7 +652,7 @@ void Editor::restore_previous_viewport()
   // This is a really big deal if we're mixing coordinate systems :boom:
   const std::string previous_filename =
     settings.value(preferences_keys::previous_building_path)
-      .toString().toStdString();
+    .toString().toStdString();
 
   printf("previous filename: %s\n", previous_filename.c_str());
   printf("current building filename: %s\n", building.get_filename().c_str());

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -209,8 +209,8 @@ Editor::Editor()
   right_tab_widget->addTab(level_table, "levels");
   right_tab_widget->addTab(layer_table, "layers");
   right_tab_widget->addTab(lift_table, "lifts");
-  right_tab_widget->addTab(traffic_table, "traffic");
-  right_tab_widget->addTab(crowd_sim_table, "crowd_sim");
+  right_tab_widget->addTab(traffic_table, "graphs");
+  right_tab_widget->addTab(crowd_sim_table, "crowds");
 
   property_editor = new QTableWidget;
   property_editor->setStyleSheet(
@@ -269,7 +269,7 @@ Editor::Editor()
   w->setMouseTracking(true);
   setMouseTracking(true);
   w->setLayout(hbox_layout);
-  w->setStyleSheet("background-color: #404040");
+  w->setStyleSheet("background-color: #707070");
   setCentralWidget(w);
 
   // BUILDING MENU
@@ -570,10 +570,10 @@ bool Editor::load_building(const QString& filename)
   {
     // use the EPSG 3857 extents: "projected-meters"
     scene->setSceneRect(QRectF(
-        -M_PI * CoordinateSystem::WGS84_A,
-        M_PI * CoordinateSystem::WGS84_A,
-        2. * M_PI * CoordinateSystem::WGS84_A,
-        -2. * M_PI * CoordinateSystem::WGS84_A));
+        -M_PI * CoordinateSystem::WGS84_A * map_view->PRESCALAR,
+        M_PI * CoordinateSystem::WGS84_A * map_view->PRESCALAR,
+        2. * M_PI * CoordinateSystem::WGS84_A * map_view->PRESCALAR,
+        -2. * M_PI * CoordinateSystem::WGS84_A * map_view->PRESCALAR));
   }
   else if (!building.levels.empty())
   {

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -137,7 +137,7 @@ bool Level::from_yaml(
     for (YAML::const_iterator it = ys.begin(); it != ys.end(); ++it)
     {
       Model m;
-      m.from_yaml(*it, this->name);
+      m.from_yaml(*it, this->name, coordinate_system);
       models.push_back(m);
     }
   }
@@ -267,7 +267,7 @@ YAML::Node Level::to_yaml(const CoordinateSystem& coordinate_system) const
   }
 
   for (const auto& model : models)
-    y["models"].push_back(model.to_yaml());
+    y["models"].push_back(model.to_yaml(coordinate_system));
 
   for (const auto& polygon : polygons)
   {

--- a/rmf_traffic_editor/gui/main.cpp
+++ b/rmf_traffic_editor/gui/main.cpp
@@ -54,6 +54,8 @@ int main(int argc, char* argv[])
 
   editor.show();
 
+  // Current understanding is that the viewport needs to be restored
+  // after the editor.show() is called
   editor.restore_previous_viewport();
 
   return app.exec();

--- a/rmf_traffic_editor/gui/map_tile_cache.cpp
+++ b/rmf_traffic_editor/gui/map_tile_cache.cpp
@@ -51,10 +51,10 @@ std::optional<const QByteArray> MapTileCache::get(
   QFile file(path);
   if (!file.open(QIODevice::ReadOnly))
   {
-    printf("cache miss: %d %d %d\n", zoom, x, y);
+    // printf("cache miss: %d %d %d\n", zoom, x, y);
     return {};
   }
-  printf("cache hit: %s\n", path.toStdString().c_str());
+  // printf("cache hit: %s\n", path.toStdString().c_str());
   return {file.readAll()};
 }
 

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -207,13 +207,13 @@ void MapView::draw_tiles()
     log(M_PI * CoordinateSystem::WGS84_A / x_meters_per_tile) / log(2);
   // printf("  zoom_exact: %.3f\n", zoom_exact);
 
-  int zoom_approx = static_cast<int>(ceil(zoom_exact));
+  int zoom = static_cast<int>(ceil(zoom_exact));
   const int MAX_ZOOM = 20;
-  if (zoom_approx < 0)
-    zoom_approx = 0;
-  if (zoom_approx > MAX_ZOOM)
-    zoom_approx = MAX_ZOOM;
-  // printf("  zoom_approx = %d\n", zoom_approx);
+  if (zoom < 0)
+    zoom = 0;
+  if (zoom > MAX_ZOOM)
+    zoom = MAX_ZOOM;
+  // printf("  zoom = %d\n", zoom);
 
   const double eps = 0.0001;
   const double MAX_X = M_PI * CoordinateSystem::WGS84_A;
@@ -222,9 +222,9 @@ void MapView::draw_tiles()
   // printf("  clamped x range: (%.3f, %.3f)\n", ulx_clamped, lrx_clamped);
 
   const int x_min_tile =
-    floor((ulx_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom_approx));
+    floor((ulx_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom));
   const int x_max_tile =
-    floor((lrx_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom_approx));
+    floor((lrx_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom));
   // printf("  x tile range: [%d, %d]\n", x_min_tile, x_max_tile);
 
   // because EPSG 3857 is a square, we can use MAX_X for the Y extents also
@@ -233,20 +233,20 @@ void MapView::draw_tiles()
   // printf("  clamped y range: (%.3f, %.3f)\n", lry_clamped, uly_clamped);
 
   const int y_min_tile =
-    (1 << zoom_approx)
+    (1 << zoom)
     - 1
-    - floor((uly_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom_approx));
+    - floor((uly_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom));
   const int y_max_tile =
-    (1 << zoom_approx)
+    (1 << zoom)
     - 1
-    - floor((lry_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom_approx));
+    - floor((lry_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom));
   // printf("  y tile range: [%d, %d]\n", y_min_tile, y_max_tile);
 
   std::vector<size_t> remove_idx;
   for (size_t i = 0; i < tile_pixmap_items.size(); i++)
   {
     const MapTilePixmapItem& item = tile_pixmap_items[i];
-    if (item.zoom != zoom_approx
+    if (item.zoom != zoom
       || item.x < x_min_tile
       || item.x > x_max_tile
       || item.y < y_min_tile
@@ -295,8 +295,8 @@ void MapView::draw_tiles()
       if (found)
         continue;
 
-      // printf("creating tile item zoom=%d, x=%d, y=%d)\n", zoom_approx, x, y);
-      std::optional<const QByteArray> p = tile_cache.get(zoom_approx, x, y);
+      // printf("creating tile item zoom=%d, x=%d, y=%d)\n", zoom, x, y);
+      std::optional<const QByteArray> p = tile_cache.get(zoom, x, y);
       if (p.has_value())
       {
         //printf("  HOORAY found the pixmap\n");
@@ -306,8 +306,8 @@ void MapView::draw_tiles()
         {
           QPixmap pixmap(QPixmap::fromImage(image.convertToFormat(
               QImage::Format_Grayscale8)));
-          // QPixmap pixmap(QPixmap::fromImage(image));
-          render_tile(zoom_approx, x, y, pixmap, MapTilePixmapItem::State::COMPLETED);
+
+          render_tile(zoom, x, y, pixmap, MapTilePixmapItem::State::COMPLETED);
         }
         else
         {
@@ -324,12 +324,12 @@ void MapView::draw_tiles()
         painter.begin(&image);
         painter.setPen(QPen(Qt::red));
         QString label;
-        label.sprintf("%d (%d,%d)", zoom_approx, x, y);
+        label.sprintf("%d (%d,%d)", zoom, x, y);
         painter.drawText(10, 10, 245, 100, Qt::AlignLeft, label);
         painter.end();
         QPixmap pixmap(QPixmap::fromImage(image));
 
-        render_tile(zoom_approx, x, y, pixmap, MapTilePixmapItem::State::QUEUED);
+        render_tile(zoom, x, y, pixmap, MapTilePixmapItem::State::QUEUED);
       }
     }
   }

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -325,7 +325,10 @@ void MapView::request_tile(const int zoom, const int x, const int y)
       zoom,
       x,
       y);
-    network->get(QNetworkRequest(QUrl(request_url)));
+    QNetworkRequest request;
+    request.setUrl(QUrl(request_url));
+    request.setRawHeader("User-Agent", "TrafficEditor/1.4 (http://open-rmf.org)");
+    network->get(request);
   }
 
   // create a dummy image for debugging

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -327,7 +327,9 @@ void MapView::request_tile(const int zoom, const int x, const int y)
       y);
     QNetworkRequest request;
     request.setUrl(QUrl(request_url));
-    request.setRawHeader("User-Agent", "TrafficEditor/1.4 (http://open-rmf.org)");
+    request.setRawHeader(
+      "User-Agent",
+      "TrafficEditor/1.4 (http://open-rmf.org)");
     network->get(request);
   }
 

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -39,21 +39,12 @@ MapView::MapView(QWidget* parent, const Building& building_)
   setMouseTracking(true);
   viewport()->setMouseTracking(true);
   setTransformationAnchor(QGraphicsView::NoAnchor);
-  //setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
-  //setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-  //setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
   setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
-  //horizontalScrollBar()->setDisabled(true);
-  //verticalScrollBar()->setDisabled(true);
-  //horizontalScrollBar()->setValue(0);
-  //verticalScrollBar()->setValue(0);
 }
 
 void MapView::wheelEvent(QWheelEvent* e)
 {
-  //setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
-
   // calculate the map position before we scale things
   const QPointF p_start = mapToScene(e->pos());
 
@@ -74,59 +65,27 @@ void MapView::wheelEvent(QWheelEvent* e)
   }
   else
   {
-    //setTransformationAnchor(QGraphicsView::AnchorViewCenter);
-    //const double dx = transform().dx();
-    //const double dy = transform().dy();
-    //const double scale_pow2 = pow(2, round(log(scale_factor)/log(2)));
-    //resetTransform();
-    //scale(scale_pow2, scale_pow2);
-    //translate(dx, dy);
-
     // in the global frame when we're rendering map tiles,
     // we want to keep to an even scaling of the tile
     // so it doesn't have too many aliasing effects
-    //QTransform t = transform();
     if (e->delta() > 0)
     {
       //double max_scale_factor = 100;
       // go to the nearest power of 2 above where we are
       // const double next_scale = pow(2, round(log(scale_factor*2)/log(2)));
       scale(2.0, 2.0);
-      //t.scale(2.0, 2.0);
     }
     else
     {
-      // double min_scale_factor = 0.01;
-
       // go to the nearest power of 2 below where we are
       // const double next_scale = pow(2, round(log(scale_factor/2)/log(2)));
 
       // limit to 2^-17 = 0.0000076294
 
-      /*
-      printf("before scale():\n  %12.3f %12.3f %12.3f\n  %12.3f %12.3f %12.3f\n  %12.3f %12.3f %12.3f\n",
-        transform().m11(), transform().m21(), transform().m31(),
-        transform().m12(), transform().m22(), transform().m32(),
-        transform().m13(), transform().m23(), transform().m33());
-      */
       if (scale_factor > 0.0000076294)
-      //if (scale_factor > 0.0000001)
         scale(0.5, 0.5);
-        //t.scale(0.5, 0.5);
-      /*
-      printf("after scale():\n  %12.3f %12.3f %12.3f\n  %12.3f %12.3f %12.3f\n  %12.3f %12.3f %12.3f\n",
-        transform().m11(), transform().m21(), transform().m31(),
-        transform().m12(), transform().m22(), transform().m32(),
-        transform().m13(), transform().m23(), transform().m33());
-      */
     }
-    //horizontalScrollBar()->setValue(0);
-    //verticalScrollBar()->setValue(0);
-    //setTransform(t);
   }
-
-  //const double nearest_nice_scale_factor = pow(2.0, round(log(scale_factor)/log(2.0)));
-  //printf("nearest nice scale factor: %.3f\n", nearest_nice_scale_factor);
 
   // calculate the mouse map position now that we've scaled
   const QPointF p_end = mapToScene(e->pos());
@@ -137,61 +96,25 @@ void MapView::wheelEvent(QWheelEvent* e)
 
   const int viewport_w = viewport()->width();
   const int viewport_h = viewport()->height();
-  QPointF c = mapToScene(QPoint(viewport_w/2, viewport_h/2));
-  printf("  viewport center: (%.3f, %.3f)\n", c.x(), c.y());
-  QPointF ul = mapToScene(QPoint(0, 0)) / PRESCALAR;
-  QPointF lr = mapToScene(QPoint(viewport_w, viewport_h)) / PRESCALAR;
+  QPointF ul = mapToScene(QPoint(0, 0));
+  QPointF lr = mapToScene(QPoint(viewport_w, viewport_h));
   const double scene_w = lr.x() - ul.x();
   const double scene_h = ul.y() - lr.y();
-  printf("  viewport w, h: (%.3f, %.3f)\n", scene_w, scene_h);
 
-  printf("  horizontal scroll position: %d\n", horizontalScrollBar()->value());
-  printf("  vertical scroll position: %d\n", verticalScrollBar()->value());
-  printf("  horizontal range: %d - %d   step: %d\n",
-    horizontalScrollBar()->minimum(),
-    horizontalScrollBar()->maximum(),
-    horizontalScrollBar()->pageStep());
-  printf("  vertical range: %d - %d\n",
-    verticalScrollBar()->minimum(),
-    verticalScrollBar()->maximum());
-
-  printf("scale: %.8f   translation: (%.3f, %.3f)    (%.3f, %.3f) -> (%.3f, %.3f)\n",
-    transform().m11(),
-    transform().dx(),
-    transform().dy(),
-    p_start.x(), p_start.y(),
-    p_end.x(), p_end.y());
-
-  //printf("  translate after zoom: (%.3f, %.3f)\n", diff.x(), diff.y());
-  //centerOn(p_start);
-  //setSceneRect(QRectF(ul, lr));
-  if (scene_w < 0.1 * M_PI * CoordinateSystem::WGS84_A * PRESCALAR)
+  if (scene_w < 0.1 * M_PI * CoordinateSystem::WGS84_A)
   {
-    printf("setting scene rect...\n");
-    //setSceneRect(QRectF(c.x() - scene_w, c.y() + scene_w, 2 * scene_w, -2 * scene_h));
-    //horizontalScrollBar()->setValue(0);
-    //verticalScrollBar()->setValue(0);
-
-    //setSceneRect(QRectF(c.x() - 2 * scene_w, c.y() + 2 * scene_w, 4 * scene_w, -4 * scene_h));
-
-    /*
-    horizontalScrollBar()->setValue(
-      (horizontalScrollBar()->minimum() + horizontalScrollBar()->maximum()) / 2);
-    verticalScrollBar()->setValue(
-      (verticalScrollBar()->minimum() + verticalScrollBar()->maximum()) / 2);
-    */
-
     const int n = 10;
-    setSceneRect(QRectF(p_start.x() - n * scene_w, p_start.y() + n * scene_w, 2 * n * scene_w, -2 * n * scene_h));
-    /*
-    verticalScrollBar()->setValue(0);
-    horizontalScrollBar()->setValue(0);
-    verticalScrollBar()->setValue(0);
-    */
+    setSceneRect(
+      QRectF(
+        p_start.x() - n * scene_w,
+        p_start.y() + n * scene_w,
+        2 * n * scene_w,
+        -2 * n * scene_h));
   }
   else
   {
-    setSceneRect(QRectF());  // sets a null rect, so it will use scene rect from the scene
+    // set a null rect, in order to the original scene rect from the scene
+    setSceneRect(QRectF());  
   }
   draw_tiles();
   e->accept();
@@ -285,8 +208,8 @@ void MapView::draw_tiles()
     return;
   const int viewport_w = viewport()->width();
   const int viewport_h = viewport()->height();
-  QPointF ul = mapToScene(QPoint(0, 0)) / PRESCALAR;
-  QPointF lr = mapToScene(QPoint(viewport_w, viewport_h)) / PRESCALAR;
+  QPointF ul = mapToScene(QPoint(0, 0));
+  QPointF lr = mapToScene(QPoint(viewport_w, viewport_h));
   last_center = mapToScene(QPoint(viewport_w/2, viewport_h/2));
   //printf("viewport center: (%.3f, %.3f)\n", last_center.x(), last_center.y());
   // printf("  ul: (%.3f, %.3f)\n", ul.x(), ul.y());
@@ -476,7 +399,7 @@ void MapView::render_tile(
   const double MAX_X = M_PI * CoordinateSystem::WGS84_A;
   // printf("  adding tile: zoom=%d, (%d, %d)\n", zoom, x, y);
   QGraphicsPixmapItem* pixmap_item = scene()->addPixmap(pixmap);
-  pixmap_item->setScale(2. * MAX_X / 256.0 / (1 << zoom) * PRESCALAR);
+  pixmap_item->setScale(2. * MAX_X / 256.0 / (1 << zoom));
   pixmap_item->setZValue(-10.0);
   //pixmap_item->setScale(360. / 256.0 / (1 << zoom));
 
@@ -484,9 +407,9 @@ void MapView::render_tile(
   // const double lon_deg = x / static_cast<double>(1 << zoom) * 360. - 180.;
   // const double n = M_PI - 2.0 * M_PI * y / static_cast<double>(1 << zoom);
   // const double lat = atan(0.5 * (exp(n) - exp(-n)));
-  const double x = (tile_x / static_cast<double>(1 << zoom) * 2. * MAX_X - MAX_X) * PRESCALAR;
+  const double x = (tile_x / static_cast<double>(1 << zoom) * 2. * MAX_X - MAX_X);
   const double y =
-    (-tile_y / static_cast<double>(1 << zoom) * 2. * MAX_X + MAX_X) * PRESCALAR;
+    (-tile_y / static_cast<double>(1 << zoom) * 2. * MAX_X + MAX_X);
 
   // project the latitude to "web mercator" latitude
   //const double lat_deg_mercator = 180. / M_PI * log(tan(lat) + 1. / cos(lat));

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -114,7 +114,7 @@ void MapView::wheelEvent(QWheelEvent* e)
   else
   {
     // set a null rect, in order to the original scene rect from the scene
-    setSceneRect(QRectF());  
+    setSceneRect(QRectF());
   }
   draw_tiles();
   e->accept();
@@ -147,35 +147,16 @@ void MapView::mouseReleaseEvent(QMouseEvent* e)
 
 void MapView::mouseMoveEvent(QMouseEvent* e)
 {
-  //setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
   if (is_panning)
   {
     const int dx = e->x() - pan_start_x;
     const int dy = e->y() - pan_start_y;
     const double s = transform().m11();
-    /*
-    QTransform t = transform();
-    t.translate(dx / s, -dy / s);
-    setTransform(t);
-    */
-    //horizontalScrollBar()->setValue(horizontalScrollBar()->value() - dx);
-    //verticalScrollBar()->setValue(verticalScrollBar()->value() - dy);
     translate(dx / s, -dy / s);
     pan_start_x = e->x();
     pan_start_y = e->y();
     e->accept();
     draw_tiles();
-
-    printf("  horizontal scroll position: %d\n", horizontalScrollBar()->value());
-    printf("  vertical scroll position: %d\n", verticalScrollBar()->value());
-    printf("  horizontal range: %d - %d   step: %d\n", horizontalScrollBar()->minimum(), horizontalScrollBar()->maximum(), horizontalScrollBar()->pageStep());
-    printf("  vertical range: %d - %d\n", verticalScrollBar()->minimum(), verticalScrollBar()->maximum());
-  
-    printf("scale: %.3f   translation: (%.3f, %.3f)\n",
-      transform().m11(),
-      transform().dx(),
-      transform().dy());
-
     return;
   }
   e->ignore();
@@ -407,7 +388,9 @@ void MapView::render_tile(
   // const double lon_deg = x / static_cast<double>(1 << zoom) * 360. - 180.;
   // const double n = M_PI - 2.0 * M_PI * y / static_cast<double>(1 << zoom);
   // const double lat = atan(0.5 * (exp(n) - exp(-n)));
-  const double x = (tile_x / static_cast<double>(1 << zoom) * 2. * MAX_X - MAX_X);
+  const double x =
+    (tile_x / static_cast<double>(1 << zoom) * 2. * MAX_X - MAX_X);
+
   const double y =
     (-tile_y / static_cast<double>(1 << zoom) * 2. * MAX_X + MAX_X);
 

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -47,6 +47,12 @@ public:
   void update_cache_size_label(QLabel* label);
   QPointF get_center() { return last_center; }
 
+  // We have to scale down from EPSG 3857 meters, otherwise
+  // we blow past +/- MAX_INT on the Qt scrollbars when zooming in
+  // to very high levels (for reasons I can't fully explain),
+  // which resets them to midpoint, in a weird/unrecoverable state.
+  const double PRESCALAR = 1; //1000.0; //0.001;
+
 protected:
   void wheelEvent(QWheelEvent* event);
   void mouseMoveEvent(QMouseEvent* e);

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -70,6 +70,13 @@ private:
     int x = 0;
     int y = 0;
     QGraphicsPixmapItem* item = nullptr;
+
+    enum State
+    {
+      QUEUED,
+      REQUESTED,
+      COMPLETED
+    } state;
   };
   std::vector<MapTilePixmapItem> tile_pixmap_items;
 
@@ -90,10 +97,13 @@ private:
     const int zoom,
     const int x,
     const int y,
-    const QPixmap& pixmap);
+    const QPixmap& pixmap,
+    const MapTilePixmapItem::State state);
 
   void request_finished(QNetworkReply* reply);
   QPointF last_center;
+
+  void process_request_queue();
 };
 
 #endif

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -47,12 +47,6 @@ public:
   void update_cache_size_label(QLabel* label);
   QPointF get_center() { return last_center; }
 
-  // We have to scale down from EPSG 3857 meters, otherwise
-  // we blow past +/- MAX_INT on the Qt scrollbars when zooming in
-  // to very high levels (for reasons I can't fully explain),
-  // which resets them to midpoint, in a weird/unrecoverable state.
-  const double PRESCALAR = 1; //1000.0; //0.001;
-
 protected:
   void wheelEvent(QWheelEvent* event);
   void mouseMoveEvent(QMouseEvent* e);

--- a/rmf_traffic_editor/gui/model.cpp
+++ b/rmf_traffic_editor/gui/model.cpp
@@ -91,9 +91,6 @@ void Model::from_yaml(
 
 YAML::Node Model::to_yaml(const CoordinateSystem& coordinate_system) const
 {
-  // This is in image space. I think it's safe to say nobody is clicking
-  // with more than 1/1000 precision inside a single pixel.
-
   YAML::Node n;
   n.SetStyle(YAML::EmitterStyle::Flow);
 

--- a/rmf_traffic_editor/gui/model.cpp
+++ b/rmf_traffic_editor/gui/model.cpp
@@ -40,12 +40,31 @@ Model::Model()
   uuid = QUuid::createUuid();
 }
 
-void Model::from_yaml(const YAML::Node& data, const string& level_name)
+void Model::from_yaml(
+  const YAML::Node& data,
+  const string& level_name,
+  const CoordinateSystem& coordinate_system)
 {
   if (!data.IsMap())
     throw std::runtime_error("Model::from_yaml() expected a map");
-  state.x = data["x"].as<double>();
-  state.y = data["y"].as<double>();
+
+  if (!coordinate_system.is_global())
+  {
+    state.x = data["x"].as<double>();
+    state.y = data["y"].as<double>();
+  }
+  else
+  {
+    CoordinateSystem::WGS84Point wgs84_point;
+    wgs84_point.lon = data["x"].as<double>();
+    wgs84_point.lat = data["y"].as<double>();
+
+    CoordinateSystem::ProjectedPoint p =
+      coordinate_system.to_epsg3857(wgs84_point);
+    state.x = p.x;
+    state.y = p.y;
+  }
+
   if (data["z"])
   {
     state.z = data["z"].as<double>();
@@ -70,15 +89,29 @@ void Model::from_yaml(const YAML::Node& data, const string& level_name)
     is_static = true;
 }
 
-YAML::Node Model::to_yaml() const
+YAML::Node Model::to_yaml(const CoordinateSystem& coordinate_system) const
 {
   // This is in image space. I think it's safe to say nobody is clicking
   // with more than 1/1000 precision inside a single pixel.
 
   YAML::Node n;
   n.SetStyle(YAML::EmitterStyle::Flow);
-  n["x"] = std::round(state.x * 1000.0) / 1000.0;
-  n["y"] = std::round(state.y * 1000.0) / 1000.0;
+
+  if (!coordinate_system.is_global())
+  {
+    // in either image or cartesian-meters coordinate spaces, we're
+    // fine with rounding to 3 decimal places
+    n["x"] = std::round(state.x * 1000.0) / 1000.0;
+    n["y"] = std::round(state.y * 1000.0) / 1000.0;
+  }
+  else
+  {
+    // convert back to WGS84 and save with as many decimal places as possible
+    CoordinateSystem::WGS84Point p =
+      coordinate_system.to_wgs84({state.x, state.y});
+    n["x"] = p.lon;
+    n["y"] = p.lat;
+  }
   n["z"] = std::round(state.z * 1000.0) / 1000.0;
   // let's give yaw another decimal place because, I don't know, reasons (?)
   n["yaw"] = std::round(state.yaw * 10000.0) / 10000.0;

--- a/rmf_traffic_editor/gui/model.h
+++ b/rmf_traffic_editor/gui/model.h
@@ -25,6 +25,7 @@
  * a map.
  */
 
+#include "coordinate_system.h"
 #include "editor_model.h"
 #include "model_state.h"
 
@@ -55,8 +56,11 @@ public:
 
   Model();
 
-  YAML::Node to_yaml() const;
-  void from_yaml(const YAML::Node& data, const std::string& level_name);
+  YAML::Node to_yaml(const CoordinateSystem& coordinate_system) const;
+  void from_yaml(
+    const YAML::Node& data,
+    const std::string& level_name,
+    const CoordinateSystem& coordinate_system);
 
   void set_param(const std::string& name, const std::string& value);
 


### PR DESCRIPTION
Hoping this patch will help handle the 

- latlon translation behavior for models ( previously, builds break when adding models due to WGS84 translation not having a "rotation" variable
- change naming convention for model positions to lat/lon instead of x/y for consistency
- apply offsets to the camera as well, so the camera view appears immediately over the working area