### PR TITLE
Add merge radius option for vertices

### DIFF
--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -1184,6 +1184,7 @@ void Level::draw(
     v.draw(
       scene,
       vertex_radius / drawing_meters_per_pixel,
+      drawing_meters_per_pixel,
       vertex_name_font,
       coordinate_system);
 

--- a/rmf_traffic_editor/gui/vertex.cpp
+++ b/rmf_traffic_editor/gui/vertex.cpp
@@ -21,8 +21,6 @@
 #include <QGraphicsSimpleTextItem>
 #include <QIcon>
 
-#include <iostream>
-
 #include "vertex.h"
 using std::string;
 using std::vector;

--- a/rmf_traffic_editor/gui/vertex.h
+++ b/rmf_traffic_editor/gui/vertex.h
@@ -22,6 +22,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <optional>
 #include <yaml-cpp/yaml.h>
 
 #include <QColor>
@@ -58,6 +59,7 @@ public:
   void draw(
     QGraphicsScene* scene,
     const double radius,
+    const double drawing_meters_per_pixel,
     const QFont& font,
     const CoordinateSystem& coordinate_system) const;
 
@@ -65,6 +67,7 @@ public:
   bool is_holding_point() const;
   bool is_cleaning_zone() const;
   bool is_charger() const;
+  std::optional<double> merge_radius() const;
 
   std::string dropoff_ingestor() const;
   std::string pickup_dispenser() const;


### PR DESCRIPTION
Vertices can now be given a merge radius which indicates how close to a vertex a robot is allowed to be to approach the vertex without using a lane.