### PR TITLE
Feature/render OpenStreetMap tiles

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y git cmake wget libyaml-cpp-dev qt5-default libceres-dev libeigen3-dev python3-shapely python3-requests python3-yaml python3-pyproj python3-fiona python3-rtree
 
+    - name: rmf-pkgs
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ros-foxy-rmf-utils
+
     - name: build
       shell: bash
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ jobs:
   ci:
     runs-on: ubuntu-20.04
     container:
-      image: docker://ros:foxy-ros-base-focal
+      image: docker://ros:galactic-ros-base-focal
     
     steps:
     - name: ros-workspace
@@ -24,13 +24,13 @@ jobs:
     - name: rmf-pkgs
       run: |
         sudo apt-get update
-        sudo apt-get install -y ros-foxy-rmf-utils
+        sudo apt-get install -y ros-galactic-rmf-utils
 
     - name: build
       shell: bash
       run: |
         cd ws
-        source /opt/ros/foxy/setup.bash
+        source /opt/ros/galactic/setup.bash
         colcon build --packages-select rmf_traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
         colcon build --packages-up-to rmf_traffic_editor_test_maps --cmake-args -DNO_DOWNLOAD_MODELS=True
 
@@ -38,12 +38,12 @@ jobs:
       shell: bash
       run: |
         cd ws
-        source /opt/ros/foxy/setup.bash
+        source /opt/ros/galactic/setup.bash
         QT_QPA_PLATFORM=offscreen colcon test --packages-select rmf_traffic_editor
 
     - name: test-results
       shell: bash
       run: |
         cd ws
-        source /opt/ros/foxy/setup.bash
+        source /opt/ros/galactic/setup.bash
         colcon test-result --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: non-ros-deps
       run: |
         sudo apt-get update
-        sudo apt-get install -y git cmake wget libyaml-cpp-dev qt5-default libceres-dev libeigen3-dev python3-shapely python3-requests python3-yaml python3-pyproj python3-fiona python3-rtree
+        sudo apt-get install -y git cmake wget libyaml-cpp-dev qt5-default libceres-dev libeigen3-dev python3-shapely python3-requests python3-yaml python3-pyproj python3-fiona python3-rtree libproj-dev
 
     - name: rmf-pkgs
       run: |

--- a/.github/workflows/pycodestyle.yaml
+++ b/.github/workflows/pycodestyle.yaml
@@ -3,8 +3,6 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-18.04
-    container:
-      image: docker://ros:eloquent-ros-base-bionic
     steps:
     - uses: actions/checkout@v1
     - name: deps

--- a/.github/workflows/pycodestyle.yaml
+++ b/.github/workflows/pycodestyle.yaml
@@ -2,7 +2,7 @@ name: style
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - name: deps

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -10,13 +10,7 @@ jobs:
     - name: deps
       run: |
         sudo apt-get update
-        sudo apt-get install pycodestyle wget
+        sudo apt-get install pycodestyle
     - name: pycodestyle
       run: |
         pycodestyle .
-    - name: rmf_uncrustify
-      shell: bash
-      run: |
-        wget https://raw.githubusercontent.com/open-rmf/rmf_utils/main/rmf_utils/test/format/rmf_code_style.cfg
-        source /opt/ros/eloquent/setup.bash
-        ament_uncrustify -c rmf_code_style.cfg .

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -17,6 +17,6 @@ jobs:
     - name: rmf_uncrustify
       shell: bash
       run: |
-        wget https://raw.githubusercontent.com/osrf/rmf_core/master/rmf_utils/test/format/rmf_code_style.cfg
+        wget https://raw.githubusercontent.com/open-rmf/rmf_utils/main/rmf_utils/test/format/rmf_code_style.cfg
         source /opt/ros/eloquent/setup.bash
         ament_uncrustify -c rmf_code_style.cfg .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![](https://github.com/osrf/traffic_editor/workflows/ci/badge.svg)](https://github.com/osrf/traffic_editor/actions/workflows/ci.yaml)
-[![](https://github.com/osrf/traffic_editor/workflows/style/badge.svg)](https://github.com/osrf/traffic_editor/actions/workflows/style.yaml)
+[![](https://github.com/osrf/traffic_editor/workflows/pycodestyle/badge.svg)](https://github.com/osrf/traffic_editor/actions/workflows/pycodestyle.yaml)
 
 # rmf_traffic\_editor
 

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -727,7 +727,7 @@ class Building:
                 properties = {
                     'name': vertex.name,
                     'level_idx': level_idx,
-                    'feature_type': 'rmf_vertex'
+                    'rmf_type': 'rmf_vertex'
                 }
                 for param_name, param_value in vertex.params.items():
                     properties[param_name] = param_value.value
@@ -744,7 +744,7 @@ class Building:
             for lane in level.lanes:
                 properties = {
                     'level_idx': level_idx,
-                    'feature_type': 'rmf_lane'
+                    'rmf_type': 'rmf_lane'
                 }
                 for param_name, param_value in lane.params.items():
                     properties[param_name] = param_value.value

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -119,7 +119,6 @@ class Building:
             self.global_transform = \
                 WGS84Transform(crs_name, (offset_x, offset_y))
 
-
         self.levels = {}
         self.model_counts = {}
         for level_name, level_yaml in yaml_node['levels'].items():

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -726,7 +726,8 @@ class Building:
                 (lat, lon) = wgs_transformer.transform(vertex.y, vertex.x)
                 properties = {
                     'name': vertex.name,
-                    'level_idx': level_idx
+                    'level_idx': level_idx,
+                    'feature_type': 'rmf_vertex'
                 }
                 for param_name, param_value in vertex.params.items():
                     properties[param_name] = param_value.value
@@ -743,6 +744,7 @@ class Building:
             for lane in level.lanes:
                 properties = {
                     'level_idx': level_idx,
+                    'feature_type': 'rmf_lane'
                 }
                 for param_name, param_value in lane.params.items():
                     properties[param_name] = param_value.value
@@ -750,6 +752,12 @@ class Building:
                 v2 = level.vertices[lane.end_idx]
                 (v1_lat, v1_lon) = wgs_transformer.transform(v1.y, v1.x)
                 (v2_lat, v2_lon) = wgs_transformer.transform(v2.y, v2.x)
+
+                if v1.name:
+                    properties['start_vertex_name'] = v1.name
+
+                if v2.name:
+                    properties['end_vertex_name'] = v2.name
 
                 features.append({
                     'type': 'Feature',

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -454,7 +454,13 @@ class Building:
 
         gui_ele = world.find('gui')
         c = self.center()
-        camera_pose = f'{c[0]} {c[1]-20} 10 0 0.6 1.57'
+        # Transforming camera to account for offsets if
+        # not in reference_image mode
+        if self.global_transform:
+            camera_pose = f'{c[0] - self.global_transform.x}  \
+            {c[1]-20 - self.global_transform.y} 10 0 0.6 1.57'
+        else:
+            camera_pose = f'{c[0]} {c[1]-20} 10 0 0.6 1.57'
         # add floor-toggle GUI plugin parameters
         if 'gazebo' in options:
             camera_pose_ele = gui_ele.find('camera').find('pose')

--- a/rmf_building_map_tools/building_map/coordinate_system.py
+++ b/rmf_building_map_tools/building_map/coordinate_system.py
@@ -5,6 +5,7 @@ class CoordinateSystem(Enum):
     reference_image = 1
     web_mercator = 2
     cartesian_meters = 3
+    wgs84 = 4
 
     def y_flip_scalar(self):
         if self == CoordinateSystem.reference_image:

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -244,8 +244,8 @@ class Level:
         for model in self.models:
             model.generate(
                 world_ele,
-                self.transform,
-                self.elevation)
+                self.elevation,
+                self.transform)
 
         # sniff around in our vertices and spawn robots if requested
         for vertex_idx, vertex in enumerate(self.vertices):

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -292,13 +292,23 @@ class Level:
                     yaw += math.pi
                 break
 
+        '''
+        Because we may be translating the world significantly in order for
+        the simulation coordinates to be near the origin, in the case of
+        Georeferenced frames, we also need to translate the robot spawn
+        point. Otherwise our poor robots could be spawned thousands of
+        kilometers from the building, thereby falling into the abyss of -NaN
+        '''
+        robot_x = vertex.x - self.transform.x
+        robot_y = vertex.y - self.transform.y
+
         include_ele = SubElement(world_ele, 'include')
         name_ele = SubElement(include_ele, 'name')
         name_ele.text = robot_name
         uri_ele = SubElement(include_ele, 'uri')
         uri_ele.text = f'model://{robot_type}'
         pose_ele = SubElement(include_ele, 'pose')
-        pose_ele.text = f'{vertex.x} {vertex.y} {vertex.z} 0 0 {yaw}'
+        pose_ele.text = f'{robot_x} {robot_y} {vertex.z} 0 0 {yaw}'
 
     def generate_floors(self, world_ele, model_name, model_path):
         i = 0

--- a/rmf_building_map_tools/building_map/model.py
+++ b/rmf_building_map_tools/building_map/model.py
@@ -30,6 +30,10 @@ class Model:
 
         self.yaw = yaml_node['yaw']
 
+        # BH: Temporary holder to keep to_yaml working for now
+        self.original_x = yaml_node['x']
+        self.original_y = yaml_node['y']
+
     def to_yaml(self, coordinate_system):
         y = {}
         y['x'] = self.x
@@ -41,17 +45,21 @@ class Model:
         y['static'] = self.static
         return y
 
-    def generate(self, world_ele, transform, elevation):
+    def generate(self, world_ele, elevation, transform):
         include_ele = SubElement(world_ele, 'include')
         name_ele = SubElement(include_ele, 'name')
         name_ele.text = self.name
         uri_ele = SubElement(include_ele, 'uri')
         uri_ele.text = f'model://{self.model_name}'
         pose_ele = SubElement(include_ele, 'pose')
-        x, y = transform.transform_point((self.x, self.y))
+
+        x_t, y_t = transform.transform_point([self.x, self.y])
+        x_t = x_t - transform.x
+        y_t = y_t - transform.y
+
         z = self.z + elevation
         yaw = self.yaw + transform.rotation
-        pose_ele.text = f'{x} {y} {z} 0 0 {yaw}'
+        pose_ele.text = f'{x_t} {y_t} {z} 0 0 {yaw}'
 
         static_ele = SubElement(include_ele, 'static')
         static_ele.text = str(self.static)

--- a/rmf_building_map_tools/building_map/passthrough_transform.py
+++ b/rmf_building_map_tools/building_map/passthrough_transform.py
@@ -4,6 +4,7 @@ class PassthroughTransform:
     def __init__(self, x, y, frame_name):
         self.x = x
         self.y = y
+        self.rotation = 0
         self.frame_name = frame_name
 
     def transform_point(self, p):

--- a/rmf_building_map_tools/building_map/transform.py
+++ b/rmf_building_map_tools/building_map/transform.py
@@ -9,6 +9,8 @@ class Transform:
         self.set_rotation(0.0)
         self.set_translation(0.0, 0.0)
         self.set_scale(1.0)
+        self.x = 0
+        self.y = 0
 
     def set_rotation(self, rotation):
         """Calculate rotation matrix"""

--- a/rmf_building_map_tools/building_map/web_mercator_transform.py
+++ b/rmf_building_map_tools/building_map/web_mercator_transform.py
@@ -7,7 +7,6 @@ class WebMercatorTransform:
     """Transforms between Web Mercator points and transverse mercator planes"""
 
     def __init__(self, crs_name):
-        # crs_4326 = CRS.from_epsg(4326)  # also known as WGS84...
         print(f'WebMercatorTransform({crs_name})')
         self.crs_name = crs_name
         self.offset = (0, 0)
@@ -32,15 +31,8 @@ class WebMercatorTransform:
         (lat, lon) = \
             self.web_mercator_to_wgs84.transform(meters_east, meters_north)
 
-        # now we need to choose a TM plane. In the future we should be more
-        # generic, but for now let's start by using SVY21
         (tm_northing, tm_easting) = \
             self.web_mercator_to_tm.transform(meters_east, meters_north)
-
-        # crs_tm = CRS.from_epsg(3414)
-        # tm_false_easting = crs_tm.to_dict()['x_0']
-        # tm_false_northing = crs_tm.to_dict()['y_0']
-        # print(f'offset: {tm_false_easting}, {tm_false_northing}')
 
         tm_easting -= self.offset[0]
         tm_northing -= self.offset[1]

--- a/rmf_building_map_tools/building_map/wgs84_transform.py
+++ b/rmf_building_map_tools/building_map/wgs84_transform.py
@@ -1,0 +1,26 @@
+from pyproj import Transformer
+from pyproj import CRS
+import math
+
+
+class WGS84Transform:
+    """Transforms between WGS84 points and transverse mercator planes"""
+
+    def __init__(self, crs_name, offset):
+        print(f'WGS84Transform({crs_name}, {offset})')
+        self.crs_name = crs_name
+        self.x = offset[0]
+        self.y = offset[1]
+        self.wgs84_to_tm = \
+            Transformer.from_crs("EPSG:4326", self.crs_name)
+
+    def transform_point(self, p):
+        lon = p[0]
+        lat = p[1]
+
+        (tm_northing, tm_easting) = \
+            self.wgs84_to_tm.transform(lat, lon)
+
+        # print(f'lat={lat} lon={lon} => ({tm_easting}, {tm_northing})')
+
+        return (tm_easting, tm_northing)

--- a/rmf_building_map_tools/building_map/wgs84_transform.py
+++ b/rmf_building_map_tools/building_map/wgs84_transform.py
@@ -11,6 +11,7 @@ class WGS84Transform:
         self.crs_name = crs_name
         self.x = offset[0]
         self.y = offset[1]
+        self.rotation = 0
         self.wgs84_to_tm = \
             Transformer.from_crs("EPSG:4326", self.crs_name)
 

--- a/rmf_traffic_editor/CMakeLists.txt
+++ b/rmf_traffic_editor/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(Ceres REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(Qt5 COMPONENTS Widgets Concurrent Test REQUIRED)
+find_package(Qt5 COMPONENTS Widgets Concurrent Test Network REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
 set(CMAKE_BUILD_TYPE RelWithDebInfo)
@@ -119,6 +119,7 @@ target_link_libraries(
   Eigen3::Eigen
   Qt5::Widgets
   Qt5::Concurrent
+  Qt5::Network
   yaml-cpp
   ${ament_index_cpp_LIBRARIES}
 )

--- a/rmf_traffic_editor/CMakeLists.txt
+++ b/rmf_traffic_editor/CMakeLists.txt
@@ -152,7 +152,21 @@ install(
     include)
 
 if (BUILD_TESTING)
+  find_package(ament_cmake_uncrustify REQUIRED)
+  find_package(rmf_utils REQUIRED)
+
   add_subdirectory(test)
+
+  find_file(uncrustify_config_file
+    NAMES "rmf_code_style.cfg"
+    PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
+
+  ament_uncrustify(
+    ARGN include gui
+    CONFIG_FILE ${uncrustify_config_file}
+    MAX_LINE_LENGTH 80
+    LANGUAGE "C++"
+  )
 endif()
 
 ament_export_include_directories(include)

--- a/rmf_traffic_editor/CMakeLists.txt
+++ b/rmf_traffic_editor/CMakeLists.txt
@@ -159,13 +159,15 @@ if (BUILD_TESTING)
 
   find_file(uncrustify_config_file
     NAMES "rmf_code_style.cfg"
-    PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
+    PATHS
+      "${rmf_utils_DIR}/../../../share/rmf_utils/"
+      "/opt/ros/galactic/share/rmf_utils")
 
   ament_uncrustify(
     ARGN include gui
     CONFIG_FILE ${uncrustify_config_file}
     MAX_LINE_LENGTH 80
-    LANGUAGE "C++"
+    LANGUAGE CPP
   )
 endif()
 

--- a/rmf_traffic_editor/CMakeLists.txt
+++ b/rmf_traffic_editor/CMakeLists.txt
@@ -69,6 +69,7 @@ set(gui_sources
   gui/lift_dialog.cpp
   gui/lift_door.cpp
   gui/lift_table.cpp
+  gui/map_tile_cache.cpp
   gui/map_view.cpp
   gui/model.cpp
   gui/model_dialog.cpp

--- a/rmf_traffic_editor/CMakeLists.txt
+++ b/rmf_traffic_editor/CMakeLists.txt
@@ -120,6 +120,7 @@ target_link_libraries(
   Qt5::Widgets
   Qt5::Concurrent
   Qt5::Network
+  proj
   yaml-cpp
   ${ament_index_cpp_LIBRARIES}
 )

--- a/rmf_traffic_editor/CMakeLists.txt
+++ b/rmf_traffic_editor/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10.0)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 project(rmf_traffic_editor)

--- a/rmf_traffic_editor/gui/add_param_dialog.h
+++ b/rmf_traffic_editor/gui/add_param_dialog.h
@@ -23,7 +23,6 @@
 #include "param.h"
 class QComboBox;
 
-
 class AddParamDialog : public QDialog
 {
 public:

--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -91,8 +91,8 @@ bool Building::load(const string& _filename)
     name = y["name"].as<string>();
 
   if (y["coordinate_system"])
-    coordinate_system =
-      CoordinateSystem::from_string(y["coordinate_system"].as<string>());
+    coordinate_system.value =
+      CoordinateSystem::value_from_string(y["coordinate_system"].as<string>());
 
   if (y["reference_level_name"])
     reference_level_name = y["reference_level_name"].as<string>();

--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -188,7 +188,7 @@ bool Building::save()
 
   y["levels"] = YAML::Node(YAML::NodeType::Map);
   for (const auto& level : levels)
-    y["levels"][level.name] = level.to_yaml();
+    y["levels"][level.name] = level.to_yaml(coordinate_system);
 
   y["lifts"] = YAML::Node(YAML::NodeType::Map);
   for (const auto& lift : lifts)

--- a/rmf_traffic_editor/gui/building_dialog.cpp
+++ b/rmf_traffic_editor/gui/building_dialog.cpp
@@ -43,6 +43,18 @@ BuildingDialog::BuildingDialog(Building& building)
       QString::fromStdString(building.reference_level_name));
   reference_level_hbox->addWidget(_reference_floor_combo_box);
 
+  QHBoxLayout* generate_crs_hbox = new QHBoxLayout;
+  generate_crs_hbox->addWidget(new QLabel("Generate CRS:"));
+
+  std::string generate_crs;
+  if (building.params.find("generate_crs") != building.params.end())
+    generate_crs = building.params["generate_crs"].value_string;
+
+  generate_crs_line_edit = new QLineEdit(
+    QString::fromStdString(generate_crs),
+    this);
+  generate_crs_hbox->addWidget(generate_crs_line_edit);
+
   QHBoxLayout* bottom_buttons_hbox = new QHBoxLayout;
   bottom_buttons_hbox->addWidget(_cancel_button);
   bottom_buttons_hbox->addWidget(_ok_button);
@@ -57,6 +69,7 @@ BuildingDialog::BuildingDialog(Building& building)
 
   top_vbox->addLayout(building_name_hbox);
   top_vbox->addLayout(reference_level_hbox);
+  top_vbox->addLayout(generate_crs_hbox);
   // todo: some sort of separator (?)
   top_vbox->addLayout(bottom_buttons_hbox);
 
@@ -70,7 +83,12 @@ BuildingDialog::~BuildingDialog()
 void BuildingDialog::ok_button_clicked()
 {
   _building.name = _building_name_line_edit->text().toStdString();
+
   _building.reference_level_name =
     _reference_floor_combo_box->currentText().toStdString();
+
+  _building.params["generate_crs"] =
+    Param(generate_crs_line_edit->text().toStdString());
+
   accept();
 }

--- a/rmf_traffic_editor/gui/building_dialog.h
+++ b/rmf_traffic_editor/gui/building_dialog.h
@@ -35,6 +35,7 @@ private:
 
   QLineEdit* _building_name_line_edit;
   QComboBox* _reference_floor_combo_box;
+  QLineEdit* generate_crs_line_edit;
   QPushButton* _ok_button, * _cancel_button;
 
 private slots:

--- a/rmf_traffic_editor/gui/coordinate_system.cpp
+++ b/rmf_traffic_editor/gui/coordinate_system.cpp
@@ -84,3 +84,8 @@ double CoordinateSystem::default_scale() const
   else
     return 1.0;
 }
+
+bool CoordinateSystem::has_tiles() const
+{
+  return (value == CoordinateSystem::WGS84);
+}

--- a/rmf_traffic_editor/gui/coordinate_system.cpp
+++ b/rmf_traffic_editor/gui/coordinate_system.cpp
@@ -137,12 +137,12 @@ bool CoordinateSystem::has_tiles() const
 }
 
 CoordinateSystem::WGS84Point CoordinateSystem::to_wgs84(
-  const double easting,
-  const double northing)
+  const ProjectedPoint& point) const
 {
-  if (value != CoordinateSystem::ReferenceImage)
+  if (value != ReferenceImage)
   {
-    const PJ_COORD c = proj_coord(easting, northing, 0, 0);
+    // todo: if CartesianMeters, use the CRS name provided somewhere
+    const PJ_COORD c = proj_coord(point.x, point.y, 0, 0);
     const PJ_COORD wgs84_coord = proj_trans(
       epsg_3857_to_wgs84,
       PJ_FWD,
@@ -156,8 +156,19 @@ CoordinateSystem::WGS84Point CoordinateSystem::to_wgs84(
 }
 
 CoordinateSystem::ProjectedPoint CoordinateSystem::to_epsg3857(
-  const double easting,
-  const double northing)
+  const WGS84Point& point) const
 {
-  return {0, 0};
+  if (value == WGS84)
+  {
+    const PJ_COORD p_in = proj_coord(point.lat, point.lon, 0, 0);
+    const PJ_COORD p_out = proj_trans(
+      epsg_3857_to_wgs84,
+      PJ_INV,
+      p_in);
+    return ProjectedPoint({p_out.v[0], p_out.v[1]});
+  }
+  else
+  {
+    return {0, 0};
+  }
 }

--- a/rmf_traffic_editor/gui/coordinate_system.cpp
+++ b/rmf_traffic_editor/gui/coordinate_system.cpp
@@ -88,7 +88,8 @@ std::string CoordinateSystem::to_string()
   }
 }
 
-CoordinateSystem::Value CoordinateSystem::value_from_string(const std::string& s)
+CoordinateSystem::Value CoordinateSystem::value_from_string(
+  const std::string& s)
 {
   if (s == "reference_image")
     return ReferenceImage;

--- a/rmf_traffic_editor/gui/coordinate_system.cpp
+++ b/rmf_traffic_editor/gui/coordinate_system.cpp
@@ -38,6 +38,7 @@ std::string CoordinateSystem::to_string()
     case ReferenceImage: return "reference_image";
     case WebMercator: return "web_mercator";
     case CartesianMeters: return "cartesian_meters";
+    case WGS84: return "wgs84";
 
     case Undefined:
     default:
@@ -54,6 +55,8 @@ CoordinateSystem CoordinateSystem::from_string(const std::string& s)
     cs.value = WebMercator;
   else if (s == "cartesian_meters")
     cs.value = CartesianMeters;
+  else if (s == "wgs84")
+    cs.value = WGS84;
   else
     cs.value = Undefined;
   return cs;

--- a/rmf_traffic_editor/gui/coordinate_system.cpp
+++ b/rmf_traffic_editor/gui/coordinate_system.cpp
@@ -94,3 +94,10 @@ bool CoordinateSystem::has_tiles() const
 {
   return value == CoordinateSystem::WGS84;
 }
+
+CoordinateSystem::ProjectedPoint CoordinateSystem::to_epsg3857(
+  const double coord_0,
+  const double coord_1)
+{
+  return ProjectedPoint{0, 0};
+}

--- a/rmf_traffic_editor/gui/coordinate_system.cpp
+++ b/rmf_traffic_editor/gui/coordinate_system.cpp
@@ -87,5 +87,5 @@ double CoordinateSystem::default_scale() const
 
 bool CoordinateSystem::has_tiles() const
 {
-  return (value == CoordinateSystem::WGS84);
+  return value == CoordinateSystem::WGS84;
 }

--- a/rmf_traffic_editor/gui/coordinate_system.cpp
+++ b/rmf_traffic_editor/gui/coordinate_system.cpp
@@ -67,6 +67,11 @@ bool CoordinateSystem::is_y_flipped() const
   return value == ReferenceImage;
 }
 
+bool CoordinateSystem::is_global() const
+{
+  return value == WGS84;
+}
+
 double CoordinateSystem::default_scale() const
 {
   // Image-based maps are often somewhere around 5cm

--- a/rmf_traffic_editor/gui/coordinate_system.h
+++ b/rmf_traffic_editor/gui/coordinate_system.h
@@ -53,14 +53,15 @@ public:
     double x = 0.0;
     double y = 0.0;
   };
-  ProjectedPoint to_epsg3857(const double easting, const double northing);
 
   struct WGS84Point
   {
     double lat = 0;
     double lon = 0;
   };
-  WGS84Point to_wgs84(const double easting, const double northing);
+
+  ProjectedPoint to_epsg3857(const WGS84Point& wgs84_point) const;
+  WGS84Point to_wgs84(const ProjectedPoint& point) const;
 
   PJ_CONTEXT* proj_context = nullptr;
   PJ* epsg_3857_to_wgs84 = nullptr;

--- a/rmf_traffic_editor/gui/coordinate_system.h
+++ b/rmf_traffic_editor/gui/coordinate_system.h
@@ -19,6 +19,7 @@
 #define COORDINATE_SYSTEM_H
 
 #include <string>
+#include <proj.h>
 
 class CoordinateSystem
 {
@@ -46,6 +47,13 @@ public:
 
   // equatorial radius of the earth in WGS84 (meters)
   static constexpr double WGS84_A = 6378137.0;
+
+  struct ProjectedPoint
+  {
+    double x = 0.0;
+    double y = 0.0;
+  };
+  ProjectedPoint to_epsg3857(const double coord_0, const double coord_1);
 };
 
 #endif

--- a/rmf_traffic_editor/gui/coordinate_system.h
+++ b/rmf_traffic_editor/gui/coordinate_system.h
@@ -43,6 +43,9 @@ public:
 
   bool has_tiles() const;
   bool is_global() const;
+
+  // equatorial radius of the earth in WGS84 (meters)
+  static constexpr double WGS84_A = 6378137.0;
 };
 
 #endif

--- a/rmf_traffic_editor/gui/coordinate_system.h
+++ b/rmf_traffic_editor/gui/coordinate_system.h
@@ -40,6 +40,8 @@ public:
   static CoordinateSystem from_string(const std::string& s);
   bool is_y_flipped() const;
   double default_scale() const;
+
+  bool has_tiles() const;
 };
 
 #endif

--- a/rmf_traffic_editor/gui/coordinate_system.h
+++ b/rmf_traffic_editor/gui/coordinate_system.h
@@ -67,6 +67,15 @@ public:
   PJ* epsg_3857_to_wgs84 = nullptr;
 
   void init_proj();
+
+  /*
+  // even for maps defined in WGS84, we often want to generate a local
+  // cartesian plane for simulation and navigation. This field is
+  // intended to hold the CRS name, such as "EPSG:XXXXX" that will be
+  // eventually used by downstream tools to generate cartesian
+  // approximations of this world.
+  std::string generate_crs;
+  */
 };
 
 #endif

--- a/rmf_traffic_editor/gui/coordinate_system.h
+++ b/rmf_traffic_editor/gui/coordinate_system.h
@@ -42,6 +42,7 @@ public:
   double default_scale() const;
 
   bool has_tiles() const;
+  bool is_global() const;
 };
 
 #endif

--- a/rmf_traffic_editor/gui/coordinate_system.h
+++ b/rmf_traffic_editor/gui/coordinate_system.h
@@ -28,7 +28,8 @@ public:
     Undefined,
     ReferenceImage,
     WebMercator,
-    CartesianMeters
+    CartesianMeters,
+    WGS84
   } value;
 
   CoordinateSystem();

--- a/rmf_traffic_editor/gui/coordinate_system.h
+++ b/rmf_traffic_editor/gui/coordinate_system.h
@@ -38,7 +38,7 @@ public:
   ~CoordinateSystem();
 
   std::string to_string();
-  static CoordinateSystem from_string(const std::string& s);
+  static CoordinateSystem::Value value_from_string(const std::string& s);
   bool is_y_flipped() const;
   double default_scale() const;
 
@@ -53,7 +53,19 @@ public:
     double x = 0.0;
     double y = 0.0;
   };
