### PR TITLE
remove usage of deprecated np.asscalar()

### DIFF
--- a/rmf_building_map_tools/building_map/transform.py
+++ b/rmf_building_map_tools/building_map/transform.py
@@ -29,7 +29,7 @@ class Transform:
     def transform_point(self, p):
         vec = np.array([[p[0]], [p[1]]])
         transformed = (self.rot_mat @ vec) * self.scale + self.t_vec
-        return (np.asscalar(transformed[0]), np.asscalar(transformed[1]))
+        return (transformed[0].item(), transformed[1].item())
 
     def set_from_fiducials(self, fiducial_pairs, ref_scale):
         print(f'Transform.set_from_fiducials()')
@@ -93,8 +93,8 @@ class Transform:
             f1x = f_pair[1].x / mean_rel_scale
             f1y = f_pair[1].y / mean_rel_scale
             rot_f_pair1 = rot_mat @ np.array([[f1x], [f1y]])
-            rot_f1x = np.asscalar(rot_f_pair1[0])
-            rot_f1y = np.asscalar(rot_f_pair1[1])
+            rot_f1x = rot_f_pair1[0].item()
+            rot_f1y = rot_f_pair1[1].item()
 
             mean_translation[0] += rot_f1x - f_pair[0].x
             mean_translation[1] += rot_f1y - f_pair[0].y


### PR DESCRIPTION
Replace deprecated `np.asscalar()` calls with equivalent `.item()` calls, so that build will succeed on latest `numpy`

Should fix #437

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>