### PR TITLE
[Humble] Move to collections.abc for crowdsim

### DIFF
--- a/rmf_building_map_tools/building_crowdsim/navmesh/file_writer.py
+++ b/rmf_building_map_tools/building_crowdsim/navmesh/file_writer.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 import sys
 import os
 

--- a/rmf_building_map_tools/building_crowdsim/navmesh/polygon_factory.py
+++ b/rmf_building_map_tools/building_crowdsim/navmesh/polygon_factory.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 import sys
 import os
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

Since Python 3.10 (default in 22.04) `collections` is deprecated hence rmf_traffic_editor fails to build maps.

### Fix applied

Move to `collections.abc`