### PR TITLE
Fix reference file name being kept when loading new building (#501)

### DIFF
--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -96,6 +96,8 @@ bool Building::load(const string& _filename)
 
   if (y["reference_level_name"])
     reference_level_name = y["reference_level_name"].as<string>();
+  else
+    reference_level_name = "";
 
   // crowd_sim_impl is initialized when creating crowd_sim_table in editor.cpp
   // just in case the pointer is not initialized


### PR DESCRIPTION
## Bug fix

### Fixed bug

Backport #501 to Humble