### PR TITLE
if map_version is present, copy it into GeoJSON

### DIFF
--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -45,6 +45,11 @@ class Building:
             for param_name, param_yaml in yaml_node['parameters'].items():
                 self.params[param_name] = ParamValue(param_yaml)
 
+        if 'map_version' in yaml_node:
+            self.map_version = yaml_node['map_version']
+        else:
+            self.map_version = None
+
         if 'coordinate_system' in yaml_node:
             self.coordinate_system = \
                 CoordinateSystem[yaml_node['coordinate_system']]
@@ -738,6 +743,9 @@ class Building:
             'type': 'FeatureCollection',
             'features': features,
         }
+
+        if self.map_version is not None:
+            j['map_version'] = self.map_version
 
         if 'suggested_offset_x' in self.params:
             j['suggested_offset_x'] = self.params['suggested_offset_x'].value


### PR DESCRIPTION
Minimal PR that just copies a `map_version` field (if present in a `.building.yaml` file) into GeoJSON generated from it. 

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>