### PR TITLE
Fix empty generate_crs in building yaml.

### DIFF
--- a/rmf_traffic_editor/gui/building_dialog.cpp
+++ b/rmf_traffic_editor/gui/building_dialog.cpp
@@ -95,6 +95,6 @@ void BuildingDialog::ok_button_clicked()
     if (_building.params.find("generate_crs") != _building.params.end())
       _building.params.erase("generate_crs");
   }
-  
+
   accept();
 }

--- a/rmf_traffic_editor/gui/building_dialog.cpp
+++ b/rmf_traffic_editor/gui/building_dialog.cpp
@@ -87,8 +87,14 @@ void BuildingDialog::ok_button_clicked()
   _building.reference_level_name =
     _reference_floor_combo_box->currentText().toStdString();
 
-  _building.params["generate_crs"] =
-    Param(generate_crs_line_edit->text().toStdString());
-
+  if (!generate_crs_line_edit->text().isEmpty()){
+    _building.params["generate_crs"] = Param(generate_crs_line_edit->text().toStdString());
+  }
+  else
+  {
+    if (_building.params.find("generate_crs") != _building.params.end())
+      _building.params.erase("generate_crs");
+  }
+  
   accept();
 }

--- a/rmf_traffic_editor/gui/building_dialog.cpp
+++ b/rmf_traffic_editor/gui/building_dialog.cpp
@@ -87,8 +87,10 @@ void BuildingDialog::ok_button_clicked()
   _building.reference_level_name =
     _reference_floor_combo_box->currentText().toStdString();
 
-  if (!generate_crs_line_edit->text().isEmpty()){
-    _building.params["generate_crs"] = Param(generate_crs_line_edit->text().toStdString());
+  if (!generate_crs_line_edit->text().isEmpty())
+  {
+    _building.params["generate_crs"] = Param(
+      generate_crs_line_edit->text().toStdString());
   }
   else
   {


### PR DESCRIPTION
# Bug Fix
Without this PR, if Generate CRS is empty when editing Building Properties, the saved building yaml will have `generate_crs` with empty value and this caused [this](https://github.com/open-rmf/rmf/discussions/407).
![image](https://github.com/open-rmf/rmf_traffic_editor/assets/3224215/9521a69d-3c64-45d7-bad9-3ba07ecb1cd9)
```
parameters:
  generate_crs = [1, ""]
```
