### PR TITLE
Fix navgraph generation for connected docking waypoints

### DIFF
--- a/rmf_building_map_tools/CHANGELOG.md
+++ b/rmf_building_map_tools/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog for package rmf\_building\_map\_tools
 
+1.6.x (xxxx-xx-xx)
+------------------
+* Fix navgraph generation for connected docking waypoints ([#452](https://github.com/open-rmf/rmf_traffic_editor/pull/452))
+* Contributors: Luca Della Vedova
+
 1.6.0 (2022-10-05)
 ------------------
 * Add Fuel tools dependency to rmf_building_map_tools ([#444](https://github.com/open-rmf/rmf_traffic_editor/pull/444))

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -500,7 +500,7 @@ class Level:
             end_dock = None
             if 'dock_name' in v2.params:  # lane segment will end at dock
                 end_dock = v2.params['dock_name'].value
-            if 'dock_name' in v1.params:
+            if 'dock_name' in v1.params:  # lane segment begins at dock
                 beginning_dock = v1.params['dock_name'].value
 
             if 'speed_limit' in l.params:
@@ -515,14 +515,12 @@ class Level:
                 # todo: clean up this logic, it's overly spaghetti
                 if end_dock:
                     forward_params['dock_name'] = end_dock
-                if beginning_dock:
-                    forward_params['undock_name'] = beginning_dock
-                nav_data['lanes'].append([start_idx, end_idx, forward_params])
-
-                if end_dock:
                     backward_params['undock_name'] = end_dock
                 if beginning_dock:
+                    forward_params['undock_name'] = beginning_dock
                     backward_params['dock_name'] = beginning_dock
+
+                nav_data['lanes'].append([start_idx, end_idx, forward_params])
 
                 if l.orientation():
                     backward_params['orientation_constraint'] = \
@@ -531,8 +529,10 @@ class Level:
             else:
                 # ensure the directionality parameter is set
                 p['is_bidirectional'] = l.is_bidirectional()
-                if dock_name:
-                    p['dock_name'] = dock_name
+                if end_dock:
+                    p['dock_name'] = end_dock
+                if beginning_dock:
+                    p['undock_name'] = beginning_dock
                 nav_data['lanes'].append([start_idx, end_idx, p])
 
         return nav_data

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -512,7 +512,6 @@ class Level:
                 backward_params = copy.deepcopy(p)
 
                 # we need to create two unidirectional lane segments
-                # todo: clean up this logic, it's overly spaghetti
                 if end_dock:
                     forward_params['dock_name'] = end_dock
                     backward_params['undock_name'] = end_dock

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -496,13 +496,12 @@ class Level:
                 p['demo_mock_lift_name'] = \
                     l.params['demo_mock_lift_name'].value
 
-            dock_name = None
-            dock_at_end = True
+            beginning_dock = None
+            end_dock = None
             if 'dock_name' in v2.params:  # lane segment will end at dock
-                dock_name = v2.params['dock_name'].value
-            elif 'dock_name' in v1.params:
-                dock_name = v1.params['dock_name'].value
-                dock_at_end = False
+                end_dock = v2.params['dock_name'].value
+            if 'dock_name' in v1.params:
+                beginning_dock = v1.params['dock_name'].value
 
             if 'speed_limit' in l.params:
                 p['speed_limit'] = l.params['speed_limit'].value
@@ -514,18 +513,16 @@ class Level:
 
                 # we need to create two unidirectional lane segments
                 # todo: clean up this logic, it's overly spaghetti
-                if dock_name:
-                    if dock_at_end:
-                        forward_params['dock_name'] = dock_name
-                    else:
-                        forward_params['undock_name'] = dock_name
+                if end_dock:
+                    forward_params['dock_name'] = end_dock
+                if beginning_dock:
+                    forward_params['undock_name'] = beginning_dock
                 nav_data['lanes'].append([start_idx, end_idx, forward_params])
 
-                if dock_name:
-                    if dock_at_end:
-                        backward_params['undock_name'] = dock_name
-                    else:
-                        backward_params['dock_name'] = dock_name
+                if end_dock:
+                    backward_params['undock_name'] = end_dock
+                if beginning_dock:
+                    backward_params['dock_name'] = beginning_dock
 
                 if l.orientation():
                     backward_params['orientation_constraint'] = \


### PR DESCRIPTION
## Bug fix

### Fixed bug

Correctly generate `dock_name` and `undock_name` when two waypoints with a `dock_name` property are connected to each other.

### Fix applied

Previously, there was an if / else statement to determine whether the dock was at the beginning or end of the lane, as such:

```
            dock_name = None
            dock_at_end = True
            if 'dock_name' in v2.params:  # lane segment will end at dock
                dock_name = v2.params['dock_name'].value
            elif 'dock_name' in v1.params:
                dock_name = v1.params['dock_name'].value
                dock_at_end = False
```

This logic wasn't able to deal with the case where both start and end waypoint have a `dock_name` property, in which case the generated navgraph would be incorrect.
The statements have now been split in two separate if statements to make sure all the possible combinations are properly accounted for. I also cleaned up the `dock_name` logic to address the todo