### PR TITLE
Only offset camera pose for global coordinate building when a floor is present

### DIFF
--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -463,7 +463,7 @@ class Building:
         c = self.center()
         # Transforming camera to account for offsets if
         # not in reference_image mode
-        if self.global_transform:
+        if self.global_transform and c != (0,0):
             camera_pose = f'{c[0] - self.global_transform.x}  \
             {c[1]-20 - self.global_transform.y} 10 0 0.6 1.57'
         else:

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -462,7 +462,7 @@ class Building:
         gui_ele = world.find('gui')
         c = self.center()
         # Transforming camera to account for offsets if
-        # not in reference_image mode
+        # not in reference_image mode and when a floor polygon is defined.
         if self.global_transform and c != (0,0):
             camera_pose = f'{c[0] - self.global_transform.x}  \
             {c[1]-20 - self.global_transform.y} 10 0 0.6 1.57'


### PR DESCRIPTION
It seems like https://github.com/open-rmf/rmf_traffic_editor/issues/433 is an edge case where global coordinates are used but no floor polygons are defined. The campus model is a single giant mesh https://github.com/open-rmf/rmf_demos/blob/c250364543b717c544fe7d39eeb73b6a2d68d0e6/rmf_demos_maps/maps/campus/campus.building.yaml#L185-L186

This PR makes a slight modification to offset the camera pose only when `level.center()` returns a non-origin pose.