### PR TITLE
fix cmake ament_index_cpp dependency for rolling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: ci
-on: [push, pull_request]
+on: [push]
 jobs:
   ci:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: docker://ros:galactic-ros-base-focal
-    
+
     steps:
     - name: ros-workspace
       run: |
@@ -46,4 +46,51 @@ jobs:
       run: |
         cd ws
         source /opt/ros/galactic/setup.bash
+        colcon test-result --verbose
+
+  ci_rolling:
+    runs-on: ubuntu-22.04
+    container:
+      image: docker://ros:rolling-ros-base-jammy
+
+    steps:
+    - name: ros-workspace
+      run: |
+        mkdir -p ws/src
+
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        path: ws/src/rmf_traffic_editor
+
+    - name: non-ros-deps
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y git cmake wget libyaml-cpp-dev qt5-default libceres-dev libeigen3-dev python3-shapely python3-requests python3-yaml python3-pyproj python3-fiona python3-rtree libproj-dev
+
+    - name: rmf-pkgs
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ros-rolling-rmf-utils
+
+    - name: build
+      shell: bash
+      run: |
+        cd ws
+        source /opt/ros/rolling/setup.bash
+        colcon build --packages-select rmf_traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
+        colcon build --packages-up-to rmf_traffic_editor_test_maps --cmake-args -DNO_DOWNLOAD_MODELS=True
+
+    - name: test
+      shell: bash
+      run: |
+        cd ws
+        source /opt/ros/rolling/setup.bash
+        QT_QPA_PLATFORM=offscreen colcon test --packages-select rmf_traffic_editor
+
+    - name: test-results
+      shell: bash
+      run: |
+        cd ws
+        source /opt/ros/rolling/setup.bash
         colcon test-result --verbose

--- a/.github/workflows/ci_rolling.yaml
+++ b/.github/workflows/ci_rolling.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
       with:
-        repository: https://github.com/open-rmf/rmf_utils
+        repository: open-rmf/rmf_utils
         path: ws/src/rmf_utils
 
     - name: non-ros-deps

--- a/.github/workflows/ci_rolling.yaml
+++ b/.github/workflows/ci_rolling.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: non-ros-deps
       run: |
         sudo apt-get update
-        sudo apt-get install -y git cmake wget libyaml-cpp-dev qt5-default libceres-dev libeigen3-dev python3-shapely python3-requests python3-yaml python3-pyproj python3-fiona python3-rtree libproj-dev
+        sudo apt-get install -y git cmake wget libyaml-cpp-dev qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libceres-dev libeigen3-dev python3-shapely python3-requests python3-yaml python3-pyproj python3-fiona python3-rtree libproj-dev
 
     - name: rmf-pkgs
       run: |

--- a/.github/workflows/ci_rolling.yaml
+++ b/.github/workflows/ci_rolling.yaml
@@ -1,10 +1,10 @@
-name: ci
+name: ci_rolling
 on: [push]
 jobs:
-  ci:
-    runs-on: ubuntu-20.04
+  ci_rolling:
+    runs-on: ubuntu-22.04
     container:
-      image: docker://ros:galactic-ros-base-focal
+      image: docker://ros:rolling-ros-base-jammy
 
     steps:
     - name: ros-workspace
@@ -24,13 +24,13 @@ jobs:
     - name: rmf-pkgs
       run: |
         sudo apt-get update
-        sudo apt-get install -y ros-galactic-rmf-utils
+        sudo apt-get install -y ros-rolling-rmf-utils
 
     - name: build
       shell: bash
       run: |
         cd ws
-        source /opt/ros/galactic/setup.bash
+        source /opt/ros/rolling/setup.bash
         colcon build --packages-select rmf_traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
         colcon build --packages-up-to rmf_traffic_editor_test_maps --cmake-args -DNO_DOWNLOAD_MODELS=True
 
@@ -38,12 +38,12 @@ jobs:
       shell: bash
       run: |
         cd ws
-        source /opt/ros/galactic/setup.bash
+        source /opt/ros/rolling/setup.bash
         QT_QPA_PLATFORM=offscreen colcon test --packages-select rmf_traffic_editor
 
     - name: test-results
       shell: bash
       run: |
         cd ws
-        source /opt/ros/galactic/setup.bash
+        source /opt/ros/rolling/setup.bash
         colcon test-result --verbose

--- a/.github/workflows/ci_rolling.yaml
+++ b/.github/workflows/ci_rolling.yaml
@@ -2,7 +2,7 @@ name: ci_rolling
 on: [push]
 jobs:
   ci_rolling:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     container:
       image: docker://ros:rolling-ros-base-jammy
 

--- a/.github/workflows/ci_rolling.yaml
+++ b/.github/workflows/ci_rolling.yaml
@@ -16,15 +16,16 @@ jobs:
       with:
         path: ws/src/rmf_traffic_editor
 
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        repository: https://github.com/open-rmf/rmf_utils
+        path: ws/src/rmf_utils
+
     - name: non-ros-deps
       run: |
         sudo apt-get update
         sudo apt-get install -y git cmake wget libyaml-cpp-dev qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libceres-dev libeigen3-dev python3-shapely python3-requests python3-yaml python3-pyproj python3-fiona python3-rtree libproj-dev
-
-    - name: rmf-pkgs
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y ros-rolling-rmf-utils
 
     - name: build
       shell: bash

--- a/.github/workflows/ci_rolling.yaml
+++ b/.github/workflows/ci_rolling.yaml
@@ -32,6 +32,7 @@ jobs:
       run: |
         cd ws
         source /opt/ros/rolling/setup.bash
+        colcon build --packages-select rmf_utils
         colcon build --packages-select rmf_traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
         colcon build --packages-up-to rmf_traffic_editor_test_maps --cmake-args -DNO_DOWNLOAD_MODELS=True
 

--- a/.github/workflows/pycodestyle.yaml
+++ b/.github/workflows/pycodestyle.yaml
@@ -1,5 +1,5 @@
 name: style
-on: [push, pull_request]
+on: [push]
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/rmf_traffic_editor/CMakeLists.txt
+++ b/rmf_traffic_editor/CMakeLists.txt
@@ -29,7 +29,6 @@ endif()
 include_directories(.)
 include_directories(gui)
 include_directories(include)
-include_directories(${ament_index_cpp_INCLUDE_DIRS})
 
 set(gui_sources
   gui/actions/add_constraint.cpp
@@ -115,6 +114,7 @@ add_library(
 
 target_link_libraries(
   gui_lib
+  ament_index_cpp::ament_index_cpp
   ceres
   Eigen3::Eigen
   Qt5::Widgets


### PR DESCRIPTION
Haven't tested this yet on Jammy, but I think this might fix the `rolling` builds which are currently failing on Ubuntu Jammy. At least, this doesn't break `galactic` on Ubuntu Focal.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>