### PR TITLE
Add mutex to lane parameters

### DIFF
--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -211,6 +211,10 @@ class Level:
                 ParamValue.DOUBLE,
                 props.get('speed_limit', 0.0)
             ])
+            edge.params['mutex'] = ParamValue([
+                ParamValue.STRING,
+                props.get('mutex', "")
+            ])
             self.lanes.append(edge)
         else:
             raise ValueError('unknown edge type!')
@@ -486,6 +490,10 @@ class Level:
                     l.params['speed_limit'].value > 0.0:
                 p['speed_limit'] = l.params['speed_limit'].value
 
+            if 'mutex' in l.params and \
+                    l.params['mutex'].value:
+                p['mutex'] = l.params['mutex'].value
+
             if 'demo_mock_floor_name' in l.params and \
                     l.params['demo_mock_floor_name'].value:
                 p['demo_mock_floor_name'] = \
@@ -502,9 +510,6 @@ class Level:
                 end_dock = v2.params['dock_name'].value
             if 'dock_name' in v1.params:  # lane segment begins at dock
                 beginning_dock = v1.params['dock_name'].value
-
-            if 'speed_limit' in l.params:
-                p['speed_limit'] = l.params['speed_limit'].value
 
             if always_unidirectional and l.is_bidirectional():
                 # now flip things around and make the second link

--- a/rmf_traffic_editor/gui/edge.cpp
+++ b/rmf_traffic_editor/gui/edge.cpp
@@ -132,6 +132,7 @@ void Edge::create_required_parameters()
       std::string());
     create_param_if_needed("demo_mock_lift_name", Param::STRING, std::string());
     create_param_if_needed("speed_limit", Param::DOUBLE, 0.0);
+    create_param_if_needed("mutex", Param::STRING, std::string());
   }
   else if (type == DOOR)
   {

--- a/rmf_traffic_editor/gui/vertex.cpp
+++ b/rmf_traffic_editor/gui/vertex.cpp
@@ -39,6 +39,7 @@ const vector<pair<string, Param::Type>> Vertex::allowed_params
   { "is_holding_point", Param::Type::BOOL },
   { "is_passthrough_point", Param::Type::BOOL },
   { "human_goal_set_name", Param::Type::STRING },
+  { "mutex", Param::Type::STRING },
 };
 
 


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This PR adds a new string parameter to lane parameters called `mutex`.

### Implementation description

I briefly investigated making this an effectively optional property added through clicking the `Add Property` button but that turned out to be a lot more involved than expected since `Add Property` has historically only been used for vertex properties and it has vertex logic quite built-in, so the refactor would have been a lot larger.
I found a small duplicated snippet when parsing speed limit so took the chance to remove it. The parameter was being added twice in the same code block.