### PR TITLE
better vertex text size in meter-scale maps

### DIFF
--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -2417,12 +2417,14 @@ void Editor::mouse_add_polygon(
 
       if (mouse_motion_polygon == nullptr)
       {
+        QPen pen(Qt::black);
+        pen.setWidthF(0.05 / active_level()->drawing_meters_per_pixel);
         QVector<QPointF> polygon_vertices;
         polygon_vertices.append(QPointF(v->x, v->y));
         QPolygonF polygon(polygon_vertices);
         mouse_motion_polygon = scene->addPolygon(
           polygon,
-          QPen(Qt::black),
+          pen,
           QBrush(QColor::fromRgbF(1.0, 0.0, 0.0, 0.5)));
         mouse_motion_polygon_vertices.clear();
       }
@@ -2482,11 +2484,14 @@ void Editor::mouse_add_polygon(
     }
     polygon_vertices.append(QPointF(p.x(), p.y()));
 
+    QPen pen(Qt::black);
+    pen.setWidthF(0.05 / active_level()->drawing_meters_per_pixel);
+
     // insert the updated polygon into the scene
     QPolygonF polygon(polygon_vertices);
     mouse_motion_polygon = scene->addPolygon(
       polygon,
-      QPen(Qt::black),
+      pen,
       QBrush(QColor::fromRgbF(1.0, 0.0, 0.0, 0.5)));
   }
 }

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -2406,8 +2406,11 @@ void Editor::mouse_add_polygon(
   {
     if (e->buttons() & Qt::LeftButton)
     {
-      const Level::NearestItem ni =
-        building.levels[level_idx].nearest_items(p.x(), p.y());
+      Level* level = active_level();
+      if (level == nullptr)
+        return;
+
+      const Level::NearestItem ni = level->nearest_items(p.x(), p.y());
       clicked_idx = ni.vertex_dist < 10.0 ? ni.vertex_idx : -1;
       if (clicked_idx < 0)
         return;// nothing to do. click wasn't on a vertex.
@@ -2418,7 +2421,7 @@ void Editor::mouse_add_polygon(
       if (mouse_motion_polygon == nullptr)
       {
         QPen pen(Qt::black);
-        pen.setWidthF(0.05 / active_level()->drawing_meters_per_pixel);
+        pen.setWidthF(0.05 / level->drawing_meters_per_pixel);
         QVector<QPointF> polygon_vertices;
         polygon_vertices.append(QPointF(v->x, v->y));
         QPolygonF polygon(polygon_vertices);

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -81,6 +81,7 @@ Editor::Editor()
   qDebug("settings filename: [%s]", qUtf8Printable(settings.fileName()));
 
   scene = new QGraphicsScene(this);
+  scene->setItemIndexMethod(QGraphicsScene::ItemIndexMethod::NoIndex);
 
   map_view = new MapView(this, building);
   map_view->setScene(scene);

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -81,7 +81,6 @@ Editor::Editor()
   qDebug("settings filename: [%s]", qUtf8Printable(settings.fileName()));
 
   scene = new QGraphicsScene(this);
-  scene->setItemIndexMethod(QGraphicsScene::ItemIndexMethod::NoIndex);
 
   map_view = new MapView(this, building);
   map_view->setScene(scene);

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -1027,9 +1027,12 @@ void Level::draw_polygon(
     polygon_vertices.append(QPointF(v.x, v.y));
   }
 
+  QPen pen(Qt::black);
+  pen.setWidthF(0.05 / drawing_meters_per_pixel);
+
   scene->addPolygon(
     QPolygonF(polygon_vertices),
-    QPen(Qt::black),
+    pen,
     polygon.selected ? selected_brush : brush);
 }
 
@@ -1172,7 +1175,7 @@ void Level::draw(
 
   QFont vertex_name_font("Helvetica");
   double vertex_name_font_size =
-    vertex_radius / drawing_meters_per_pixel * 1.5;
+    vertex_radius / drawing_meters_per_pixel * 1.5 * 10.0;
   if (vertex_name_font_size < 1.0)
     vertex_name_font_size = 1.0;
   vertex_name_font.setPointSizeF(vertex_name_font_size);

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -515,6 +515,9 @@ void MapView::request_finished(QNetworkReply* reply)
   // Now that this request is completed, we can issue the next request
   // in the queue.
   process_request_queue();
+
+  // schedule this reply object for deletion (eventually)
+  reply->deleteLater();
 }
 
 void MapView::clear()

--- a/rmf_traffic_editor/gui/map_view.cpp
+++ b/rmf_traffic_editor/gui/map_view.cpp
@@ -384,7 +384,7 @@ void MapView::request_tile(const int zoom, const int x, const int y)
 
     QString request_url;
     request_url.sprintf(
-      "http://tiles.sandbox.open-rmf.org/tile/%d/%d/%d.png",
+      "https://tiles.sandbox.open-rmf.org/tile/%d/%d/%d.png",
       zoom,
       x,
       y);

--- a/rmf_traffic_editor/gui/vertex.cpp
+++ b/rmf_traffic_editor/gui/vertex.cpp
@@ -289,8 +289,8 @@ void Vertex::draw(
       // default screen coordinates: +Y=down. Nothing special needed.
       text_item->setTransform(QTransform::fromScale(0.1, 0.1));
       text_item->setPos(
-          x - 0.05 * bb.width(),
-          y + 3.5 * radius - 0.05 * bb.height());
+        x - 0.05 * bb.width(),
+        y + 3.5 * radius - 0.05 * bb.height());
     }
     else
     {
@@ -298,8 +298,8 @@ void Vertex::draw(
       // flip the text, because Qt's default is for +Y=down screen coords
       text_item->setTransform(QTransform::fromScale(0.1, -0.1));
       text_item->setPos(
-          x - 0.05 * bb.width(),
-          y - 3.5 * radius + 0.05 * bb.height());
+        x - 0.05 * bb.width(),
+        y - 3.5 * radius + 0.05 * bb.height());
     }
   }
 }

--- a/rmf_traffic_editor/gui/vertex.cpp
+++ b/rmf_traffic_editor/gui/vertex.cpp
@@ -283,17 +283,23 @@ void Vertex::draw(
       font);
     text_item->setBrush(selected ? selected_color : vertex_color);
 
+    QRectF bb = text_item->sceneBoundingRect();
     if (coordinate_system.is_y_flipped())
     {
       // default screen coordinates: +Y=down. Nothing special needed.
-      text_item->setPos(x, y - 1 + radius);
+      text_item->setTransform(QTransform::fromScale(0.1, 0.1));
+      text_item->setPos(
+          x - 0.05 * bb.width(),
+          y + 3.5 * radius - 0.05 * bb.height());
     }
     else
     {
       // if Y is not flipped, this means we have +Y=up, so we have to
       // flip the text, because Qt's default is for +Y=down screen coords
-      text_item->setTransform(QTransform::fromScale(1.0, -1.0));
-      text_item->setPos(x, y + 1 + radius);
+      text_item->setTransform(QTransform::fromScale(0.1, -0.1));
+      text_item->setPos(
+          x - 0.05 * bb.width(),
+          y - 3.5 * radius + 0.05 * bb.height());
     }
   }
 }


### PR DESCRIPTION
There was an issue with Qt font size scaling for Cartesian-meters maps: it seems at least on Linux, the Qt font size cannot be smaller than 1.0  which is normally fine, but when rendering the QGraphicsScene for Cartesian meter-scale maps, often we will want fonts that are significantly smaller than 1.0 in order to not have the font size appear huge in the scene. For reasons unknown, it seems that a reasonable workaround is to calculate 10x the font size we want, and then use 0.1 scaling in the Qt transform on the resulting QGraphicsSimpleTextItem

This PR also fixes a few remaining non-scaled pen widths in the polygon tool, which make the floor polygon border look silly in Cartesian-meters mode.

Tested against all of the `rmf_demos` maps, as well as some non-public Cartesian-meters maps. Seems to work as expected in both reference-image-pixels mode as well as Cartesian-meters mode.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>