### PR TITLE
fix #419 by calculating transformed x/y in image-based maps

### DIFF
--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -1445,9 +1445,6 @@ void Editor::populate_property_editor(const Edge& edge)
 
 void Editor::populate_property_editor(const Vertex& vertex, const int index)
 {
-  const Level& level = building.levels[level_idx];
-  const double scale = level.drawing_meters_per_pixel;
-
   property_editor->blockSignals(true);  // otherwise we get tons of callbacks
   property_editor->setRowCount(6 + vertex.params.size());
 
@@ -1456,9 +1453,21 @@ void Editor::populate_property_editor(const Vertex& vertex, const int index)
   {
     property_editor_set_row(1, "x (pixels)", vertex.x, 3, true);
     property_editor_set_row(2, "y (pixels)", vertex.y, 3, true);
-    property_editor_set_row(3, "x (m)", vertex.x * scale);
+
+    QPointF p_ref_level;
+    building.transform_between_levels(
+      level_idx,
+      QPoint(vertex.x, vertex.y),
+      building.get_reference_level_idx(),
+      p_ref_level);
+
     const double y_flip = building.coordinate_system.is_y_flipped() ? -1 : 1;
-    property_editor_set_row(4, "y (m)", y_flip * vertex.y * scale);
+    const Level& ref_level = building.levels[building.get_reference_level_idx()];
+    const QPointF p_meters(
+      p_ref_level.x() * ref_level.drawing_meters_per_pixel,
+      p_ref_level.y() * ref_level.drawing_meters_per_pixel * y_flip);
+    property_editor_set_row(3, "x (m)", p_meters.x());
+    property_editor_set_row(4, "y (m)", p_meters.y());
   }
   else
   {

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -1454,21 +1454,32 @@ void Editor::populate_property_editor(const Vertex& vertex, const int index)
     property_editor_set_row(1, "x (pixels)", vertex.x, 3, true);
     property_editor_set_row(2, "y (pixels)", vertex.y, 3, true);
 
-    QPointF p_ref_level;
-    building.transform_between_levels(
-      level_idx,
-      QPoint(vertex.x, vertex.y),
-      building.get_reference_level_idx(),
-      p_ref_level);
+    const size_t ref_level_idx =
+      static_cast<size_t>(building.get_reference_level_idx());
 
-    const double y_flip = building.coordinate_system.is_y_flipped() ? -1 : 1;
-    const Level& ref_level =
-      building.levels[building.get_reference_level_idx()];
-    const QPointF p_meters(
-      p_ref_level.x() * ref_level.drawing_meters_per_pixel,
-      p_ref_level.y() * ref_level.drawing_meters_per_pixel * y_flip);
-    property_editor_set_row(3, "x (m)", p_meters.x());
-    property_editor_set_row(4, "y (m)", p_meters.y());
+    if (ref_level_idx < building.levels.size())
+    {
+      QPointF p_ref_level;
+      building.transform_between_levels(
+        level_idx,
+        QPoint(vertex.x, vertex.y),
+        ref_level_idx,
+        p_ref_level);
+
+      const double y_flip = building.coordinate_system.is_y_flipped() ? -1 : 1;
+      const double scale =
+        building.levels[ref_level_idx].drawing_meters_per_pixel;
+      const QPointF p_meters(
+        p_ref_level.x() * scale,
+        p_ref_level.y() * scale * y_flip);
+      property_editor_set_row(3, "x (m)", p_meters.x());
+      property_editor_set_row(4, "y (m)", p_meters.y());
+    }
+    else
+    {
+      property_editor_set_row(3, "x (m)", "");
+      property_editor_set_row(4, "y (m)", "");
+    }
   }
   else
   {

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -1462,7 +1462,8 @@ void Editor::populate_property_editor(const Vertex& vertex, const int index)
       p_ref_level);
 
     const double y_flip = building.coordinate_system.is_y_flipped() ? -1 : 1;
-    const Level& ref_level = building.levels[building.get_reference_level_idx()];
+    const Level& ref_level =
+      building.levels[building.get_reference_level_idx()];
     const QPointF p_meters(
       p_ref_level.x() * ref_level.drawing_meters_per_pixel,
       p_ref_level.y() * ref_level.drawing_meters_per_pixel * y_flip);


### PR DESCRIPTION
In image-based maps (which almost everyone is currently using), there was some ambiguity about what the `x(m)` and `y(m)` properties panel meant when a vertex was selected. Due to long-ago historical reasons, it was simply dividing the pixel coordinate by the calculated scale of the floorplan image. This works fine for single-level worlds, but it caused problems in multi-level worlds, because the `x(m)` and `y(m)` coordinates were in meters relative to the corner of that level's floorplan image. Typically, multi-floor maps require some translation (guided by fiducials) to align the floorplan images, and this translation was not incorporated into the vertex properties panel.

This PR fixes this, so that the `x(m)` and `y(m)` coordinates are now in the metric frame of the reference level. This should coincide with what appears in the generated navigation graph and simulation model.

For reasons I haven't fully chased down at the moment, they seem to be a few centimeters difference in some of the large test maps I've tried. I need to more closely compare the C++ implementation of level-alignment (as used in the Traffic Editor GUI) and the Python implementation that is used during navigation-graph and simulation-model generation. But this fix as-is should be close enough to unblock some current work.

It should also be noted that the gradual migration to global coordinates (latitude/longitude) in traffic-editor maps will eliminate problems like this :smile: 

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>