### PR TITLE
Add Fuel tools dependency to rmf_building_map_tools

### DIFF
--- a/rmf_building_map_tools/CHANGELOG.md
+++ b/rmf_building_map_tools/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 1.6.0 (2022-XX-YY)
 ------------------
+* Add Fuel tools dependency to rmf_building_map_tools ([#444](https://github.com/open-rmf/rmf_traffic_editor/pull/444))
 * Fix building_map_server crashes when level scale is not defined ([#442](https://github.com/open-rmf/rmf_traffic_editor/pull/442))
 * Fixed usage of download\_models ([#440](https://github.com/open-rmf/rmf_traffic_editor/pull/440))
 * remove usage of deprecated np.asscalar() ([#438](https://github.com/open-rmf/rmf_traffic_editor/pull/438))

--- a/rmf_building_map_tools/package.xml
+++ b/rmf_building_map_tools/package.xml
@@ -11,6 +11,7 @@
   <build_depend>rmf_building_map_msgs</build_depend>
 
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>ignition-fuel-tools7</exec_depend>
   <exec_depend>python3-fiona</exec_depend>
   <exec_depend>python3-pyproj</exec_depend>
   <exec_depend>python3-requests</exec_depend>


### PR DESCRIPTION
## Bug fix

### Fixed bug

`pit_crew` uses ignition-fuel-tools to fetch the models from the Fuel server but it is not listed as a dependency, which causes model download to silently fail if tools are not installed on the user's machine.

### Fix applied

Add it as a dependency to the `package.xml`

Note that this will introduce an Ignition dependency on the package, which should be kept in sync with other packages across the RMF stack. The chosen version is the one shipped with Fortress