-  ProjectedPoint to_epsg3857(const double coord_0, const double coord_1);
+  ProjectedPoint to_epsg3857(const double easting, const double northing);
+
+  struct WGS84Point
+  {
+    double lat = 0;
+    double lon = 0;
+  };
+  WGS84Point to_wgs84(const double easting, const double northing);
+
+  PJ_CONTEXT* proj_context = nullptr;
+  PJ* epsg_3857_to_wgs84 = nullptr;
+
+  void init_proj();
 };
 
 #endif

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -209,8 +209,8 @@ Editor::Editor()
   right_tab_widget->addTab(level_table, "levels");
   right_tab_widget->addTab(layer_table, "layers");
   right_tab_widget->addTab(lift_table, "lifts");
-  right_tab_widget->addTab(traffic_table, "traffic");
-  right_tab_widget->addTab(crowd_sim_table, "crowd_sim");
+  right_tab_widget->addTab(traffic_table, "graphs");
+  right_tab_widget->addTab(crowd_sim_table, "crowds");
 
   property_editor = new QTableWidget;
   property_editor->setStyleSheet(
@@ -269,7 +269,7 @@ Editor::Editor()
   w->setMouseTracking(true);
   setMouseTracking(true);
   w->setLayout(hbox_layout);
-  w->setStyleSheet("background-color: #404040");
+  w->setStyleSheet("background-color: #707070");
   setCentralWidget(w);
 
   // BUILDING MENU
@@ -566,6 +566,8 @@ bool Editor::load_building(const QString& filename)
 
   level_idx = 0;
 
+  map_view->set_show_tiles(false);
+
   if (building.coordinate_system.is_global())
   {
     // use the EPSG 3857 extents: "projected-meters"
@@ -574,6 +576,15 @@ bool Editor::load_building(const QString& filename)
         M_PI * CoordinateSystem::WGS84_A,
         2. * M_PI * CoordinateSystem::WGS84_A,
         -2. * M_PI * CoordinateSystem::WGS84_A));
+
+    const double y_flip = building.coordinate_system.is_y_flipped() ? 1 : -1;
+
+    QTransform t;
+    t.scale(1, y_flip);
+    map_view->setTransform(t);
+
+    map_view->set_show_tiles(true);
+    map_view->draw_tiles();
   }
   else if (!building.levels.empty())
   {
@@ -586,9 +597,6 @@ bool Editor::load_building(const QString& filename)
   create_scene();
 
   update_tables();
-
-  QSettings settings;
-  settings.setValue(preferences_keys::previous_building_path, absolute_path);
 
   setWindowModified(false);
 
@@ -639,19 +647,36 @@ void Editor::restore_previous_viewport()
   if (isnan(viewport_scale))
     viewport_scale = 1.0;
 
-  printf("restoring viewport: (%.1f, %.1f, %3f)\n",
-    viewport_center_x,
-    viewport_center_y,
-    viewport_scale);
+  // See if the previous building name matches the current building name
+  // if they mismatch, don't attempt to use the previous viewport!
+  // This is a really big deal if we're mixing coordinate systems :boom:
+  const std::string previous_filename =
+    settings.value(preferences_keys::previous_building_path)
+    .toString().toStdString();
 
-  double y_flip = building.coordinate_system.is_y_flipped() ? 1 : -1;
+  printf("previous filename: %s\n", previous_filename.c_str());
+  printf("current building filename: %s\n", building.get_filename().c_str());
 
-  QTransform t;
-  t.scale(viewport_scale, y_flip * viewport_scale);
-  map_view->setTransform(t);
-  map_view->centerOn(QPointF(viewport_center_x, viewport_center_y));
-  map_view->set_show_tiles(true);
-  map_view->draw_tiles();
+  if (previous_filename == building.get_filename())
+  {
+    printf("restoring viewport: (%.1f, %.1f, %3f)\n",
+      viewport_center_x,
+      viewport_center_y,
+      viewport_scale);
+
+    const double y_flip = building.coordinate_system.is_y_flipped() ? 1 : -1;
+    QTransform t;
+    t.scale(viewport_scale, y_flip * viewport_scale);
+    map_view->setTransform(t);
+
+    map_view->centerOn(QPointF(viewport_center_x, viewport_center_y));
+    map_view->draw_tiles();
+  }
+  else
+  {
+    printf("resetting view...\n");
+    zoom_reset();
+  }
 }
 
 bool Editor::load_previous_building()
