### PR TITLE
Always use ign=True and remove spaces when comparing model names

### DIFF
--- a/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
+++ b/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
@@ -7,6 +7,7 @@ from pprint import pprint
 import argparse
 import logging
 import sys
+import shutil
 import os
 import yaml
 
@@ -77,6 +78,14 @@ def get_crowdsim_models(input_filename):
             logger.error(f"Could not get crowd_sim models, error: {e}."
                          " Ignore models in crowd_sim...")
         return actor_names
+
+
+def export_downloaded_model(model_path, export_path):
+    if os.path.exists(export_path) or os.path.isdir(export_path):
+        logger.warning("%s already exists, skipping..." % (export_path))
+        return
+    logger.info("Exporting to %s..." % (export_path))
+    shutil.copytree(src=model_path, dst=export_path)
 
 
 def download_models(
@@ -153,6 +162,23 @@ def download_models(
     if missing_models.get('missing', []):
         logger.warning("\nMissing models (not in local or Fuel):")
         pprint(missing_models['missing'])
+
+    if export_path is not None:
+        available_models = missing_models.get('available', [])
+        for model_name, paths in available_models:
+            if paths is None:
+                logger.warning("No path for exporting model %s, skipping..."
+                               % (model_name))
+                continue
+
+            if len(paths) > 1:
+                logger.warning("More than one path for model %s, selecting "
+                               "first path that was found, %s"
+                               % (model_name, paths[0]))
+
+            export_model_path = os.path.join(export_path, model_name)
+            export_model_path = os.path.expanduser(export_model_path)
+            export_downloaded_model(paths[0], export_model_path)
 
 
 def main():

--- a/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
+++ b/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
@@ -125,7 +125,8 @@ def download_models(
         cache_file_path=cache,
         lower=True,
         priority_dir=include,
-        ign=True
+        ign=True,
+        use_dir_as_name=True
     )
 
     logger.info("\n== REQUESTED MODEL REPORT ==")

--- a/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
+++ b/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
@@ -51,7 +51,7 @@ parser.add_argument("-c", "--cache", type=str,
 parser.add_argument("-f", "--fuel-tools", action=HTTPDownloadDeprecated,
                     help="Use ignition fuel tools to download models instead "
                          "of http", nargs=0)
-parser.add_argument("-i", "--include", type=str,
+parser.add_argument("-i", "--include", type=str, default=None,
                     help="Search this directory first for models.")
 parser.add_argument("-e", "--export-path", type=str, default=None,
                     help="Export model downloaded using ignition fuel tools "
@@ -116,6 +116,7 @@ def download_models(
         cache_file_path=cache,
         lower=True,
         priority_dir=include,
+        ign=True
     )
 
     logger.info("\n== REQUESTED MODEL REPORT ==")

--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -74,8 +74,10 @@ logger.addHandler(logging.NullHandler())
 
 ModelNames = namedtuple("ModelNames", ["model_name", "author_name"])
 
+
 def remove_spaces(original):
     return ''.join([x for x in original if x not in string.whitespace])
+
 
 def swag(print_swag=True):
     """Swag!"""

--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -144,15 +144,10 @@ def get_missing_models(model_names, model_path=None,
             - Missing models are models that are not in your local directory
                 and also missing from Fuel.
     """
-    original_model_names = model_names
-    for model_name in original_model_names:
+    for key, model_name in enumerate(model_names):
         if isinstance(model_name, ModelNames) or isinstance(model_name, tuple):
             assert len(model_name) == 2, \
                 "Invalid model name tuple given: %s!" % model_name
-
-    model_names = set()
-    for original in original_model_names:
-        model_names.add((remove_spaces(original[0]), original[1]))
 
     if update_cache:
         cache = build_and_update_cache(cache_file_path=cache_file_path,
@@ -367,7 +362,7 @@ def get_model_name_tuple(config_file_path, config_file="model.config",
         else:
             config_file = os.path.basename(config_file_path)
         tree = ET.parse(config_file_path)
-        model_name = remove_spaces(tree.find("name").text)
+        model_name = tree.find("name").text
         author_name = tree.find("author").find("name").text
     except Exception as e:
         logger.error("Could not parse %s file! %s"

--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -167,23 +167,23 @@ def get_missing_models(model_names, model_path=None,
     if priority_dir is not None:
         logger.info("Will check '%s' directory first for models"
                     % (priority_dir))
-        for priority_model in get_local_model_name_tuples(
+        priority_models_dict = get_local_model_name_tuples(
             priority_dir, config_file=config_file, lower=lower,
-            use_dir_as_name=use_dir_as_name, ign=ign
-        ):
+            use_dir_as_name=use_dir_as_name, ign=ign)
+        for priority_model, path in priority_models_dict.items():
             if priority_model[0] in priority_models:
-                priority_models[priority_model[0]].append(priority_model[1])
+                priority_models[priority_model[0]].append(path)
             else:
-                priority_models[priority_model[0]] = [[priority_model[1]]]
+                priority_models[priority_model[0]] = [path]
 
-    for local_model in get_local_model_name_tuples(
+    local_models_dict = get_local_model_name_tuples(
         model_path, config_file=config_file, lower=lower,
-        use_dir_as_name=use_dir_as_name, ign=ign
-    ):
+        use_dir_as_name=use_dir_as_name, ign=ign)
+    for local_model, path in local_models_dict.items():
         if local_model[0] in local_models:
-            local_models[local_model[0]].append(local_model[1])
+            local_models[local_model[0]].append(path)
         else:
-            local_models[local_model[0]] = [local_model[1]]
+            local_models[local_model[0]] = [path]
 
     output = {'missing': [],
               'downloadable': [],
@@ -214,14 +214,16 @@ def get_missing_models(model_names, model_path=None,
                 (model_name, priority_dir, model_path, priority_dir))
 
         if model_name in priority_models:
-            output['available'].append(model_name_original)
+            output['available'].append(
+                (model_name_original, ))
             if author_name:
                 if author_name not in priority_models[model_name]:
                     logger.warning("Model %s in local model directory"
                                    " is not by the requested author %s!"
                                    % (model_name, author_name))
         elif model_name in local_models:
-            output['available'].append(model_name_original)
+            output['available'].append(
+                (model_name_original, local_models[model_name]))
             if author_name:
                 if author_name not in local_models[model_name]:
                     logger.warning("Model %s in local model directory"
@@ -264,11 +266,11 @@ def get_local_model_name_tuples(path=None, config_file="model.config",
             following Ignition's directory structure. Defaults to False.
 
     Returns:
-        set of (str, str): Set of unique ModelNames tuples of
-            (model_name, author_name). Each name will be lower-case only
-            unless lower is False.
+        dictionary (ModelNames: str): Dictionary where ModelNames tuples are
+        keys, and the model path is the value. Each name will be lower-case
+        only unless lower is False.
     """
-    output = set()
+    output = {}
 
     if path is None:
         if ign:
@@ -300,8 +302,9 @@ def get_local_model_name_tuples(path=None, config_file="model.config",
             latest_ver = ""
 
         if config_file in os.listdir(os.path.join(model_path, latest_ver)):
+            latest_ver_path = os.path.join(model_path, latest_ver)
             name_tuple = get_model_name_tuple(
-                os.path.join(model_path, latest_ver, config_file),
+                os.path.join(latest_ver_path, config_file),
                 default_author_name=default_author_name,
                 lower=lower
             )
@@ -318,7 +321,7 @@ def get_local_model_name_tuples(path=None, config_file="model.config",
                     name_tuple = ModelNames(os.path.basename(model_path),
                                             name_tuple.author_name)
 
-                output.add(name_tuple)
+                output[name_tuple] = latest_ver_path
         else:
             logger.warning("%s does not contain a valid config_file! "
                            "Skipping..." % model_path)


### PR DESCRIPTION
This PR addresses two issues related to fetching models from fuel:

* We will now always use the `ign=True` mode since we are always caching models in the `.ignition/fuel` model cache.
* We will ignore all spaces in model names when deciding if a local model copy matches a model on fuel. Sometimes the models on fuel are inconsistent about their use of spaces, and when that happens pit crew would accidentally re-download it (but this is fixed in this PR).