### PR TITLE
Update changelogs and switch to markdown

### DIFF
--- a/rmf_building_map_tools/CHANGELOG.md
+++ b/rmf_building_map_tools/CHANGELOG.md
@@ -1,6 +1,14 @@
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Changelog for package rmf_building_map_tools
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+## Changelog for package rmf\_building\_map\_tools
+
+2.0.0 (2022-XX-YY)
+------------------
+* Fix building_map_server crashes when level scale is not defined ([#442](https://github.com/open-rmf/rmf_traffic_editor/pull/442))
+* Fixed usage of download\_models ([#440](https://github.com/open-rmf/rmf_traffic_editor/pull/440))
+* remove usage of deprecated np.asscalar() ([#438](https://github.com/open-rmf/rmf_traffic_editor/pull/438))
+* Added a dispensable field for models ([#436](https://github.com/open-rmf/rmf_traffic_editor/pull/436))
+* Only offset camera pose for global coordinate building when a floor is present ([#434](https://github.com/open-rmf/rmf_traffic_editor/pull/434))
+* Move to collections.abc for crowdsim ([#432](https://github.com/open-rmf/rmf_traffic_editor/pull/432))
+* Contributors: Aaron Chong, Luca Della Vedova, Morgan Quigley, Yadunund
 
 1.5.1 (2022-04-20)
 ------------------

--- a/rmf_building_map_tools/CHANGELOG.md
+++ b/rmf_building_map_tools/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog for package rmf\_building\_map\_tools
 
-2.0.0 (2022-XX-YY)
+1.6.0 (2022-XX-YY)
 ------------------
 * Fix building_map_server crashes when level scale is not defined ([#442](https://github.com/open-rmf/rmf_traffic_editor/pull/442))
 * Fixed usage of download\_models ([#440](https://github.com/open-rmf/rmf_traffic_editor/pull/440))

--- a/rmf_building_map_tools/package.xml
+++ b/rmf_building_map_tools/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_building_map_tools</name>
-  <version>1.5.1</version>
+  <version>1.6.0</version>
   <description>RMF Building map tools</description>
   <maintainer email="mquigley@openrobotics.org">Morgan Quigley</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>

--- a/rmf_traffic_editor/CHANGELOG.md
+++ b/rmf_traffic_editor/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog for package rmf\_traffic\_editor
 
-2.0.0 (2022-XX-YY)
+1.6.0 (2022-XX-YY)
 ------------------
 
 * Added a dispensable field for models ([#436](https://github.com/open-rmf/rmf_traffic_editor/pull/436))

--- a/rmf_traffic_editor/CHANGELOG.md
+++ b/rmf_traffic_editor/CHANGELOG.md
@@ -1,6 +1,12 @@
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Changelog for package rmf_traffic_editor
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+## Changelog for package rmf\_traffic\_editor
+
+2.0.0 (2022-XX-YY)
+------------------
+
+* Added a dispensable field for models ([#436](https://github.com/open-rmf/rmf_traffic_editor/pull/436))
+* Use index based iterator to avoid yaml cpp bug ([#435](https://github.com/open-rmf/rmf_traffic_editor/pull/435))
+* better vertex text size in meter-scale maps ([#431](https://github.com/open-rmf/rmf_traffic_editor/pull/431))
+* Contributors: Aaron Chong, Luca Della Vedova, Morgan Quigley
 
 1.5.1 (2022-04-20)
 ------------------

--- a/rmf_traffic_editor/package.xml
+++ b/rmf_traffic_editor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_traffic_editor</name>
-  <version>1.5.1</version>
+  <version>1.6.0</version>
   <description>traffic editor</description>
   <maintainer email="morgan@openrobotics.org">Morgan Quigley</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>

--- a/rmf_traffic_editor_assets/CHANGELOG.md
+++ b/rmf_traffic_editor_assets/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog for package rmf\_traffic\_editor\_assets
 
-2.0.0 (2022-XX-YY)
+1.6.0 (2022-XX-YY)
 ------------------
 
 1.5.1 (2022-04-20)

--- a/rmf_traffic_editor_assets/CHANGELOG.md
+++ b/rmf_traffic_editor_assets/CHANGELOG.md
@@ -1,6 +1,7 @@
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Changelog for package rmf_traffic_editor_assets
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+## Changelog for package rmf\_traffic\_editor\_assets
+
+2.0.0 (2022-XX-YY)
+------------------
 
 1.5.1 (2022-04-20)
 ------------------

--- a/rmf_traffic_editor_assets/package.xml
+++ b/rmf_traffic_editor_assets/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rmf_traffic_editor_assets</name>
-  <version>1.5.1</version>
+  <version>1.6.0</version>
   <description>Assets for use with traffic_editor.</description>
 
   <maintainer email="brandon@openrobotics.org">Brandon Ong</maintainer>

--- a/rmf_traffic_editor_test_maps/CHANGELOG.md
+++ b/rmf_traffic_editor_test_maps/CHANGELOG.md
@@ -1,6 +1,7 @@
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Changelog for package rmf_traffic_editor_test_maps
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+## Changelog for package rmf\_traffic\_editor\_test\_maps
+
+2.0.0 (2022-XX-YY)
+------------------
 
 1.5.1 (2022-04-20)
 ------------------

--- a/rmf_traffic_editor_test_maps/CHANGELOG.md
+++ b/rmf_traffic_editor_test_maps/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog for package rmf\_traffic\_editor\_test\_maps
 
-2.0.0 (2022-XX-YY)
+1.6.0 (2022-XX-YY)
 ------------------
 
 1.5.1 (2022-04-20)

--- a/rmf_traffic_editor_test_maps/package.xml
+++ b/rmf_traffic_editor_test_maps/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_traffic_editor_test_maps</name>
-  <version>1.5.1</version>
+  <version>1.6.0</version>
   <description>
     Some test maps for traffic_editor and rmf_building_map_tools.
   </description>


### PR DESCRIPTION
We need a new release of the package for 22.04 / Humble since the old version fails building maps because of an issue with deprecated usage of `collections` (specifically [this PR](https://github.com/open-rmf/rmf_traffic_editor/pull/432) needs to be released).

I bumped and updated the changelogs to 1.6.0 since this will be the first version targeting Humble.

We should probably also merge https://github.com/open-rmf/rmf_traffic_editor/pull/444 since maps packages might end up being built empty otherwise.