@@ -855,34 +880,7 @@ void Editor::view_tiles()
 
 void Editor::zoom_reset()
 {
-  const double viewport_scale = 1.0;
-  const double y_flip = building.coordinate_system.is_y_flipped() ? 1 : -1;
-
-  QTransform t;
-  t.scale(viewport_scale, y_flip * viewport_scale);
-  map_view->setTransform(t);
-
-  // compute center of all vertices on the active level
-  Level* level = active_level();
-  if (level)
-  {
-    const size_t n_vertex = level->vertices.size();
-    if (n_vertex > 0)
-    {
-      double x_sum = 0, y_sum = 0;
-      for (const auto& v : level->vertices)
-      {
-        x_sum += v.x;
-        y_sum += v.y;
-      }
-      const double xc = x_sum / n_vertex;
-      const double yc = y_sum / n_vertex;
-      printf("center: (%.3f, %.3f)\n", xc, yc);
-      map_view->centerOn(QPointF(xc, yc));
-    }
-  }
-
-  map_view->draw_tiles();
+  map_view->zoom_fit(level_idx);
 }
 
 void Editor::mouse_event(const MouseType t, QMouseEvent* e)
@@ -2667,6 +2665,10 @@ void Editor::closeEvent(QCloseEvent* event)
   settings.setValue(preferences_keys::viewport_center_x, p_center_scene.x());
   settings.setValue(preferences_keys::viewport_center_y, p_center_scene.y());
   settings.setValue(preferences_keys::viewport_scale, scale);
+
+  settings.setValue(
+    preferences_keys::previous_building_path,
+    QString::fromStdString(building.get_filename()));
 
   if (!building.levels.empty())
     settings.setValue(

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -629,6 +629,8 @@ void Editor::restore_previous_viewport()
   t.scale(viewport_scale, y_flip * viewport_scale);
   map_view->setTransform(t);
   map_view->centerOn(QPointF(viewport_center_x, viewport_center_y));
+  map_view->set_show_tiles(true);
+  map_view->update_tiles();
 }
 
 bool Editor::load_previous_building()
@@ -682,6 +684,7 @@ void Editor::building_new()
   building_save();
   zoom_reset();
   update_tables();
+  map_view->update_tiles();
 
   QSettings settings;
   settings.setValue(

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -553,7 +553,11 @@ bool Editor::load_building(const QString& filename)
 
   level_idx = 0;
 
-  if (!building.levels.empty())
+  if (building.coordinate_system.is_global())
+  {
+    scene->setSceneRect(QRectF(-180., 180., 360., -360.));
+  }
+  else if (!building.levels.empty())
   {
     const Level& level = building.levels[level_idx];
     scene->setSceneRect(

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -565,7 +565,6 @@ bool Editor::load_building(const QString& filename)
     previous_mouse_point = QPointF(level.drawing_width, level.drawing_height);
   }
 
-  map_view->update_tiles();
   create_scene();
 
   update_tables();
@@ -634,7 +633,7 @@ void Editor::restore_previous_viewport()
   map_view->setTransform(t);
   map_view->centerOn(QPointF(viewport_center_x, viewport_center_y));
   map_view->set_show_tiles(true);
-  map_view->update_tiles();
+  map_view->draw_tiles();
 }
 
 bool Editor::load_previous_building()
@@ -688,7 +687,6 @@ void Editor::building_new()
   building_save();
   zoom_reset();
   update_tables();
-  map_view->update_tiles();
 
   QSettings settings;
   settings.setValue(
@@ -866,7 +864,7 @@ void Editor::zoom_reset()
     }
   }
 
-  map_view->update_tiles();
+  map_view->draw_tiles();
 }
 
 void Editor::mouse_event(const MouseType t, QMouseEvent* e)
@@ -1620,6 +1618,7 @@ void Editor::property_editor_cell_changed(int row, int column)
 bool Editor::create_scene()
 {
   scene->clear();  // destroys the mouse_motion_* items if they are there
+  map_view->clear();  // reset the list of currently rendered tiles
   building.clear_scene();  // forget all pointers to the graphics items
   mouse_motion_line = nullptr;
   mouse_motion_model = nullptr;

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -82,7 +82,7 @@ Editor::Editor()
 
   scene = new QGraphicsScene(this);
 
-  map_view = new MapView(this);
+  map_view = new MapView(this, building);
   map_view->setScene(scene);
   map_view->setStyleSheet(
     "QToolTip { color: #000000; background-color: #ffff88; border: 0px; }");

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -570,10 +570,10 @@ bool Editor::load_building(const QString& filename)
   {
     // use the EPSG 3857 extents: "projected-meters"
     scene->setSceneRect(QRectF(
-      -M_PI * CoordinateSystem::WGS84_A,
-      M_PI * CoordinateSystem::WGS84_A,
-      2. * M_PI * CoordinateSystem::WGS84_A,
-      -2. * M_PI * CoordinateSystem::WGS84_A));
+        -M_PI * CoordinateSystem::WGS84_A,
+        M_PI * CoordinateSystem::WGS84_A,
+        2. * M_PI * CoordinateSystem::WGS84_A,
+        -2. * M_PI * CoordinateSystem::WGS84_A));
   }
   else if (!building.levels.empty())
   {

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -415,6 +415,11 @@ Editor::Editor()
     "QToolBar {background-color: #404040; border: none; spacing: 5px} QToolButton {background-color: #c0c0c0; color: blue; border: 1px solid black;} QToolButton:checked {background-color: #808080; color: red; border: 1px solid black;}");
   addToolBar(Qt::TopToolBarArea, toolbar);
 
+  // STATUS BAR
+  cache_size_label = new QLabel("cache size");
+  statusBar()->addPermanentWidget(cache_size_label);
+  map_view->update_cache_size_label(cache_size_label);
+
   ///////////////////////////////////////////////////////////
   // SET SIZE
   const int width =
@@ -445,6 +450,14 @@ Editor::Editor()
 
   load_model_names();
   level_table->setCurrentCell(level_idx, 0);
+
+  cache_size_update_timer = new QTimer;
+  connect(
+    cache_size_update_timer,
+    &QTimer::timeout,
+    this,
+    &Editor::cache_size_update_timer_timeout);
+  cache_size_update_timer->start(10 * 1000);
 }
 
 Editor::~Editor()
@@ -2746,4 +2759,10 @@ Layer* Editor::active_layer()
     return &level->layers[layer_idx - 1];
 
   return nullptr;
+}
+
+void Editor::cache_size_update_timer_timeout()
+{
+  printf("cache_size_update_timer_timeout()\n");
+  map_view->update_cache_size_label(cache_size_label);
 }

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -29,7 +29,6 @@
 #include <QListWidget>
 #include <QToolBar>
 
-#include <proj.h>
 #include <yaml-cpp/yaml.h>
 
 #include "ament_index_cpp/get_package_share_directory.hpp"
@@ -1468,8 +1467,11 @@ void Editor::populate_property_editor(const Vertex& vertex, const int index)
     property_editor_set_row(1, "x (m)", vertex.x);
     property_editor_set_row(2, "y (m)", vertex.y);
 
-    //property_editor_set_row(1, "lon (deg)", vertex.x, 3, true);
-    //property_editor_set_row(2, "lat (deg)", vertex.y, 3, true);
+    CoordinateSystem::WGS84Point wgs84_point =
+      building.coordinate_system.to_wgs84(vertex.x, vertex.y);
+
+    property_editor_set_row(3, "lon (deg)", wgs84_point.lon, 6, true);
+    property_editor_set_row(4, "lat (deg)", wgs84_point.lat, 6, true);
   }
   property_editor_set_row(
     5,

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -568,7 +568,12 @@ bool Editor::load_building(const QString& filename)
 
   if (building.coordinate_system.is_global())
   {
-    scene->setSceneRect(QRectF(-180., 180., 360., -360.));
+    // use the EPSG 3857 extents: "projected-meters"
+    scene->setSceneRect(QRectF(
+      -M_PI * CoordinateSystem::WGS84_A,
+      M_PI * CoordinateSystem::WGS84_A,
+      2. * M_PI * CoordinateSystem::WGS84_A,
+      -2. * M_PI * CoordinateSystem::WGS84_A));
   }
   else if (!building.levels.empty())
   {

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -1468,7 +1468,7 @@ void Editor::populate_property_editor(const Vertex& vertex, const int index)
     property_editor_set_row(2, "y (m)", vertex.y);
 
     CoordinateSystem::WGS84Point wgs84_point =
-      building.coordinate_system.to_wgs84(vertex.x, vertex.y);
+      building.coordinate_system.to_wgs84({vertex.x, vertex.y});
 
     property_editor_set_row(3, "lon (deg)", wgs84_point.lon, 6, true);
     property_editor_set_row(4, "lat (deg)", wgs84_point.lat, 6, true);

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -355,6 +355,12 @@ Editor::Editor()
     view_menu->addAction("&Models", this, &Editor::view_models);
   view_models_action->setCheckable(true);
   view_models_action->setChecked(true);
+
+  view_tiles_action =
+    view_menu->addAction("Map &Tiles", this, &Editor::view_tiles);
+  view_tiles_action->setCheckable(true);
+  view_tiles_action->setChecked(true);
+
   view_menu->addSeparator();
 
   view_menu->addAction("&Reset zoom level", this, &Editor::zoom_reset);
@@ -555,6 +561,7 @@ bool Editor::load_building(const QString& filename)
     previous_mouse_point = QPointF(level.drawing_width, level.drawing_height);
   }
 
+  map_view->update_tiles();
   create_scene();
 
   update_tables();
@@ -656,7 +663,7 @@ void Editor::building_new()
   Ui::NewBuildingDialog new_building_dialog_ui;
   new_building_dialog_ui.setupUi(&new_building_dialog);
   new_building_dialog_ui.name_line_edit->setText(
-      QString::fromStdString(guessed_building_name));
+    QString::fromStdString(guessed_building_name));
 
   if (new_building_dialog.exec() != QDialog::Accepted)
     return;
@@ -673,6 +680,7 @@ void Editor::building_new()
 
   create_scene();
   building_save();
+  zoom_reset();
   update_tables();
 
   QSettings settings;
@@ -816,6 +824,12 @@ void Editor::view_models()
   create_scene();
 }
 
+void Editor::view_tiles()
+{
+  map_view->set_show_tiles(view_tiles_action->isChecked());
+  create_scene();
+}
+
 void Editor::zoom_reset()
 {
   const double viewport_scale = 1.0;
@@ -844,6 +858,8 @@ void Editor::zoom_reset()
       map_view->centerOn(QPointF(xc, yc));
     }
   }
+
+  map_view->update_tiles();
 }
 
 void Editor::mouse_event(const MouseType t, QMouseEvent* e)
@@ -1602,6 +1618,9 @@ bool Editor::create_scene()
   mouse_motion_model = nullptr;
   mouse_motion_ellipse = nullptr;
   mouse_motion_polygon = nullptr;
+
+  // first draw the background map tiles (if requested)
+  map_view->draw_tiles();
 
   building.draw(scene, level_idx, editor_models, rendering_options);
 

--- a/rmf_traffic_editor/gui/editor.h
+++ b/rmf_traffic_editor/gui/editor.h
@@ -362,6 +362,10 @@ private:
   RotateModelCommand* latest_rotate_model = nullptr;
 
   void sanity_check();
+
+  QLabel* cache_size_label = nullptr;
+  QTimer* cache_size_update_timer = nullptr;
+  void cache_size_update_timer_timeout();
 };
 
 #endif

--- a/rmf_traffic_editor/gui/editor.h
+++ b/rmf_traffic_editor/gui/editor.h
@@ -154,6 +154,7 @@ private:
 
   void zoom_reset();
   void view_models();
+  void view_tiles();
 
   void help_about();
 
@@ -188,6 +189,7 @@ private:
   MapView* map_view = nullptr;
 
   QAction* view_models_action = nullptr;
+  QAction* view_tiles_action = nullptr;
 
   const QString tool_id_to_string(const int id);
   QButtonGroup* tool_button_group = nullptr;

--- a/rmf_traffic_editor/gui/layer.cpp
+++ b/rmf_traffic_editor/gui/layer.cpp
@@ -171,12 +171,13 @@ void Layer::draw(
 
   // for purposes of the origin mark, let's say the origin is the center
   // of the first pixel of the image
+  const double y_flip = coordinate_system.is_y_flipped() ? -1 : 1;
   const QPointF origin(
     transform.translation().x() / level_meters_per_pixel
     + 0.5 * transform.scale() / level_meters_per_pixel *
     cos(transform.yaw() - M_PI / 4),
     transform.translation().y() / level_meters_per_pixel
-    - 0.5 * transform.scale() / level_meters_per_pixel *
+    + y_flip * 0.5 * transform.scale() / level_meters_per_pixel *
     sin(transform.yaw() - M_PI / 4));
 
   scene->addEllipse(
@@ -188,9 +189,8 @@ void Layer::draw(
 
   QPointF x_arrow(
     origin.x() + 2.0 * origin_radius * cos(transform.yaw()),
-    origin.y() - 2.0 * origin_radius * sin(transform.yaw()));
+    origin.y() + y_flip * 2.0 * origin_radius * sin(transform.yaw()));
   scene->addLine(QLineF(origin, x_arrow), origin_pen);
-
 
   for (Feature& feature : features)
     feature.draw(scene, color, transform, level_meters_per_pixel);

--- a/rmf_traffic_editor/gui/layer.cpp
+++ b/rmf_traffic_editor/gui/layer.cpp
@@ -33,7 +33,10 @@ Layer::~Layer()
 {
 }
 
-bool Layer::from_yaml(const std::string& _name, const YAML::Node& y)
+bool Layer::from_yaml(
+  const std::string& _name,
+  const YAML::Node& y,
+  const CoordinateSystem& coordinate_system)
 {
   if (!y.IsMap())
     throw std::runtime_error("Layer::from_yaml() expected a map");
@@ -77,7 +80,7 @@ bool Layer::from_yaml(const std::string& _name, const YAML::Node& y)
     visible = y["visible"].as<bool>();
 
   if (y["transform"] && y["transform"].IsMap())
-    transform.from_yaml(y["transform"]);
+    transform.from_yaml(y["transform"], coordinate_system);
 
   if (y["color"] && y["color"].IsSequence() && y["color"].size() == 4)
     color = QColor::fromRgbF(
@@ -121,7 +124,7 @@ bool Layer::load_image()
   return true;
 }
 
-YAML::Node Layer::to_yaml() const
+YAML::Node Layer::to_yaml(const CoordinateSystem& coordinate_system) const
 {
   YAML::Node y;
   y["filename"] = filename;
@@ -136,7 +139,7 @@ YAML::Node Layer::to_yaml() const
   for (const auto& feature : features)
     y["features"].push_back(feature.to_yaml());
 
-  y["transform"] = transform.to_yaml();
+  y["transform"] = transform.to_yaml(coordinate_system);
 
   return y;
 }

--- a/rmf_traffic_editor/gui/layer.h
+++ b/rmf_traffic_editor/gui/layer.h
@@ -58,8 +58,12 @@ public:
 
   std::vector<Feature> features;
 
-  bool from_yaml(const std::string& name, const YAML::Node& data);
-  YAML::Node to_yaml() const;
+  bool from_yaml(
+    const std::string& name,
+    const YAML::Node& data,
+    const CoordinateSystem& coordinate_system);
+
+  YAML::Node to_yaml(const CoordinateSystem& coordinate_system) const;
 
   bool load_image();
   void colorize_image();

--- a/rmf_traffic_editor/gui/layer_dialog.h
+++ b/rmf_traffic_editor/gui/layer_dialog.h
@@ -32,6 +32,8 @@ public:
   LayerDialog(QWidget* parent, Layer& _layer, bool edit_mode = true);
   ~LayerDialog();
 
+  void set_center(const double x, const double y);
+
 private:
   Layer& layer;
   bool _edit_mode = true;
@@ -44,6 +46,7 @@ private:
   QLineEdit* rotation_line_edit;
 
   QPushButton* filename_button;
+  QPushButton* center_in_window_button;
   QPushButton* ok_button, * cancel_button;
 
   void update_layer();
@@ -52,9 +55,11 @@ private slots:
   void filename_button_clicked();
   void ok_button_clicked();
   void filename_line_edited(const QString& text);
+  void center_in_window_clicked();
 
 signals:
   void redraw();
+  void center_layer();
 };
 
 #endif

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -116,11 +116,6 @@ bool Level::from_yaml(
     }
   }
 
-  if (_data["flattened_x_offset"])
-    flattened_x_offset = _data["flattened_x_offset"].as<double>();
-  if (_data["flattened_y_offset"])
-    flattened_y_offset = _data["flattened_y_offset"].as<double>();
-
   load_yaml_edge_sequence(_data, "lanes", Edge::LANE);
   load_yaml_edge_sequence(_data, "walls", Edge::WALL);
   load_yaml_edge_sequence(_data, "measurements", Edge::MEAS);
@@ -220,8 +215,6 @@ YAML::Node Level::to_yaml() const
     y["y_meters"] = y_meters;
   }
   y["elevation"] = elevation;
