### PR TITLE
change URL to global tile server.

### DIFF
--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -384,7 +384,7 @@ void MapView::request_tile(const int zoom, const int x, const int y)
 
     QString request_url;
     request_url.sprintf(
-      "http://tiles.demo.open-rmf.org/tile/%d/%d/%d.png",
+      "http://tiles.sandbox.open-rmf.org/tile/%d/%d/%d.png",
       zoom,
       x,
       y);

--- a/rmf_traffic_editor/gui/new_building_dialog.ui
+++ b/rmf_traffic_editor/gui/new_building_dialog.ui
@@ -46,7 +46,7 @@
       <enum>QFrame::Plain</enum>
      </property>
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;RMF supports two coordinate systems: geographic and image-based.&lt;/p&gt;&lt;p&gt;Geographic-coordinate maps are defined in WGS 84 latitude/longitude, and RMF traffic management will run in a standard geographic tangent plane, such as a UTM Zone or a country-specific plane. We recommend this for all new maps.&lt;/p&gt;&lt;p&gt;Image-coordinate maps use a reference image, such as an architectural drawing, as the basis for their coordinate system. This is simpler to get started, but less powerful in the long run, since they cannot be combined with indoor/outdoor navigation systems or interoperate with other GIS tools.&lt;/p&gt;&lt;p&gt;Which would you like to use for this map?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;RMF supports two coordinate systems: geographic and image-based.&lt;/p&gt;&lt;p&gt;Geographic-coordinate maps are defined in WGS 84 latitude/longitude, and RMF traffic management will run in a standard geographic tangent plane, such as a UTM Zone or a country-specific plane.&lt;/p&gt;&lt;p&gt;Image-coordinate maps use a reference image, such as an architectural drawing, as the basis for their coordinate system. This is simpler to get started, but less powerful in the long run, since they cannot be combined with indoor/outdoor navigation systems or interoperate with other GIS tools.&lt;/p&gt;&lt;p&gt;Which would you like to use for this map?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -56,7 +56,7 @@
    <item>
     <widget class="QRadioButton" name="geolocated_radio">
      <property name="text">
-      <string>Geographic coordinates (recommended)</string>
+      <string>Geographic coordinates</string>
      </property>
      <property name="checked">
       <bool>true</bool>


### PR DESCRIPTION
For WGS 84 (latitude / longitude) map files, this PR will use the URL of our new tile server, which is holding OpenStreetMap's full planet data. This will allow detailed OpenStreetMap background tiles to show up in the Traffic Editor GUI when used in WGS 84 (georeferenced) mode, anywhere in the world.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>