### PR TITLE
Use index based iterator to avoid yaml cpp bug

### DIFF
--- a/rmf_traffic_editor/gui/lift.cpp
+++ b/rmf_traffic_editor/gui/lift.cpp
@@ -85,9 +85,9 @@ void Lift::from_yaml(
       const YAML::Node& ds = it->second;  // doors sequence node
       if (ds.IsSequence())
       {
-        for (YAML::const_iterator dit = ds.begin(); dit != ds.end(); ++dit)
+        for (std::size_t idx = 0; idx < ds.size(); ++idx)
         {
-          const std::string door_name = (*dit).as<string>();
+          const std::string door_name = ds[idx].as<string>();
           level_doors[level_name].push_back(door_name);
         }
       }


### PR DESCRIPTION
## Bug fix

### Fixed bug

Stumbled upon this issue when using traffic editor under Ubuntu 22.04 / Humble, it seems to be due to iteration in yaml-cpp not working as intended. Specifically, the iteration goes past the end of the container and traffic editor segfaults, for example when parsing the clinic world with a lift and some levels, I added a printout to print the name of the level and the name of the door and the following happened:

```
Parsing level L1
Found door lift_1_door
Found door null
Found door null

Thread 1 "traffic-editor" received signal SIGSEGV, Segmentation fault.
YAML::Node::Type (this=0x7fffffffb050) at /usr/include/yaml-cpp/node/impl.h:85
85	  return m_pNode ? m_pNode->type() : NodeType::Null;
(gdb) where
#0  YAML::Node::Type (this=0x7fffffffb050) at /usr/include/yaml-cpp/node/impl.h:85
#1  YAML::as_if<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, void>::operator() (this=this@entry=0x7fffffffb2e0) at /usr/include/yaml-cpp/node/impl.h:143
#2  0x00005555556414ff in YAML::Node::as<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > (this=0x7fffffffb050) at /usr/include/yaml-cpp/node/impl.h:156
#3  Lift::from_yaml (this=0x7fffffffb4b8, _name=..., data=..., 
    levels=std::vector of length 5, capacity 8 = {...})
    at /home/luca/trl_ws/src/rmf/rmf_traffic_editor/rmf_traffic_editor/gui/lift.cpp:90
#4  0x000055555562c0fd in Building::load (this=0x7fffffffb900, _filename=...)
    at /home/luca/trl_ws/src/rmf/rmf_traffic_editor/rmf_traffic_editor/gui/building.cpp:146
#5  0x00005555555b4d06 in Editor::load_building (this=0x7fffffffb878, filename=...)
    at /home/luca/trl_ws/src/rmf/rmf_traffic_editor/rmf_traffic_editor/gui/editor.cpp:564
#6  0x00005555555acb17 in main (argc=2, argv=<optimized out>)
    at /home/luca/trl_ws/src/rmf/rmf_traffic_editor/rmf_traffic_editor/gui/main.cpp:53
```

To reproduce just open the clinic map under 22.04 / Humble.

### Fix applied

It seems a bunch of people are having such an issue in yaml-cpp, for example [here](https://github.com/jbeder/yaml-cpp/issues/833). This approach follows one of the recommended instructions that is to use old fashioned indexes instead of iterators and fixes the segfault under 22.04 / Humble.