-  y["flattened_x_offset"] = flattened_x_offset;
-  y["flattened_y_offset"] = flattened_y_offset;
 
   for (const auto& v : vertices)
     y["vertices"].push_back(v.to_yaml());

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -1129,7 +1129,6 @@ void Level::draw(
   else
   {
     // leave the SceneRect as-is; no need to adjust it for each level
-    //vertex_radius = 0.1 * 0.000009009;  // meters-at-equator to degrees
     vertex_radius = 0.1 * 0.00009009;  // meters-at-equator to degrees
   }
 

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -137,7 +137,7 @@ bool Level::from_yaml(
     for (YAML::const_iterator it = ys.begin(); it != ys.end(); ++it)
     {
       Model m;
-      m.from_yaml(*it, this->name);
+      m.from_yaml(*it, this->name, coordinate_system);
       models.push_back(m);
     }
   }
@@ -267,7 +267,7 @@ YAML::Node Level::to_yaml(const CoordinateSystem& coordinate_system) const
   }
 
   for (const auto& model : models)
-    y["models"].push_back(model.to_yaml());
+    y["models"].push_back(model.to_yaml(coordinate_system));
 
   for (const auto& polygon : polygons)
   {

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -1103,24 +1103,34 @@ void Level::draw(
   const CoordinateSystem& coordinate_system)
 {
   printf("Level::draw()\n");
-  if (drawing_filename.size() && _drawing_visible)
+  if (!coordinate_system.is_global())
   {
-    const double extra_scroll_area_width = 1.0 * drawing_width;
-    const double extra_scroll_area_height = 1.0 * drawing_height;
-    scene->setSceneRect(
-      QRectF(
-        -extra_scroll_area_width,
-        -extra_scroll_area_height,
-        drawing_width + 2 * extra_scroll_area_width,
-        drawing_height + 2 * extra_scroll_area_height));
-    scene->addPixmap(floorplan_pixmap);
+    vertex_radius = 0.1;
+    if (drawing_filename.size() && _drawing_visible)
+    {
+      const double extra_scroll_area_width = 1.0 * drawing_width;
+      const double extra_scroll_area_height = 1.0 * drawing_height;
+      scene->setSceneRect(
+        QRectF(
+          -extra_scroll_area_width,
+          -extra_scroll_area_height,
+          drawing_width + 2 * extra_scroll_area_width,
+          drawing_height + 2 * extra_scroll_area_height));
+      scene->addPixmap(floorplan_pixmap);
+    }
+    else
+    {
+      const double w = x_meters / drawing_meters_per_pixel;
+      const double h = y_meters / drawing_meters_per_pixel;
+      scene->setSceneRect(QRectF(0, 0, w, h));
+      scene->addRect(0, 0, w, h, Qt::NoPen, Qt::white);
+    }
   }
   else
   {
-    const double w = x_meters / drawing_meters_per_pixel;
-    const double h = y_meters / drawing_meters_per_pixel;
-    scene->setSceneRect(QRectF(0, 0, w, h));
-    scene->addRect(0, 0, w, h, Qt::NoPen, Qt::white);
+    // leave the SceneRect as-is; no need to adjust it for each level
+    //vertex_radius = 0.1 * 0.000009009;  // meters-at-equator to degrees
+    vertex_radius = 0.1 * 0.00009009;  // meters-at-equator to degrees
   }
 
   draw_polygons(scene);

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -1103,9 +1103,13 @@ void Level::draw(
   const CoordinateSystem& coordinate_system)
 {
   printf("Level::draw()\n");
+  vertex_radius = 0.1;
+
   if (!coordinate_system.is_global())
   {
-    vertex_radius = 0.1;
+    // If we're using an image-defined coordinate system, we should
+    // adjust the SceneRect to match the reference image, so the
+    // scrollbar range makes sense for this level.
     if (drawing_filename.size() && _drawing_visible)
     {
       const double extra_scroll_area_width = 1.0 * drawing_width;
@@ -1125,11 +1129,6 @@ void Level::draw(
       scene->setSceneRect(QRectF(0, 0, w, h));
       scene->addRect(0, 0, w, h, Qt::NoPen, Qt::white);
     }
-  }
-  else
-  {
-    // leave the SceneRect as-is; no need to adjust it for each level
-    vertex_radius = 0.1 * 0.00009009;  // meters-at-equator to degrees
   }
 
   draw_polygons(scene);

--- a/rmf_traffic_editor/gui/level.h
+++ b/rmf_traffic_editor/gui/level.h
@@ -87,7 +87,7 @@ public:
     const std::string& name,
     const YAML::Node& data,
     const CoordinateSystem& coordinate_system);
-  YAML::Node to_yaml() const;
+  YAML::Node to_yaml(const CoordinateSystem& coordinate_system) const;
 
   const Feature* find_feature(const QUuid& id) const;
   const Feature* find_feature(const double x, const double y) const;
@@ -197,8 +197,6 @@ private:
     const YAML::Node& data,
     const char* sequence_name,
     const Edge::Type type);
-
-  bool parse_vertices(const YAML::Node& _data);
 
   bool _drawing_visible = true;
 

--- a/rmf_traffic_editor/gui/level.h
+++ b/rmf_traffic_editor/gui/level.h
@@ -76,11 +76,6 @@ public:
   double x_meters = 10.0;  // manually specified if no drawing supplied
   double y_meters = 10.0;  // manually specified if no drawing supplied
 
-  // when generating the building in "flattened" mode, the levels have
-  // to be offset in the (x, y) plane to avoid clobbering each other.
-  double flattened_x_offset = 0.0;
-  double flattened_y_offset = 0.0;
-
   std::vector<Model> models;
   std::vector<Fiducial> fiducials;
   std::vector<Feature> floorplan_features;

--- a/rmf_traffic_editor/gui/level.h
+++ b/rmf_traffic_editor/gui/level.h
@@ -71,7 +71,7 @@ public:
   int drawing_height = 0;
   double drawing_meters_per_pixel = 0.05;
   double elevation = 0.0;
-  const double vertex_radius = 0.1;  // meters
+  double vertex_radius = 0.1;  // meters or degrees, depending on coordinates
 
   double x_meters = 10.0;  // manually specified if no drawing supplied
   double y_meters = 10.0;  // manually specified if no drawing supplied

--- a/rmf_traffic_editor/gui/level_dialog.cpp
+++ b/rmf_traffic_editor/gui/level_dialog.cpp
@@ -72,20 +72,6 @@ LevelDialog::LevelDialog(Level& _level,
   y_hbox->addWidget(new QLabel("y dimension (meters):"));
   y_hbox->addWidget(y_line_edit);
 
-  flattened_x_offset_line_edit =
-    new QLineEdit(QString::number(building_level.flattened_x_offset));
-  QHBoxLayout* flattened_x_offset_hbox = new QHBoxLayout;
-  flattened_x_offset_hbox->addWidget(
-    new QLabel("flattened x offset (meters)"));
-  flattened_x_offset_hbox->addWidget(flattened_x_offset_line_edit);
-
-  flattened_y_offset_line_edit =
-    new QLineEdit(QString::number(building_level.flattened_y_offset));
-  QHBoxLayout* flattened_y_offset_hbox = new QHBoxLayout;
-  flattened_y_offset_hbox->addWidget(
-    new QLabel("flattened y offset (meters)"));
-  flattened_y_offset_hbox->addWidget(flattened_y_offset_line_edit);
-
   QHBoxLayout* bottom_buttons_hbox = new QHBoxLayout;
   bottom_buttons_hbox->addWidget(cancel_button);
   bottom_buttons_hbox->addWidget(ok_button);
@@ -107,8 +93,6 @@ LevelDialog::LevelDialog(Level& _level,
   top_vbox->addLayout(instr_hbox);
   top_vbox->addLayout(x_hbox);
   top_vbox->addLayout(y_hbox);
-  top_vbox->addLayout(flattened_x_offset_hbox);
-  top_vbox->addLayout(flattened_y_offset_hbox);
   // todo: some sort of separator (?)
   top_vbox->addLayout(bottom_buttons_hbox);
 
@@ -219,11 +203,6 @@ void LevelDialog::ok_button_clicked()
     building_level.x_meters = 0.0;
     building_level.y_meters = 0.0;
   }
-
-  building_level.flattened_x_offset =
-    flattened_x_offset_line_edit->text().toDouble();
-  building_level.flattened_y_offset =
-    flattened_y_offset_line_edit->text().toDouble();
 
   building_level.calculate_scale(building.coordinate_system);
   accept();

--- a/rmf_traffic_editor/gui/level_dialog.h
+++ b/rmf_traffic_editor/gui/level_dialog.h
@@ -36,8 +36,6 @@ private:
 
   QLineEdit* name_line_edit, * drawing_filename_line_edit;
   QLineEdit* x_line_edit, * y_line_edit;
-  QLineEdit* flattened_x_offset_line_edit;
-  QLineEdit* flattened_y_offset_line_edit;
   QLineEdit* elevation_line_edit;
   QPushButton* drawing_filename_button;
   QPushButton* ok_button, * cancel_button;

--- a/rmf_traffic_editor/gui/level_dialog_wgs84.ui
+++ b/rmf_traffic_editor/gui/level_dialog_wgs84.ui
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LevelDialogWGS84</class>
+ <widget class="QDialog" name="LevelDialogWGS84">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>280</width>
+    <height>133</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="name_line_edit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="elevation_label">
+     <property name="text">
+      <string>Elevation (meters):</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="elevation_line_edit">
+     <property name="inputMethodHints">
+      <set>Qt::ImhNone</set>
+     </property>
+     <property name="inputMask">
+      <string/>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::MinimumExpanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="name_label">
+     <property name="text">
+      <string>Level name:</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>name_line_edit</tabstop>
+  <tabstop>elevation_line_edit</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>LevelDialogWGS84</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>273</x>
+     <y>121</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>189</x>
+     <y>75</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>LevelDialogWGS84</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>273</x>
+     <y>121</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>189</x>
+     <y>75</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/rmf_traffic_editor/gui/main.cpp
+++ b/rmf_traffic_editor/gui/main.cpp
@@ -54,6 +54,8 @@ int main(int argc, char* argv[])
 
   editor.show();
 
+  // Current understanding is that the viewport needs to be restored
+  // after the editor.show() is called
   editor.restore_previous_viewport();
 
   return app.exec();

--- a/rmf_traffic_editor/gui/map_tile_cache.cpp
+++ b/rmf_traffic_editor/gui/map_tile_cache.cpp
@@ -61,7 +61,7 @@ void MapTileCache::set(const int zoom, const int x, const int y, const QPixmap& 
   
   if (cache.size() > MAX_CACHE_SIZE)
   {
-    printf("trimming oldest element from the tile cache...\n");
+    printf("cache has %d elements. trimming oldest element...\n", (int)cache.size());
     //MapTileCacheElement old = cache.back();
     //printf("about to delete z=%d, x=%d, y=%d...\n", old.zoom, old.x, old.y);
     //delete old.pixmap;

--- a/rmf_traffic_editor/gui/map_tile_cache.cpp
+++ b/rmf_traffic_editor/gui/map_tile_cache.cpp
@@ -27,7 +27,7 @@ MapTileCache::~MapTileCache()
 {
 }
 
-QPixmap* MapTileCache::get(
+std::optional<const QPixmap> MapTileCache::get(
   const int zoom,
   const int x,
   const int y) const
@@ -35,20 +35,18 @@ QPixmap* MapTileCache::get(
   for (auto it = cache.begin(); it != cache.end(); ++it)
   {
     if (it->zoom == zoom && it->x == x && it->y == y)
-      return it->pixmap;
+      return {it->pixmap};
   }
-  return nullptr;
+  return {};
 }
 
-void MapTileCache::set(const int zoom, const int x, const int y, QPixmap* pixmap)
+void MapTileCache::set(const int zoom, const int x, const int y, const QPixmap& pixmap)
 {
   for (auto it = cache.begin(); it != cache.end(); ++it)
   {
     if (it->zoom == zoom && it->x == x && it->y == y)
     {
       it->pixmap = pixmap;
-      if (it->pixmap)
-        delete it->pixmap;
       return;
     }
   }
@@ -63,8 +61,11 @@ void MapTileCache::set(const int zoom, const int x, const int y, QPixmap* pixmap
   
   if (cache.size() > MAX_CACHE_SIZE)
   {
-    MapTileCacheElement old = cache.back();
-    delete old.pixmap;
+    printf("trimming oldest element from the tile cache...\n");
+    //MapTileCacheElement old = cache.back();
+    //printf("about to delete z=%d, x=%d, y=%d...\n", old.zoom, old.x, old.y);
+    //delete old.pixmap;
+    //printf("done\n");
     cache.pop_back();
   }
 }

--- a/rmf_traffic_editor/gui/map_tile_cache.cpp
+++ b/rmf_traffic_editor/gui/map_tile_cache.cpp
@@ -19,9 +19,11 @@
 
 MapTileCache::MapTileCache()
 {
+  /*
   std::string tile_cache_root = QStandardPaths::writableLocation(
     QStandardPaths::CacheLocation).toStdString();
   printf("tile_cache_root: %s\n", tile_cache_root.c_str());
+  */
 }
 
 MapTileCache::~MapTileCache()
@@ -63,10 +65,11 @@ void MapTileCache::set(
   e.pixmap = pixmap;
 
   cache.push_front(e);
-  
+
   if (cache.size() > MAX_CACHE_SIZE)
   {
-    printf("cache has %d elements. trimming oldest element...\n", (int)cache.size());
+    printf("cache has %d elements. trimming oldest element...\n",
+      (int)cache.size());
     //MapTileCacheElement old = cache.back();
     //printf("about to delete z=%d, x=%d, y=%d...\n", old.zoom, old.x, old.y);
     //delete old.pixmap;

--- a/rmf_traffic_editor/gui/map_tile_cache.cpp
+++ b/rmf_traffic_editor/gui/map_tile_cache.cpp
@@ -19,8 +19,8 @@
 
 MapTileCache::MapTileCache()
 {
-  // use a deque so that LRU cleanup of the cache is fast?
-  // or use an unordered_map so that lookup is fast?
+  std::string tile_cache_root = QStandardPaths::writableLocation(QStandardPaths::CacheLocation).toStdString();
+  printf("tile_cache_root: %s\n", tile_cache_root.c_str());
 }
 
 MapTileCache::~MapTileCache()

--- a/rmf_traffic_editor/gui/map_tile_cache.cpp
+++ b/rmf_traffic_editor/gui/map_tile_cache.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019-2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "map_tile_cache.h"
+
+MapTileCache::MapTileCache()
+{
+  // use a deque so that LRU cleanup of the cache is fast?
+  // or use an unordered_map so that lookup is fast?
+}
+
+MapTileCache::~MapTileCache()
+{
+}
+
+bool MapTileCache::contains(const int zoom, const int x, const int y) const
+{
+  return false;
+}
+
+const QPixmap* const MapTileCache::get(const int zoom, const int x, const int y) const
+{
+  return nullptr;
+}
+
+void MapTileCache::set(const int zoom, const int x, const int y, QPixmap* item)
+{
+}

--- a/rmf_traffic_editor/gui/map_tile_cache.cpp
+++ b/rmf_traffic_editor/gui/map_tile_cache.cpp
@@ -19,7 +19,8 @@
 
 MapTileCache::MapTileCache()
 {
-  std::string tile_cache_root = QStandardPaths::writableLocation(QStandardPaths::CacheLocation).toStdString();
+  std::string tile_cache_root = QStandardPaths::writableLocation(
+    QStandardPaths::CacheLocation).toStdString();
   printf("tile_cache_root: %s\n", tile_cache_root.c_str());
 }
 
@@ -40,7 +41,11 @@ std::optional<const QPixmap> MapTileCache::get(
   return {};
 }
 
-void MapTileCache::set(const int zoom, const int x, const int y, const QPixmap& pixmap)
+void MapTileCache::set(
+  const int zoom,
+  const int x,
+  const int y,
+  const QPixmap& pixmap)
 {
   for (auto it = cache.begin(); it != cache.end(); ++it)
   {

--- a/rmf_traffic_editor/gui/map_tile_cache.cpp
+++ b/rmf_traffic_editor/gui/map_tile_cache.cpp
@@ -33,7 +33,7 @@ MapTileCache::MapTileCache()
   {
     printf("creating tile cache directory in %s\n",
       tile_cache_root.toStdString().c_str());
-    QDir::root().mkpath(tile_cache_root); 
+    QDir::root().mkpath(tile_cache_root);
   }
   getSize();
 }

--- a/rmf_traffic_editor/gui/map_tile_cache.cpp
+++ b/rmf_traffic_editor/gui/map_tile_cache.cpp
@@ -51,10 +51,10 @@ std::optional<const QByteArray> MapTileCache::get(
   QFile file(path);
   if (!file.open(QIODevice::ReadOnly))
   {
-    printf("cache miss: %d %d %d\n", zoom, x, y);
+    // printf("cache miss: %d %d %d\n", zoom, x, y);
     return {};
   }
-  printf("cache hit: %s\n", path.toStdString().c_str());
+  // printf("cache hit: %s\n", path.toStdString().c_str());
   return {file.readAll()};
 }
 

--- a/rmf_traffic_editor/gui/map_tile_cache.cpp
+++ b/rmf_traffic_editor/gui/map_tile_cache.cpp
@@ -27,16 +27,44 @@ MapTileCache::~MapTileCache()
 {
 }
 
-bool MapTileCache::contains(const int zoom, const int x, const int y) const
+QPixmap* MapTileCache::get(
+  const int zoom,
+  const int x,
+  const int y) const
 {
-  return false;
-}
-
-const QPixmap* const MapTileCache::get(const int zoom, const int x, const int y) const
-{
+  for (auto it = cache.begin(); it != cache.end(); ++it)
+  {
+    if (it->zoom == zoom && it->x == x && it->y == y)
+      return it->pixmap;
+  }
   return nullptr;
 }
 
-void MapTileCache::set(const int zoom, const int x, const int y, QPixmap* item)
+void MapTileCache::set(const int zoom, const int x, const int y, QPixmap* pixmap)
 {
+  for (auto it = cache.begin(); it != cache.end(); ++it)
+  {
+    if (it->zoom == zoom && it->x == x && it->y == y)
+    {
+      it->pixmap = pixmap;
+      if (it->pixmap)
+        delete it->pixmap;
+      return;
+    }
+  }
+  // if we get here, we didn't find it, so we should create a cache entry
+  MapTileCacheElement e;
+  e.zoom = zoom;
+  e.x = x;
+  e.y = y;
+  e.pixmap = pixmap;
+
+  cache.push_front(e);
+  
+  if (cache.size() > MAX_CACHE_SIZE)
+  {
+    MapTileCacheElement old = cache.back();
+    delete old.pixmap;
+    cache.pop_back();
+  }
 }

--- a/rmf_traffic_editor/gui/map_tile_cache.h
+++ b/rmf_traffic_editor/gui/map_tile_cache.h
@@ -19,6 +19,8 @@
 #define TRAFFIC_EDITOR_MAP_TILE_CACHE_H
 
 #include <deque>
+#include <optional>
+
 #include <QPixmap>
 
 class MapTileCache
@@ -27,8 +29,8 @@ public:
   MapTileCache();
   ~MapTileCache();
 
-  QPixmap* get(const int zoom, const int x, const int y) const;
-  void set(const int zoom, const int x, const int y, QPixmap* pixmap);
+  std::optional<const QPixmap> get(const int zoom, const int x, const int y) const;
+  void set(const int zoom, const int x, const int y, const QPixmap& pixmap);
 
 private:
   struct MapTileCacheElement
@@ -36,11 +38,11 @@ private:
     int zoom = 0;
     int x = 0;
     int y = 0;
-    QPixmap* pixmap = nullptr;
+    QPixmap pixmap;
   };
 
   std::deque<MapTileCacheElement> cache;
-  const size_t MAX_CACHE_SIZE = 100;
+  const size_t MAX_CACHE_SIZE = 1000;
 };
 
 #endif

--- a/rmf_traffic_editor/gui/map_tile_cache.h
+++ b/rmf_traffic_editor/gui/map_tile_cache.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2019-2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef TRAFFIC_EDITOR_MAP_TILE_CACHE_H
+#define TRAFFIC_EDITOR_MAP_TILE_CACHE_H
+
+#include <QPixmap>
+
+class MapTileCache
+{
+public:
+  MapTileCache();
+  ~MapTileCache();
+
+  bool contains(const int zoom, const int x, const int y) const;
+  const QPixmap* const get(const int zoom, const int x, const int y) const;
+  void set(const int zoom, const int x, const int y, QPixmap* item);
+
+private:
+  // std::
+};
+
+#endif

--- a/rmf_traffic_editor/gui/map_tile_cache.h
+++ b/rmf_traffic_editor/gui/map_tile_cache.h
@@ -40,6 +40,14 @@ public:
     const int y,
     const QByteArray& bytes);
 
+  struct CacheSize
+  {
+    int bytes = 0;
+    int files = 0;
+  };
+
+  CacheSize getSize();
+
 private:
   /*
   struct MapTileCacheElement
@@ -60,6 +68,9 @@ private:
     int zoom,
     int x,
     int y) const;
+
+  bool modified_since_last_size_check = true;  // for an initial size check
+  CacheSize last_size = {0, 0};
 };
 
 #endif

--- a/rmf_traffic_editor/gui/map_tile_cache.h
+++ b/rmf_traffic_editor/gui/map_tile_cache.h
@@ -28,7 +28,7 @@ public:
   ~MapTileCache();
 
   QPixmap* get(const int zoom, const int x, const int y) const;
-  void set(const int zoom, const int x, const int y, QPixmap* item);
+  void set(const int zoom, const int x, const int y, QPixmap* pixmap);
 
 private:
   struct MapTileCacheElement

--- a/rmf_traffic_editor/gui/map_tile_cache.h
+++ b/rmf_traffic_editor/gui/map_tile_cache.h
@@ -18,6 +18,7 @@
 #ifndef TRAFFIC_EDITOR_MAP_TILE_CACHE_H
 #define TRAFFIC_EDITOR_MAP_TILE_CACHE_H
 
+#include <deque>
 #include <QPixmap>
 
 class MapTileCache
@@ -26,12 +27,20 @@ public:
   MapTileCache();
   ~MapTileCache();
 
-  bool contains(const int zoom, const int x, const int y) const;
-  const QPixmap* const get(const int zoom, const int x, const int y) const;
+  QPixmap* get(const int zoom, const int x, const int y) const;
   void set(const int zoom, const int x, const int y, QPixmap* item);
 
 private:
-  // std::
+  struct MapTileCacheElement
+  {
+    int zoom = 0;
+    int x = 0;
+    int y = 0;
+    QPixmap* pixmap = nullptr;
+  };
+
+  std::deque<MapTileCacheElement> cache;
+  const size_t MAX_CACHE_SIZE = 100;
 };
 
 #endif

--- a/rmf_traffic_editor/gui/map_tile_cache.h
+++ b/rmf_traffic_editor/gui/map_tile_cache.h
@@ -29,7 +29,7 @@ public:
   MapTileCache();
   ~MapTileCache();
 
-  std::optional<const QPixmap> get(
+  std::optional<const QByteArray> get(
     const int zoom,
     const int x,
     const int y) const;
@@ -38,9 +38,10 @@ public:
     const int zoom,
     const int x,
     const int y,
-    const QPixmap& pixmap);
+    const QByteArray& bytes);
 
 private:
+  /*
   struct MapTileCacheElement
   {
     int zoom = 0;
@@ -48,9 +49,17 @@ private:
     int y = 0;
     QPixmap pixmap;
   };
+  */
 
-  std::deque<MapTileCacheElement> cache;
-  const size_t MAX_CACHE_SIZE = 1000;
+  // std::deque<MapTileCacheElement> cache;
+  // const size_t MAX_CACHE_SIZE = 1000;
+
+  QString tile_cache_root;
+
+  QString tile_path(
+    int zoom,
+    int x,
+    int y) const;
 };
 
 #endif

--- a/rmf_traffic_editor/gui/map_tile_cache.h
+++ b/rmf_traffic_editor/gui/map_tile_cache.h
@@ -29,8 +29,16 @@ public:
   MapTileCache();
   ~MapTileCache();
 
-  std::optional<const QPixmap> get(const int zoom, const int x, const int y) const;
-  void set(const int zoom, const int x, const int y, const QPixmap& pixmap);
+  std::optional<const QPixmap> get(
+    const int zoom,
+    const int x,
+    const int y) const;
+
+  void set(
+    const int zoom,
+    const int x,
+    const int y,
+    const QPixmap& pixmap);
 
 private:
   struct MapTileCacheElement

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -97,7 +97,7 @@ void MapView::mouseMoveEvent(QMouseEvent* e)
   e->ignore();
 }
 
-void MapView::resizeEvent(QResizeEvent *e)
+void MapView::resizeEvent(QResizeEvent *)
 {
   update_tiles();
 }
@@ -130,8 +130,13 @@ void MapView::update_tiles()
   if (!show_tiles || !building.coordinate_system.has_tiles())
     return;
   printf("MapView::update_tiles()\n");
+  const int viewport_width = viewport()->width();
+  const int viewport_height = viewport()->height();
   QPointF ul = mapToScene(QPoint(0, 0));
-  QPointF lr = mapToScene(QPoint(viewport()->width(), viewport()->height()));
+  QPointF lr = mapToScene(QPoint(viewport_width, viewport_height));
   printf("  ul: (%.3f, %.3f)\n", ul.x(), ul.y());
   printf("  lr: (%.3f, %.3f)\n", lr.x(), lr.y());
+  const double lon_extent = lr.x() - ul.x();
+  printf("  lon extent: %.3f\n", lon_extent);
+  const double ntiles_x = viewport_width / 256.0;
 }

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -52,6 +52,7 @@ void MapView::wheelEvent(QWheelEvent* e)
   // translate the map back so hopefully the mouse stays in the same spot
   const QPointF diff = p_end - p_start;
   translate(diff.x(), diff.y());
+  update_tiles();
 }
 
 void MapView::mousePressEvent(QMouseEvent* e)
@@ -90,9 +91,15 @@ void MapView::mouseMoveEvent(QMouseEvent* e)
     pan_start_x = e->x();
     pan_start_y = e->y();
     e->accept();
+    update_tiles();
     return;
   }
   e->ignore();
+}
+
+void MapView::resizeEvent(QResizeEvent *e)
+{
+  update_tiles();
 }
 
 void MapView::zoom_fit(int level_index)
@@ -111,10 +118,20 @@ void MapView::zoom_fit(int level_index)
   //centerOn(cx, cy);
 }
 
