### PR TITLE
Speed up pagination for pit_crew

### DIFF
--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -844,7 +844,7 @@ def build_and_update_cache(cache_file_path=None, write_to_cache=True,
     while status == 200 and not break_flag:
         logger.info("Fetching page: %d" % page)
 
-        resp = requests.get("%s?page=%d" % (url_base, page))
+        resp = requests.get("%s?page=%d&per_page=100" % (url_base, page))
         status = resp.status_code
         page += 1
 


### PR DESCRIPTION
The default number of models that fuel returns is 20. This PR makes the number of models returned per page 5x larger, meaning fewer calls are made, and pagination completes much faster.

Setting the `per_page` to higher than 100 causes fuel to reject the arg and drop you back down to 10 models per page.

This mostly impacts people building from scratch, since the greatest impact is on initial building of the model cache.