### PR TITLE
Fix MultiPolygon not iterable

### DIFF
--- a/rmf_building_map_tools/building_map/floor.py
+++ b/rmf_building_map_tools/building_map/floor.py
@@ -133,7 +133,7 @@ class Floor:
                         plt.plot(poly_x, poly_y, 'b', linewidth=4)
 
             elif geom.geom_type == 'MultiPolygon':
-                for poly in list(geom):
+                for poly in list(geom.geoms):
                     self.triangulate_polygon(poly, triangles)
 
             elif geom.geom_type == 'GeometryCollection':


### PR DESCRIPTION
Similar to https://github.com/open-rmf/rmf_traffic_editor/pull/476, `shapely` migration requires a minor [update](https://shapely.readthedocs.io/en/stable/migration.html#multi-part-geometries-will-no-longer-be-sequences-length-iterable-indexable) to our code. Without this PR fix the following error will occur when building certain maps that involve MultiPolygon: `TypeError: 'MultiPolygon' object is not iterable` 