-void MapView::draw_osm_tiles()
+void MapView::draw_tiles()
 {
-  if (!show_osm_tiles)
+  if (!show_tiles || !building.coordinate_system.has_tiles())
     return;
-  if (!building.coordinate_system.has_tiles())
+  printf("MapView::draw_tiles()\n");
+}
+
+void MapView::update_tiles()
+{
+  if (!show_tiles || !building.coordinate_system.has_tiles())
     return;
+  printf("MapView::update_tiles()\n");
+  QPointF ul = mapToScene(QPoint(0, 0));
+  QPointF lr = mapToScene(QPoint(viewport()->width(), viewport()->height()));
+  printf("  ul: (%.3f, %.3f)\n", ul.x(), ul.y());
+  printf("  lr: (%.3f, %.3f)\n", lr.x(), lr.y());
 }

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -16,6 +16,8 @@
 */
 
 #include <cmath>
+#include <QCoreApplication>
+#include <QGraphicsColorizeEffect>
 #include <QLabel>
 #include <QScrollBar>
 #include <QNetworkAccessManager>
@@ -38,10 +40,14 @@ MapView::MapView(QWidget* parent, const Building& building_)
   setMouseTracking(true);
   viewport()->setMouseTracking(true);
   setTransformationAnchor(QGraphicsView::NoAnchor);
+  setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+  setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
 }
 
 void MapView::wheelEvent(QWheelEvent* e)
 {
+  e->accept();
+
   // calculate the map position before we scale things
   const QPointF p_start = mapToScene(e->pos());
 
@@ -59,16 +65,15 @@ void MapView::wheelEvent(QWheelEvent* e)
       if (scale_factor > 0.01)
         scale(0.75, 0.75);
     }
+    // calculate the mouse map position now that we've scaled
+    const QPointF p_end = mapToScene(e->pos());
+
+    // translate the map back so hopefully the mouse stays in the same spot
+    const QPointF diff = p_end - p_start;
+    translate(diff.x(), diff.y());
   }
   else
   {
-    //const double dx = transform().dx();
-    //const double dy = transform().dy();
-    //const double scale_pow2 = pow(2, round(log(scale_factor)/log(2)));
-    //resetTransform();
-    //scale(scale_pow2, scale_pow2);
-    //translate(dx, dy);
-
     // in the global frame when we're rendering map tiles,
     // we want to keep to an even scaling of the tile
     // so it doesn't have too many aliasing effects
@@ -81,31 +86,46 @@ void MapView::wheelEvent(QWheelEvent* e)
     }
     else
     {
-      // double min_scale_factor = 0.01;
-
       // go to the nearest power of 2 below where we are
       // const double next_scale = pow(2, round(log(scale_factor/2)/log(2)));
 
       // limit to 2^-17 = 0.0000076294
-      //if (next_scale < 0.0000076294)
-      //  next_scale = 0.0000076294;
 
       if (scale_factor > 0.0000076294)
         scale(0.5, 0.5);
     }
+
+    // calculate the mouse map position now that we've scaled
+    const QPointF p_end = mapToScene(e->pos());
+
+    // translate the map back so hopefully the mouse stays in the same spot
+    const QPointF diff = p_end - p_start;
+    translate(diff.x(), diff.y());
+
+    const int viewport_w = viewport()->width();
+    const int viewport_h = viewport()->height();
+    QPointF ul = mapToScene(QPoint(0, 0));
+    QPointF lr = mapToScene(QPoint(viewport_w, viewport_h));
+    const double scene_w = lr.x() - ul.x();
+    const double scene_h = ul.y() - lr.y();
+
+    if (scene_w < 0.1 * M_PI * CoordinateSystem::WGS84_A)
+    {
+      const int n = 10;
+      setSceneRect(
+        QRectF(
+          p_start.x() - n * scene_w,
+          p_start.y() + n * scene_w,
+          2 * n * scene_w,
+          -2 * n * scene_h));
+    }
+    else
+    {
+      // set a null rect, in order to the original scene rect from the scene
+      setSceneRect(QRectF());
+    }
+    draw_tiles();
   }
-
-  printf("scale factor: %.3f\n", scale_factor);
-  //const double nearest_nice_scale_factor = pow(2.0, round(log(scale_factor)/log(2.0)));
-  //printf("nearest nice scale factor: %.3f\n", nearest_nice_scale_factor);
-
-  // calculate the mouse map position now that we've scaled
-  const QPointF p_end = mapToScene(e->pos());
-
-  // translate the map back so hopefully the mouse stays in the same spot
-  const QPointF diff = p_end - p_start;
-  translate(diff.x(), diff.y());
-  draw_tiles();
 }
 
 void MapView::mousePressEvent(QMouseEvent* e)
