### PR TITLE
Migrate to using gzsim server url for fuel

### DIFF
--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -23,7 +23,7 @@ Features:
 
 See Also:
     pit_crew is very much like a Gazebo supporting variant of:
-    https://github.com/ignitionrobotics/ign-fuel-tools
+    https://github.com/gazebosim/gz-fuel-tools
 
     In other words, pit_crew is not related to ign-fuel-tools, but fills the
     same feature-niche, except for Gazebo instead of Ignition Gazebo.
@@ -504,7 +504,7 @@ def download_model(model_name, author_name, version="tip",
             "tip", which will download the latest model.
         download_path (str, optional): The root directory for downloading
             and unzipping the models into. Defaults to None. If None, function
-            will use "~/.ignition/fuel/fuel.ignitionrobotics.org" or
+            will use "~/.ignition/fuel/fuel.gazebosim.org" or
             "~/.gazebo/models" depending on the state of the ign argument.
         sync_names (bool, optional): Change downloaded model.sdf model name to
             match folder name. Defaults to False.
@@ -523,7 +523,7 @@ def download_model(model_name, author_name, version="tip",
         if download_path is None:
             if ign:
                 download_path = os.path.expanduser(
-                    "~/.ignition/fuel/fuel.ignitionrobotics.org"
+                    "~/.ignition/fuel/fuel.gazebosim.org"
                 )
             else:
                 download_path = os.path.expanduser("~/.gazebo/models")
@@ -538,7 +538,7 @@ def download_model(model_name, author_name, version="tip",
             logger.warning("Download path does not exist! Created: %s"
                            % download_path)
 
-        url_base = "https://fuel.ignitionrobotics.org/1.0"
+        url_base = "https://fuel.gazebosim.org/1.0"
         metadata = requests.get("%s/%s/models/%s/%s/%s"
                                 % (url_base, author_name,
                                    model_name, version, model_name))
@@ -626,11 +626,11 @@ def download_model_fuel_tools(model_name, author_name,
         # Currently, ignition fuel download can only download to this folder.
         # Fuel tools creates this folder if it does not yet exist
         download_path = os.path.expanduser(
-            "~/.ignition/fuel/fuel.ignitionrobotics.org"
+            "~/.ignition/fuel/fuel.gazebosim.org"
         )
         # Command line
         url_model_name = parse.quote(model_name)
-        full_url = ("https://fuel.ignitionrobotics.org/1.0" +
+        full_url = ("https://fuel.gazebosim.org/1.0" +
                     '/' + author_name + '/models' + '/' + url_model_name)
         full_command = full_command = ("ign fuel download -u "
                                        + full_url + " -v 4")
@@ -828,14 +828,14 @@ def build_and_update_cache(cache_file_path=None, write_to_cache=True,
             old_cache = {'model_cache': set(), 'fuel_cache': []}
             logger.info("Cache not found! Rebuilding cache...")
 
-    url_base = "https://fuel.ignitionrobotics.org/1.0/models"
+    url_base = "https://fuel.gazebosim.org/1.0/models"
     status = 200
     break_flag = False
     page = 1
     new_cache_count = 0
 
     logger.info("Topping up Fuel (updating cache) from:"
-                " https://fuel.ignitionrobotics.org/1.0/models")
+                " https://fuel.gazebosim.org/1.0/models")
 
     # RFE: Doing this asynchronously will significantly speed this up.
     # Any solution must guarantee:

--- a/rmf_building_map_tools/pit_crew/usage_examples.py
+++ b/rmf_building_map_tools/pit_crew/usage_examples.py
@@ -39,7 +39,7 @@ model_cache_caps = pit_crew.load_cache(lower=False)
 # And then look for models in our local model directory!
 models = pit_crew.get_local_model_name_tuples(lower=False)
 
-# Or your Ignition model directory!
+# Or your Gazebosim model directory!
 ign_models = pit_crew.get_local_model_name_tuples(lower=False, ign=True)
 
 # Or you can use the model's folder name as its name!

--- a/rmf_traffic_editor_assets/README.md
+++ b/rmf_traffic_editor_assets/README.md
@@ -21,4 +21,4 @@ git pull
 
 ## Artist Credits and Licenses
 
-Credits and licenses for each individual asset's creator can be found by downloading the model that corresponds to the asset's name on [Ignition Fuel](https://app.ignitionrobotics.org/fuel)!
+Credits and licenses for each individual asset's creator can be found by downloading the model that corresponds to the asset's name on [Gazebosim Fuel](https://app.gazebosim.org/fuel)!


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

* Migrated to using `gazebosim` Fuel server url, possibly to help with model download stability