@@ -139,8 +159,9 @@ void MapView::mouseMoveEvent(QMouseEvent* e)
   {
     const int dx = e->x() - pan_start_x;
     const int dy = e->y() - pan_start_y;
-    horizontalScrollBar()->setValue(horizontalScrollBar()->value() - dx);
-    verticalScrollBar()->setValue(verticalScrollBar()->value() - dy);
+    const double s = transform().m11();
+    const double y_flip = building.coordinate_system.is_y_flipped() ? 1 : -1;
+    translate(dx / s, y_flip * dy / s);
     pan_start_x = e->x();
     pan_start_y = e->y();
     e->accept();
@@ -155,38 +176,62 @@ void MapView::resizeEvent(QResizeEvent*)
   draw_tiles();
 }
 
-void MapView::zoom_fit(int level_index)
+void MapView::zoom_fit(int level_idx)
 {
-  if (building.levels.empty())
-    return;
-  const Level& level = building.levels[level_index];
-  const int w = level.drawing_width;
-  const int h = level.drawing_height;
-  const double cx = w / 2;
-  const double cy = h / 2;
-  // todo: this doesn't seem to work. not sure how to use this function.
-  ensureVisible(cx, cy, w, h);
-  //resetTransform();
-  //fitInView(cx, cy, w, h, Qt::KeepAspectRatio);
-  //centerOn(cx, cy);
+  const Level* level = nullptr;
+  if (level_idx >= 0 && level_idx < static_cast<int>(building.levels.size()))
+    level = &building.levels[level_idx];
+  else if (building.levels.size() > 0)
+    level = &building.levels[0];
+
+  if (level != nullptr)
+  {
+    const double viewport_scale = 1.0;
+    const double y_flip = building.coordinate_system.is_y_flipped() ? 1 : -1;
+
+    QTransform t;
+    t.scale(viewport_scale, y_flip * viewport_scale);
+    setTransform(t);
+
+    // compute center of all vertices on the active level
+    const size_t n_vertex = level->vertices.size();
+    if (n_vertex > 0)
+    {
+      double x_sum = 0, y_sum = 0;
+      for (const auto& v : level->vertices)
+      {
+        x_sum += v.x;
+        y_sum += v.y;
+      }
+      const double xc = x_sum / n_vertex;
+      const double yc = y_sum / n_vertex;
+      printf("center: (%.3f, %.3f)\n", xc, yc);
+      centerOn(QPointF(xc, yc));
+    }
+  }
+
+  if (building.coordinate_system.is_global())
+  {
+    draw_tiles();
+  }
 }
 
 void MapView::draw_tiles()
 {
   if (!show_tiles || !building.coordinate_system.has_tiles())
     return;
-  const int viewport_width = viewport()->width();
-  const int viewport_height = viewport()->height();
+  const int viewport_w = viewport()->width();
+  const int viewport_h = viewport()->height();
   QPointF ul = mapToScene(QPoint(0, 0));
-  QPointF lr = mapToScene(QPoint(viewport_width, viewport_height));
-  last_center = mapToScene(QPoint(viewport_width/2, viewport_height/2));
-  // printf("viewport center: (%.3f, %.3f)\n", c.x(), c.y());
+  QPointF lr = mapToScene(QPoint(viewport_w, viewport_h));
+  last_center = mapToScene(QPoint(viewport_w/2, viewport_h/2));
+  //printf("viewport center: (%.3f, %.3f)\n", last_center.x(), last_center.y());
   // printf("  ul: (%.3f, %.3f)\n", ul.x(), ul.y());
   // printf("  lr: (%.3f, %.3f)\n", lr.x(), lr.y());
 
   const double x_extent = lr.x() - ul.x();
   // printf("  x extent: %.3f\n", x_extent);
-  const double tiles_visible_x = viewport_width / 256.0;
+  const double tiles_visible_x = viewport_w / 256.0;
   // printf("  tiles_visible_x: %.3f\n", tiles_visible_x);
   const double x_meters_per_tile = x_extent / tiles_visible_x;
   // printf("  x_meters_per_tile: %.3f\n", x_meters_per_tile);
@@ -194,13 +239,13 @@ void MapView::draw_tiles()
     log(M_PI * CoordinateSystem::WGS84_A / x_meters_per_tile) / log(2);
   // printf("  zoom_exact: %.3f\n", zoom_exact);
 
-  int zoom_approx = static_cast<int>(ceil(zoom_exact));
+  int zoom = static_cast<int>(ceil(zoom_exact));
   const int MAX_ZOOM = 20;
-  if (zoom_approx < 0)
-    zoom_approx = 0;
-  if (zoom_approx > MAX_ZOOM)
-    zoom_approx = MAX_ZOOM;
-  // printf("  zoom_approx = %d\n", zoom_approx);
+  if (zoom < 0)
+    zoom = 0;
+  if (zoom > MAX_ZOOM)
+    zoom = MAX_ZOOM;
+  // printf("  zoom = %d\n", zoom);
 
   const double eps = 0.0001;
   const double MAX_X = M_PI * CoordinateSystem::WGS84_A;
@@ -209,9 +254,9 @@ void MapView::draw_tiles()
   // printf("  clamped x range: (%.3f, %.3f)\n", ulx_clamped, lrx_clamped);
 
   const int x_min_tile =
-    floor((ulx_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom_approx));
+    floor((ulx_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom));
   const int x_max_tile =
-    floor((lrx_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom_approx));
+    floor((lrx_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom));
   // printf("  x tile range: [%d, %d]\n", x_min_tile, x_max_tile);
 
   // because EPSG 3857 is a square, we can use MAX_X for the Y extents also
@@ -220,42 +265,46 @@ void MapView::draw_tiles()
   // printf("  clamped y range: (%.3f, %.3f)\n", lry_clamped, uly_clamped);
 
   const int y_min_tile =
-    (1 << zoom_approx)
+    (1 << zoom)
     - 1
-    - floor((uly_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom_approx));
+    - floor((uly_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom));
   const int y_max_tile =
-    (1 << zoom_approx)
+    (1 << zoom)
     - 1
-    - floor((lry_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom_approx));
+    - floor((lry_clamped + MAX_X) / (2. * MAX_X) * (1 << zoom));
   // printf("  y tile range: [%d, %d]\n", y_min_tile, y_max_tile);
 
   std::vector<size_t> remove_idx;
   for (size_t i = 0; i < tile_pixmap_items.size(); i++)
   {
     const MapTilePixmapItem& item = tile_pixmap_items[i];
-    if (item.zoom != zoom_approx
+    if (item.zoom != zoom
       || item.x < x_min_tile
       || item.x > x_max_tile
       || item.y < y_min_tile
       || item.y > y_max_tile)
     {
       remove_idx.push_back(i);
+      /*
       printf("  need to remove remove tile idx %d: zoom=%d, (%d, %d)\n",
         (int)i,
         item.zoom,
         item.x,
         item.y);
+      */
     }
   }
 
   for (auto idx_it = remove_idx.rbegin(); idx_it != remove_idx.rend(); ++idx_it)
   {
     MapTilePixmapItem& item = tile_pixmap_items[*idx_it];
+    /*
     printf("  now removing tile idx %d: zoom=%d, (%d, %d)\n",
       (int)*idx_it,
       item.zoom,
       item.x,
       item.y);
+    */
     scene()->removeItem(item.item);
     delete item.item;
     tile_pixmap_items.erase(tile_pixmap_items.begin() + *idx_it);
@@ -278,8 +327,8 @@ void MapView::draw_tiles()
       if (found)
         continue;
 
-      //printf("request zoom=%d, x=%d, y=%d)\n", zoom_approx, x, y);
-      std::optional<const QByteArray> p = tile_cache.get(zoom_approx, x, y);
+      // printf("creating tile item zoom=%d, x=%d, y=%d)\n", zoom, x, y);
+      std::optional<const QByteArray> p = tile_cache.get(zoom, x, y);
       if (p.has_value())
       {
         //printf("  HOORAY found the pixmap\n");
@@ -289,8 +338,8 @@ void MapView::draw_tiles()
         {
           QPixmap pixmap(QPixmap::fromImage(image.convertToFormat(
               QImage::Format_Grayscale8)));
-          // QPixmap pixmap(QPixmap::fromImage(image));
-          render_tile(zoom_approx, x, y, pixmap);
+
+          render_tile(zoom, x, y, pixmap, MapTilePixmapItem::State::COMPLETED);
         }
         else
         {
@@ -299,10 +348,24 @@ void MapView::draw_tiles()
       }
       else
       {
-        request_tile(zoom_approx, x, y);
+        // create a dummy image while waiting for the server
+        QImage image(256, 256, QImage::Format_RGB888);
+        image.fill(qRgb(255, 255, 0));
+
+        QPainter painter;
+        painter.begin(&image);
+        painter.setPen(QPen(Qt::red));
+        QString label;
+        label.sprintf("%d (%d,%d)", zoom, x, y);
+        painter.drawText(10, 10, 245, 100, Qt::AlignLeft, label);
+        painter.end();
+        QPixmap pixmap(QPixmap::fromImage(image));
+
+        render_tile(zoom, x, y, pixmap, MapTilePixmapItem::State::QUEUED);
       }
     }
   }
+  process_request_queue();
 }
 
 void MapView::request_tile(const int zoom, const int x, const int y)
@@ -325,32 +388,27 @@ void MapView::request_tile(const int zoom, const int x, const int y)
       zoom,
       x,
       y);
-    network->get(QNetworkRequest(QUrl(request_url)));
+    QNetworkRequest request;
+    request.setUrl(QUrl(request_url));
+    request.setRawHeader(
+      "User-Agent",
+      "TrafficEditor/1.4 (http://open-rmf.org)");
+    network->get(request);
   }
-
-  // create a dummy image for debugging
-  QImage image(256, 256, QImage::Format_RGB888);
-  image.fill(qRgb(255, 255, 255));
-
-  QPainter painter;
-  painter.begin(&image);
-  painter.setPen(QPen(Qt::red));
-  QString label;
-  label.sprintf("%d (%d,%d)", zoom, x, y);
-  painter.drawText(10, 10, 245, 100, Qt::AlignLeft, label);
-  painter.end();
-  QPixmap pixmap(QPixmap::fromImage(image));
-
-  // tile_cache.set(zoom, x, y, pixmap);
-
-  render_tile(zoom, x, y, pixmap);
+  else
+  {
+    printf("past max number of requests this run (%d)..."
+      "in case this is a wild bug, I'm stopping now!\n",
+      s_num_requests);
+  }
 }
 
 void MapView::render_tile(
   const int zoom,
   const int tile_x,
   const int tile_y,
-  const QPixmap& pixmap)
+  const QPixmap& pixmap,
+  const MapView::MapTilePixmapItem::State state)
 {
   const double MAX_X = M_PI * CoordinateSystem::WGS84_A;
   // printf("  adding tile: zoom=%d, (%d, %d)\n", zoom, x, y);
@@ -363,9 +421,11 @@ void MapView::render_tile(
   // const double lon_deg = x / static_cast<double>(1 << zoom) * 360. - 180.;
   // const double n = M_PI - 2.0 * M_PI * y / static_cast<double>(1 << zoom);
   // const double lat = atan(0.5 * (exp(n) - exp(-n)));
-  const double x = tile_x / static_cast<double>(1 << zoom) * 2. * MAX_X - MAX_X;
+  const double x =
+    (tile_x / static_cast<double>(1 << zoom) * 2. * MAX_X - MAX_X);
+
   const double y =
-    -tile_y / static_cast<double>(1 << zoom) * 2. * MAX_X + MAX_X;
+    (-tile_y / static_cast<double>(1 << zoom) * 2. * MAX_X + MAX_X);
 
   // project the latitude to "web mercator" latitude
   //const double lat_deg_mercator = 180. / M_PI * log(tan(lat) + 1. / cos(lat));
@@ -385,6 +445,7 @@ void MapView::render_tile(
   item.x = tile_x;
   item.y = tile_y;
   item.item = pixmap_item;
+  item.state = state;
   tile_pixmap_items.push_back(item);
 }
 
@@ -431,8 +492,6 @@ void MapView::request_finished(QNetworkReply* reply)
   bool parse_ok = image.loadFromData(bytes);
   if (parse_ok)
   {
-    // printf("  parse OK to %d x %d image\n", image.width(), image.height());
-    // QPixmap pixmap(QPixmap::fromImage(image));
     QPixmap pixmap(QPixmap::fromImage(image.convertToFormat(
         QImage::Format_Grayscale8)));
     tile_cache.set(zoom, x, y, bytes);
@@ -442,6 +501,8 @@ void MapView::request_finished(QNetworkReply* reply)
       if (item.x == x && item.y == y && item.zoom == zoom)
       {
         item.item->setPixmap(pixmap);
+        item.item->setGraphicsEffect(nullptr);
+        item.state = MapTilePixmapItem::State::COMPLETED;
         break;
       }
     }
@@ -450,6 +511,10 @@ void MapView::request_finished(QNetworkReply* reply)
   {
     printf("  unable to parse\n");
   }
+
+  // Now that this request is completed, we can issue the next request
+  // in the queue.
+  process_request_queue();
 }
 
 void MapView::clear()
@@ -467,4 +532,41 @@ void MapView::update_cache_size_label(QLabel* label)
     QString("Tile cache: %1 files, %2 MB")
     .arg(size.files)
     .arg(size.bytes / 1.0e6, 0, 'g', 3));
+}
+
+void MapView::process_request_queue()
+{
+  int n_requested = 0;
+  for (const auto& tile : tile_pixmap_items)
+  {
+    if (tile.state == MapTilePixmapItem::State::REQUESTED)
+      n_requested++;
+  }
+  // printf("  %d tile requests currently in flight\n", n_requested);
+
+  for (auto& tile : tile_pixmap_items)
+  {
+    // todo: tune this, or allow it to be a user-configurable parameter.
+    // It seems to behave fairly nicely with a cap at just one
+    // request in flight, but that may vary depending on server load
+    // and latency.
+    const int MAX_REQUESTS = 1;
+    if (n_requested >= MAX_REQUESTS)
+      break;
+
+    // since we have less than N requests outstanding, let's request
+    // some more tiles
+    if (tile.state == MapTilePixmapItem::State::QUEUED)
+    {
+      request_tile(tile.zoom, tile.x, tile.y);
+      tile.state = MapTilePixmapItem::State::REQUESTED;
+
+      QGraphicsColorizeEffect* colorize = new QGraphicsColorizeEffect;
+      colorize->setColor(QColor::fromRgbF(1.0, 0.0, 0.0, 1.0));
+      colorize->setStrength(1.0);
+      tile.item->setGraphicsEffect(colorize);
+
+      n_requested++;
+    }
+  }
 }

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -150,6 +150,8 @@ void MapView::update_tiles()
   const int viewport_height = viewport()->height();
   QPointF ul = mapToScene(QPoint(0, 0));
   QPointF lr = mapToScene(QPoint(viewport_width, viewport_height));
+  //QPointF c = mapToScene(QPoint(viewport_width/2, viewport_height/2));
+  //printf("viewport center: (%.3f, %.3f)\n", c.x(), c.y());
   // printf("  ul: (%.3f, %.3f)\n", ul.x(), ul.y());
   // printf("  lr: (%.3f, %.3f)\n", lr.x(), lr.y());
 

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -288,8 +288,6 @@ void MapView::request_tile(const int zoom, const int x, const int y)
   QPainter painter;
   painter.begin(&image);
   painter.setPen(QPen(Qt::red));
-  //p.setFont(QFont('helvetica', 12, QFont::Bold));
-  //QPen pen = 
   QString label;
   label.sprintf("%d (%d,%d)", zoom, x, y);
   painter.drawText(10, 10, 245, 100, Qt::AlignLeft, label);
@@ -303,7 +301,7 @@ void MapView::request_tile(const int zoom, const int x, const int y)
 
 void MapView::render_tile(const int zoom, const int x, const int y, QPixmap* pixmap)
 {
-  printf("  adding tile: zoom=%d, (%d, %d)\n", zoom, x, y); 
+  printf("  adding tile: zoom=%d, (%d, %d)\n", zoom, x, y);
   QGraphicsPixmapItem *pixmap_item = scene()->addPixmap(*pixmap);
   pixmap_item->setScale(360. / 256.0 / (1 << zoom));
 
@@ -316,9 +314,8 @@ void MapView::render_tile(const int zoom, const int x, const int y, QPixmap* pix
   const double lat_deg_mercator = 180. / M_PI * log(tan(lat) + 1. / cos(lat));
 
   // printf("  %.5f -> %.5f\n", 180. / M_PI * lat, lat_deg_mercator);
-  
   pixmap_item->setPos(lon_deg, lat_deg_mercator);
-  
+
   // flip Y because we want +Y = up
   pixmap_item->setTransform(pixmap_item->transform().scale(1., -1.));
 
@@ -338,4 +335,9 @@ void MapView::request_finished(QNetworkReply* reply)
   printf("mapview::request_finished()\n");
   printf("  request url: %s\n",
     reply->request().url().path().toStdString().c_str());
+  std::string url = reply->request().url().path().toStdString;
+  if (url.size() < 10)
+    return;
+  // size_t zoom_start_pos = 6;
+  // size_t zoom_end_pos = url.find('/', zoom_start_pos);
 }

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -92,9 +92,6 @@ void MapView::wheelEvent(QWheelEvent* e)
 
       if (scale_factor > 0.0000076294)
         scale(0.5, 0.5);
- 
-      //if (scale_factor > min_scale_factor)
-      //  scale(0.75, 0.75);
     }
   }
 
@@ -290,7 +287,8 @@ void MapView::draw_tiles()
         bool parse_ok = image.loadFromData(p.value());
         if (parse_ok)
         {
-          QPixmap pixmap(QPixmap::fromImage(image.convertToFormat(QImage::Format_Grayscale8)));
+          QPixmap pixmap(QPixmap::fromImage(image.convertToFormat(
+              QImage::Format_Grayscale8)));
           // QPixmap pixmap(QPixmap::fromImage(image));
           render_tile(zoom_approx, x, y, pixmap);
         }
@@ -366,7 +364,8 @@ void MapView::render_tile(
   // const double n = M_PI - 2.0 * M_PI * y / static_cast<double>(1 << zoom);
   // const double lat = atan(0.5 * (exp(n) - exp(-n)));
   const double x = tile_x / static_cast<double>(1 << zoom) * 2. * MAX_X - MAX_X;
-  const double y = -tile_y / static_cast<double>(1 << zoom) * 2. * MAX_X + MAX_X;
+  const double y =
+    -tile_y / static_cast<double>(1 << zoom) * 2. * MAX_X + MAX_X;
 
   // project the latitude to "web mercator" latitude
   //const double lat_deg_mercator = 180. / M_PI * log(tan(lat) + 1. / cos(lat));
@@ -434,7 +433,8 @@ void MapView::request_finished(QNetworkReply* reply)
   {
     // printf("  parse OK to %d x %d image\n", image.width(), image.height());
     // QPixmap pixmap(QPixmap::fromImage(image));
-    QPixmap pixmap(QPixmap::fromImage(image.convertToFormat(QImage::Format_Grayscale8)));
+    QPixmap pixmap(QPixmap::fromImage(image.convertToFormat(
+        QImage::Format_Grayscale8)));
     tile_cache.set(zoom, x, y, bytes);
     // find the placeholder pixmapitem and update its pixmap
     for (auto& item : tile_pixmap_items)

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -68,7 +68,7 @@ void MapView::wheelEvent(QWheelEvent* e)
   // translate the map back so hopefully the mouse stays in the same spot
   const QPointF diff = p_end - p_start;
   translate(diff.x(), diff.y());
-  update_tiles();
+  draw_tiles();
 }
 
 void MapView::mousePressEvent(QMouseEvent* e)
@@ -107,7 +107,7 @@ void MapView::mouseMoveEvent(QMouseEvent* e)
     pan_start_x = e->x();
     pan_start_y = e->y();
     e->accept();
-    update_tiles();
+    draw_tiles();
     return;
   }
   e->ignore();
@@ -115,7 +115,7 @@ void MapView::mouseMoveEvent(QMouseEvent* e)
 
 void MapView::resizeEvent(QResizeEvent*)
 {
-  update_tiles();
+  draw_tiles();
 }
 
 void MapView::zoom_fit(int level_index)
@@ -138,14 +138,6 @@ void MapView::draw_tiles()
 {
   if (!show_tiles || !building.coordinate_system.has_tiles())
     return;
-  printf("MapView::draw_tiles()\n");
-}
-
-void MapView::update_tiles()
-{
-  if (!show_tiles || !building.coordinate_system.has_tiles())
-    return;
-  // printf("MapView::update_tiles()\n");
   const int viewport_width = viewport()->width();
   const int viewport_height = viewport()->height();
   QPointF ul = mapToScene(QPoint(0, 0));
@@ -217,13 +209,22 @@ void MapView::update_tiles()
       || item.y > y_max_tile)
     {
       remove_idx.push_back(i);
-      // printf("  removing tile: zoom=%d, (%d, %d)\n", item.zoom, item.x, item.y); 
+      printf("  need to remove remove tile idx %d: zoom=%d, (%d, %d)\n",
+        (int)i,
+        item.zoom,
+        item.x,
+        item.y); 
     }
   }
 
   for (auto idx_it = remove_idx.rbegin(); idx_it != remove_idx.rend(); ++idx_it)
   {
     MapTilePixmapItem& item = tile_pixmap_items[*idx_it];
+    printf("  now removing tile idx %d: zoom=%d, (%d, %d)\n",
+      (int)*idx_it,
+      item.zoom,
+      item.x,
+      item.y);
     scene()->removeItem(item.item);
     delete item.item;
     tile_pixmap_items.erase(tile_pixmap_items.begin() + *idx_it);
@@ -387,4 +388,9 @@ void MapView::request_finished(QNetworkReply* reply)
   {
     printf("  unable to parse\n");
   }
+}
+
+void MapView::clear()
+{
+  tile_pixmap_items.clear();
 }

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -213,7 +213,7 @@ void MapView::draw_tiles()
         (int)i,
         item.zoom,
         item.x,
-        item.y); 
+        item.y);
     }
   }
 
@@ -270,7 +270,12 @@ void MapView::request_tile(const int zoom, const int x, const int y)
 
   if (s_num_requests <= 2000)
   {
-    printf("  requesting tile %d: zoom=%d, x=%d, y=%d\n", s_num_requests, zoom, x, y);
+    printf("  requesting tile %d: zoom=%d, x=%d, y=%d\n",
+      s_num_requests,
+      zoom,
+      x,
+      y);
+
     QString request_url;
     request_url.sprintf(
       "http://tiles.demo.open-rmf.org/tile/%d/%d/%d.png",
@@ -305,7 +310,7 @@ void MapView::render_tile(
   const QPixmap& pixmap)
 {
   // printf("  adding tile: zoom=%d, (%d, %d)\n", zoom, x, y);
-  QGraphicsPixmapItem *pixmap_item = scene()->addPixmap(pixmap);
+  QGraphicsPixmapItem* pixmap_item = scene()->addPixmap(pixmap);
   pixmap_item->setScale(360. / 256.0 / (1 << zoom));
 
   // magic math from the OpenStreetMap "Slippy map tilenames" wiki page
@@ -366,7 +371,12 @@ void MapView::request_finished(QNetworkReply* reply)
   const int y = std::stoi(y_str);
 
   QByteArray bytes = reply->readAll();
-  printf("received %d-byte tile: zoom=%d x=%d y=%d\n", bytes.length(), zoom, x, y);
+  printf("received %d-byte tile: zoom=%d x=%d y=%d\n",
+     ytes.length(),
+     zoom,
+     x,
+     y);
+
   QImage image;
   bool parse_ok = image.loadFromData(bytes);
   if (parse_ok)

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -18,11 +18,9 @@
 #include "map_view.h"
 #include <QScrollBar>
 
-MapView::MapView(QWidget* parent)
+MapView::MapView(QWidget* parent, const Building& building_)
 : QGraphicsView(parent),
-  is_panning(false),
-  pan_start_x(0),
-  pan_start_y(0)
+  building(building_)
 {
   setMouseTracking(true);
   viewport()->setMouseTracking(true);
@@ -97,7 +95,7 @@ void MapView::mouseMoveEvent(QMouseEvent* e)
   e->ignore();
 }
 
-void MapView::zoom_fit(const Building& building, int level_index)
+void MapView::zoom_fit(int level_index)
 {
   if (building.levels.empty())
     return;
@@ -111,4 +109,12 @@ void MapView::zoom_fit(const Building& building, int level_index)
   //resetTransform();
   //fitInView(cx, cy, w, h, Qt::KeepAspectRatio);
   //centerOn(cx, cy);
+}
+
+void MapView::draw_osm_tiles()
+{
+  if (!show_osm_tiles)
+    return;
+  if (!building.coordinate_system.has_tiles())
+    return;
 }

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -243,4 +243,19 @@ void MapView::update_tiles()
 void MapView::request_tile(const int zoom, const int x, const int y)
 {
   printf("  requesting tile: zoom=%d, x=%d, y=%d\n", zoom, x, y);
+
+  // create a dummy image for debugging
+  QImage image(256, 256, QImage::Format_RGB888);
+  image.fill(qRgb(255, 255, 255));
+
+  QPainter painter;
+  painter.begin(&image);
+  painter.setPen(QPen(Qt::red));
+  //p.setFont(QFont('helvetica', 12, QFont::Bold));
+  //QPen pen = 
+  painter.drawText(10, 10, 245, 100, Qt::AlignLeft, tr("hello world"));
+  painter.end();
+  QPixmap *pixmap = new QPixmap(QPixmap::fromImage(image));
+
+  tile_cache.set(zoom, x, y, pixmap);
 }

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -419,11 +419,11 @@ void MapView::clear()
 void MapView::update_cache_size_label(QLabel* label)
 {
   if (!label)
-    return;  // always sanity check :|
+    return;
 
   MapTileCache::CacheSize size = tile_cache.getSize();
   label->setText(
     QString("Tile cache: %1 files, %2 MB")
-      .arg(size.files)
-      .arg(size.bytes / 1.0e6, 0, 'g', 3));
+    .arg(size.files)
+    .arg(size.bytes / 1.0e6, 0, 'g', 3));
 }

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -16,6 +16,7 @@
 */
 
 #include <cmath>
+#include <QLabel>
 #include <QScrollBar>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
@@ -413,4 +414,16 @@ void MapView::request_finished(QNetworkReply* reply)
 void MapView::clear()
 {
   tile_pixmap_items.clear();
+}
+
+void MapView::update_cache_size_label(QLabel* label)
+{
+  if (!label)
+    return;  // always sanity check :|
+
+  MapTileCache::CacheSize size = tile_cache.getSize();
+  label->setText(
+    QString("Tile cache: %1 files, %2 MB")
+      .arg(size.files)
+      .arg(size.bytes / 1.0e6, 0, 'g', 3));
 }

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -21,6 +21,8 @@
 #include <QNetworkReply>
 #include "map_view.h"
 
+using std::string;
+
 MapView::MapView(QWidget* parent, const Building& building_)
 : QGraphicsView(parent),
   building(building_)
@@ -335,9 +337,33 @@ void MapView::request_finished(QNetworkReply* reply)
   printf("mapview::request_finished()\n");
   printf("  request url: %s\n",
     reply->request().url().path().toStdString().c_str());
-  std::string url = reply->request().url().path().toStdString;
+  const string url(reply->request().url().path().toStdString());
   if (url.size() < 10)
     return;
-  // size_t zoom_start_pos = 6;
-  // size_t zoom_end_pos = url.find('/', zoom_start_pos);
+  const size_t zoom_start = 6;
+  const size_t zoom_end = url.find('/', zoom_start);
+  if (zoom_end == string::npos)
+    return;
+  const string zoom_str = url.substr(zoom_start, zoom_end - zoom_start);
+  printf("zoom str: [%s]\n", zoom_str.c_str());
+
+  const size_t x_start = zoom_end + 1;
+  if (x_start >= url.size())
+    return;
+  const size_t x_end = url.find('/', x_start);
+  const string x_str = url.substr(x_start, x_end - x_start);
+  printf("x str: [%s]\n", x_str.c_str());
+
+  const size_t y_start = x_end + 1;
+  if (y_start >= url.size())
+    return;
+  const size_t y_end = url.find('.', y_start);
+  const string y_str = url.substr(y_start, y_end - y_start);
+  printf("y str: [%s]\n", y_str.c_str());
+
+  const int zoom = std::stoi(zoom_str);
+  const int x = std::stoi(x_str);
+  const int y = std::stoi(y_str);
+
+  printf("received tile: zoom=%d x=%d y=%d\n", zoom, x, y);
 }

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -372,10 +372,10 @@ void MapView::request_finished(QNetworkReply* reply)
 
   QByteArray bytes = reply->readAll();
   printf("received %d-byte tile: zoom=%d x=%d y=%d\n",
-     ytes.length(),
-     zoom,
-     x,
-     y);
+    bytes.length(),
+    zoom,
+    x,
+    y);
 
   QImage image;
   bool parse_ok = image.loadFromData(bytes);

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -159,8 +159,10 @@ void MapView::update_tiles()
   const double lrx_clamped = std::max(std::min(lr.x(), 180.0), -180.0);
   printf("  clamped lon range: (%.3f, %.3f)\n", ulx_clamped, lrx_clamped);
 
-  const int x_min_tile = floor((ulx_clamped + 180.) / 360. * (1 << zoom_approx));
-  const int x_max_tile = floor((lrx_clamped + 180.) / 360. * (1 << zoom_approx));
+  const int x_min_tile =
+    floor((ulx_clamped + 180.) / 360. * (1 << zoom_approx));
+  const int x_max_tile =
+    floor((lrx_clamped + 180.) / 360. * (1 << zoom_approx));
   printf("  x tile range: [%d, %d]\n", x_min_tile, x_max_tile);
 
   const double MAX_LAT = 85.0511;
@@ -169,17 +171,13 @@ void MapView::update_tiles()
   printf("  clamped lat range: (%.3f, %.3f)\n", lry_clamped, uly_clamped);
 
   // some trig magic from the OpenStreetMap "Slippy map tilenames" wiki page
-  const int y_min_tile =
-    floor(
-      (1.0 - asinh(tan(uly_clamped * M_PI / 180.)) / M_PI)
-      / 2.0 * (1 << zoom_approx)
-    );
+  const int y_min_tile = floor(
+    (1.0 - asinh(tan(uly_clamped * M_PI / 180.)) / M_PI)
+    / 2.0 * (1 << zoom_approx));
 
-  const int y_max_tile =
-    floor(
-      (1.0 - asinh(tan(lry_clamped * M_PI / 180.)) / M_PI)
-      / 2.0 * (1 << zoom_approx)
-    );
+  const int y_max_tile = floor(
+    (1.0 - asinh(tan(lry_clamped * M_PI / 180.)) / M_PI)
+    / 2.0 * (1 << zoom_approx));
 
   printf("  y tile range: [%d, %d]\n", y_min_tile, y_max_tile);
 
@@ -188,10 +186,10 @@ void MapView::update_tiles()
   {
     const MapTilePixmapItem& item = tile_pixmap_items[i];
     if (item.zoom != zoom_approx
-        || item.x < x_min_tile
-        || item.x > x_max_tile
-        || item.y < y_min_tile
-        || item.y > y_max_tile)
+      || item.x < x_min_tile
+      || item.x > x_max_tile
+      || item.y < y_min_tile
+      || item.y > y_max_tile)
       remove_idx.push_back(i);
   }
 
@@ -217,9 +215,18 @@ void MapView::update_tiles()
           break;
         }
       }
-      if (!found)
+      if (found)
+        continue;
+
+      printf("request zoom=%d, x=%d, y=%d)\n", zoom_approx, x, y);
+      QPixmap* pixmap = tile_cache.get(zoom_approx, x, y);
+      if (pixmap)
       {
-        printf("request zoom=%d, x=%d, y=%d)\n", zoom_approx, x, y);
+        printf("  HOORAY found the pixmap\n");
+      }
+      else
+      {
+        request_tile(zoom_approx, x, y);
       }
     }
   }
@@ -230,4 +237,10 @@ void MapView::update_tiles()
   //     * if not, see if it's in the cache.
   //     * if it's not in the cache, request it from the tile server
   // todo: when a request from the tile server returns, add it to the cache and render it
+
+}
+
+void MapView::request_tile(const int zoom, const int x, const int y)
+{
+  printf("  requesting tile: zoom=%d, x=%d, y=%d\n", zoom, x, y);
 }

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -18,11 +18,13 @@
 #ifndef MAP_VIEW_H
 #define MAP_VIEW_H
 
+#include <vector>
+
+#include <QGraphicsPixmapItem>
 #include <QGraphicsView>
 #include <QWheelEvent>
 
 #include "building.h"
-
 
 class MapView : public QGraphicsView
 {
@@ -31,16 +33,19 @@ class MapView : public QGraphicsView
 public:
   MapView(QWidget* parent, const Building& building_);
   void zoom_fit(int level_index);
-  void set_show_osm_tiles(const bool show_osm_tiles_)
+  void set_show_tiles(const bool show_tiles_)
   {
-    show_osm_tiles = show_osm_tiles_;
+    show_tiles = show_tiles_;
   }
+  void draw_tiles();
+  void update_tiles();
 
 protected:
   void wheelEvent(QWheelEvent* event);
   void mouseMoveEvent(QMouseEvent* e);
   void mousePressEvent(QMouseEvent* e);
   void mouseReleaseEvent(QMouseEvent* e);
+  void resizeEvent(QResizeEvent *e);
 
 private:
   bool is_panning = false;
@@ -48,9 +53,9 @@ private:
   int pan_start_y = 0;
 
   const Building& building;
-  bool show_osm_tiles = false;
+  bool show_tiles = true;
 
-  void update_osm_tiles();
+  std::vector<QGraphicsPixmapItem *> map_tiles;
 };
 
 #endif

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -45,6 +45,7 @@ public:
   void draw_tiles();
   void clear();
   void update_cache_size_label(QLabel* label);
+  QPointF get_center() { return last_center; }
 
 protected:
   void wheelEvent(QWheelEvent* event);
@@ -92,6 +93,7 @@ private:
     const QPixmap& pixmap);
 
   void request_finished(QNetworkReply* reply);
+  QPointF last_center;
 };
 
 #endif

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -57,6 +57,24 @@ private:
   bool show_tiles = false;  // ignore first few resize events during startup
 
   MapTileCache cache;
+
+  struct MapTilePixmapItem
+  {
+    int zoom = 0;
+    int x = 0;
+    int y = 0;
+    QGraphicsPixmapItem* item = nullptr;
+  };
+  std::vector<MapTilePixmapItem> tile_pixmap_items;
+
+  struct MapTileRequest
+  {
+    int zoom = 0;
+    int x = 0;
+    int y = 0;
+    // todo: time it was requested?
+  };
+  std::vector<MapTileRequest> tile_requests;
 };
 
 #endif

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -77,6 +77,7 @@ private:
   std::vector<MapTileRequest> tile_requests;
 
   void request_tile(const int zoom, const int x, const int y);
+  void render_tile(const int zoom, const int x, const int y, QPixmap* pixmap);
 };
 
 #endif

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -42,7 +42,7 @@ public:
     show_tiles = show_tiles_;
   }
   void draw_tiles();
-  void update_tiles();
+  void clear();
 
 protected:
   void wheelEvent(QWheelEvent* event);

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -70,6 +70,13 @@ private:
     int x = 0;
     int y = 0;
     QGraphicsPixmapItem* item = nullptr;
+
+    enum State
+    {
+      QUEUED,
+      REQUESTED,
+      COMPLETED
+    } state;
   };
   std::vector<MapTilePixmapItem> tile_pixmap_items;
 
@@ -90,10 +97,13 @@ private:
     const int zoom,
     const int x,
     const int y,
-    const QPixmap& pixmap);
+    const QPixmap& pixmap,
+    const MapTilePixmapItem::State state);
 
   void request_finished(QNetworkReply* reply);
   QPointF last_center;
+
+  void process_request_queue();
 };
 
 #endif

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -29,8 +29,12 @@ class MapView : public QGraphicsView
   Q_OBJECT
 
 public:
-  MapView(QWidget* parent = nullptr);
-  void zoom_fit(const Building& building, int level_index);
+  MapView(QWidget* parent, const Building& building_);
+  void zoom_fit(int level_index);
+  void set_show_osm_tiles(const bool show_osm_tiles_)
+  {
+    show_osm_tiles = show_osm_tiles_;
+  }
 
 protected:
   void wheelEvent(QWheelEvent* event);
@@ -38,8 +42,15 @@ protected:
   void mousePressEvent(QMouseEvent* e);
   void mouseReleaseEvent(QMouseEvent* e);
 
-  bool is_panning;
-  int pan_start_x, pan_start_y;
+private:
+  bool is_panning = false;
+  int pan_start_x = 0;
+  int pan_start_y = 0;
+
+  const Building& building;
+  bool show_osm_tiles = false;
+
+  void update_osm_tiles();
 };
 
 #endif

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -29,6 +29,7 @@
 
 class QNetworkAccessManager;
 class QNetworkReply;
+class QLabel;
 
 class MapView : public QGraphicsView
 {
@@ -43,6 +44,7 @@ public:
   }
   void draw_tiles();
   void clear();
+  void update_cache_size_label(QLabel* label);
 
 protected:
   void wheelEvent(QWheelEvent* event);

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -79,10 +79,16 @@ private:
   };
   std::vector<MapTileRequest> tile_requests;
 
-  QNetworkAccessManager *network = nullptr;
+  QNetworkAccessManager* network = nullptr;
 
   void request_tile(const int zoom, const int x, const int y);
-  void render_tile(const int zoom, const int x, const int y, const QPixmap& pixmap);
+
+  void render_tile(
+    const int zoom,
+    const int x,
+    const int y,
+    const QPixmap& pixmap);
+
   void request_finished(QNetworkReply* reply);
 };
 

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -25,6 +25,7 @@
 #include <QWheelEvent>
 
 #include "building.h"
+#include "map_tile_cache.h"
 
 class MapView : public QGraphicsView
 {
@@ -45,7 +46,7 @@ protected:
   void mouseMoveEvent(QMouseEvent* e);
   void mousePressEvent(QMouseEvent* e);
   void mouseReleaseEvent(QMouseEvent* e);
-  void resizeEvent(QResizeEvent *e);
+  void resizeEvent(QResizeEvent* e);
 
 private:
   bool is_panning = false;
@@ -53,9 +54,9 @@ private:
   int pan_start_y = 0;
 
   const Building& building;
-  bool show_tiles = true;
+  bool show_tiles = false;  // ignore first few resize events during startup
 
-  std::vector<QGraphicsPixmapItem *> map_tiles;
+  MapTileCache cache;
 };
 
 #endif

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -27,6 +27,9 @@
 #include "building.h"
 #include "map_tile_cache.h"
 
+class QNetworkAccessManager;
+class QNetworkReply;
+
 class MapView : public QGraphicsView
 {
   Q_OBJECT
@@ -76,8 +79,11 @@ private:
   };
   std::vector<MapTileRequest> tile_requests;
 
+  QNetworkAccessManager *network = nullptr;
+
   void request_tile(const int zoom, const int x, const int y);
   void render_tile(const int zoom, const int x, const int y, QPixmap* pixmap);
+  void request_finished(QNetworkReply* reply);
 };
 
 #endif

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -56,7 +56,7 @@ private:
   const Building& building;
   bool show_tiles = false;  // ignore first few resize events during startup
 
-  MapTileCache cache;
+  MapTileCache tile_cache;
 
   struct MapTilePixmapItem
   {
@@ -75,6 +75,8 @@ private:
     // todo: time it was requested?
   };
   std::vector<MapTileRequest> tile_requests;
+
+  void request_tile(const int zoom, const int x, const int y);
 };
 
 #endif

--- a/rmf_traffic_editor/gui/map_view.h
+++ b/rmf_traffic_editor/gui/map_view.h
@@ -82,7 +82,7 @@ private:
   QNetworkAccessManager *network = nullptr;
 
   void request_tile(const int zoom, const int x, const int y);
-  void render_tile(const int zoom, const int x, const int y, QPixmap* pixmap);
+  void render_tile(const int zoom, const int x, const int y, const QPixmap& pixmap);
   void request_finished(QNetworkReply* reply);
 };
 

--- a/rmf_traffic_editor/gui/model.h
+++ b/rmf_traffic_editor/gui/model.h
@@ -25,6 +25,7 @@
  * a map.
  */
 
+#include "coordinate_system.h"
 #include "editor_model.h"
 #include "model_state.h"
 
@@ -55,8 +56,11 @@ public:
 
   Model();
 
-  YAML::Node to_yaml() const;
-  void from_yaml(const YAML::Node& data, const std::string& level_name);
+  YAML::Node to_yaml(const CoordinateSystem& coordinate_system) const;
+  void from_yaml(
+    const YAML::Node& data,
+    const std::string& level_name,
+    const CoordinateSystem& coordinate_system);
 
   void set_param(const std::string& name, const std::string& value);
 

--- a/rmf_traffic_editor/gui/new_building_dialog.ui
+++ b/rmf_traffic_editor/gui/new_building_dialog.ui
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>NewBuildingDialog</class>
+ <widget class="QDialog" name="NewBuildingDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>419</width>
+    <height>308</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>New Building</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
+     </property>
+     <item>
+      <widget class="QLabel" name="name_label">
+       <property name="text">
+        <string>Map Name:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="name_line_edit"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;RMF supports two coordinate systems: geographic and image-based.&lt;/p&gt;&lt;p&gt;Geographic-coordinate maps are defined in WGS 84 latitude/longitude, and RMF traffic management will run in a standard geographic tangent plane, such as a UTM Zone or a country-specific plane. We recommend this for all new maps.&lt;/p&gt;&lt;p&gt;Image-coordinate maps use a reference image, such as an architectural drawing, as the basis for their coordinate system. This is simpler to get started, but less powerful in the long run, since they cannot be combined with indoor/outdoor navigation systems or interoperate with other GIS tools.&lt;/p&gt;&lt;p&gt;Which would you like to use for this map?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="geolocated_radio">
+     <property name="text">
+      <string>Geographic coordinates (recommended)</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="reference_image_radio">
+     <property name="text">
+      <string>Reference-image coordinates</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>NewBuildingDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>NewBuildingDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/rmf_traffic_editor/gui/param.cpp
+++ b/rmf_traffic_editor/gui/param.cpp
@@ -80,6 +80,7 @@ YAML::Node Param::to_yaml() const
     return YAML::Node();
 
   YAML::Node y;
+  y.SetStyle(YAML::EmitterStyle::Flow);
   y.push_back(static_cast<int>(type));
   if (type == STRING)
     y.push_back(value_string);

--- a/rmf_traffic_editor/gui/transform.cpp
+++ b/rmf_traffic_editor/gui/transform.cpp
@@ -26,13 +26,27 @@ Transform::Transform()
 {
 }
 
-bool Transform::from_yaml(const YAML::Node& data)
+bool Transform::from_yaml(
+  const YAML::Node& data,
+  const CoordinateSystem& coordinate_system)
 {
-  if (data["translation_x"])
-    _translation.setX(data["translation_x"].as<double>());
-
-  if (data["translation_y"])
-    _translation.setY(data["translation_y"].as<double>());
+  if (!coordinate_system.is_global())
+  {
+    if (data["translation_x"])
+      _translation.setX(data["translation_x"].as<double>());
+    if (data["translation_y"])
+      _translation.setY(data["translation_y"].as<double>());
+  }
+  else if (data["translation_lat"] && data["translation_lon"])
+  {
+    CoordinateSystem::WGS84Point wgs84_point;
+    wgs84_point.lon = data["translation_lon"].as<double>();
+    wgs84_point.lat = data["translation_lat"].as<double>();
+    CoordinateSystem::ProjectedPoint p =
+      coordinate_system.to_epsg3857(wgs84_point);
+    _translation.setX(p.x);
+    _translation.setY(p.y);
+  }
 
   if (data["yaw"])
     _yaw = data["yaw"].as<double>();
@@ -43,13 +57,26 @@ bool Transform::from_yaml(const YAML::Node& data)
   return true;
 }
 
-YAML::Node Transform::to_yaml() const
+YAML::Node Transform::to_yaml(const CoordinateSystem& coordinate_system) const
 {
   YAML::Node y;
   y["yaw"] = _yaw;
-  y["translation_x"] = _translation.x();
-  y["translation_y"] = _translation.y();
   y["scale"] = _scale;
+
+  if (!coordinate_system.is_global())
+  {
+    y["translation_x"] = _translation.x();
+    y["translation_y"] = _translation.y();
+  }
+  else
+  {
+    const CoordinateSystem::WGS84Point p = coordinate_system.to_wgs84({
+      _translation.x(),
+      _translation.y()
+    });
+    y["translation_lat"] = p.lat;
+    y["translation_lon"] = p.lon;
+  }
   return y;
 }
 

--- a/rmf_traffic_editor/gui/transform.cpp
+++ b/rmf_traffic_editor/gui/transform.cpp
@@ -70,10 +70,8 @@ YAML::Node Transform::to_yaml(const CoordinateSystem& coordinate_system) const
   }
   else
   {
-    const CoordinateSystem::WGS84Point p = coordinate_system.to_wgs84({
-      _translation.x(),
-      _translation.y()
-    });
+    const CoordinateSystem::WGS84Point p =
+      coordinate_system.to_wgs84({_translation.x(), _translation.y()});
     y["translation_lat"] = p.lat;
     y["translation_lon"] = p.lon;
   }

--- a/rmf_traffic_editor/gui/transform.hpp
+++ b/rmf_traffic_editor/gui/transform.hpp
@@ -24,6 +24,8 @@
 
 #include <QPointF>
 
+#include "coordinate_system.h"
+
 //=============================================================================
 /// A transform from one space to another. For now this will be linear,
 /// but in the future we expect to use various types of nonlinear transforms.
@@ -51,8 +53,11 @@ public:
   QPointF forwards(const QPointF& p) const;
   QPointF backwards(const QPointF& p) const;
 
-  bool from_yaml(const YAML::Node& data);
-  YAML::Node to_yaml() const;
+  bool from_yaml(
+    const YAML::Node& data,
+    const CoordinateSystem& coordinate_system);
+
+  YAML::Node to_yaml(const CoordinateSystem& coordinate_system) const;
 
   Transform inverse() const;
 

--- a/rmf_traffic_editor/gui/vertex.h
+++ b/rmf_traffic_editor/gui/vertex.h
@@ -47,8 +47,11 @@ public:
   Vertex();
   Vertex(double _x, double _y, const std::string& _name = std::string());
 
-  void from_yaml(const YAML::Node& data);
-  YAML::Node to_yaml() const;
+  void from_yaml(
+    const YAML::Node& data,
+    const CoordinateSystem& coordinate_system);
+
+  YAML::Node to_yaml(const CoordinateSystem& coordinate_system) const;
 
   void set_param(const std::string& name, const std::string& value);
 

--- a/rmf_traffic_editor/package.xml
+++ b/rmf_traffic_editor/package.xml
@@ -21,6 +21,7 @@
 
   <depend>libceres-dev</depend>
   <depend>libgoogle-glog-dev</depend>
+  <depend>proj</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmf_traffic_editor/package.xml
+++ b/rmf_traffic_editor/package.xml
@@ -15,6 +15,9 @@
   <build_depend>libqt5-widgets</build_depend>
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>eigen</build_depend>
+  <build_depend>rmf_utils</build_depend>
+
+  <test_depend>ament_cmake_uncrustify</test_depend>
 
   <depend>libceres-dev</depend>
   <depend>libgoogle-glog-dev</depend>


### PR DESCRIPTION
This is a mega-PR that allows Traffic Editor to work in a global coordinate system: WGS84 latitude/longitude. To make sense of where you are in the world the editor will stream OpenStreetMap tiles into the UI when you're editing a WGS84-based map.

OpenStreetMap tiles are cached locally in a subdirectory in `~/.cache`. The size of this cache is periodically calculated. At some point in the future we could consider auto-deleting old tiles, but at the moment in our current use case it seems to stay around 100-150 MB given "typical" amounts of scrolling/panning/zooming, which doesn't seem so bad.

To choose between this new "geo-referenced" mode and the "classic" Traffic-Editor coordinates of "pixels on a canonical building drawing", there is a dialog box that pops up when you create a new building map.