### PR TITLE
Introducing lift delete button

### DIFF
--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -498,6 +498,50 @@ bool Level::delete_selected()
   return true;
 }
 
+bool Level::delete_lift_vertex(std::string lift_name)
+{
+  std::vector<int> selected_vertex_idxes;
+  for (int i = 0; i < static_cast<int>(vertices.size()); i++)
+  {
+    if (vertices[i].params.count("lift_cabin"))
+    {
+      if (vertices[i].params["lift_cabin"].value_string == lift_name)
+      {
+        selected_vertex_idxes.push_back(i);
+      }
+    }
+  }
+
+  for (const auto& idx : selected_vertex_idxes)
+  {
+    edges.erase(
+      std::remove_if(
+        edges.begin(),
+        edges.end(),
+        [idx](const Edge& edge)
+        {
+          if (edge.start_idx == idx ||
+          edge.end_idx == idx)
+          {
+            return true;
+          }
+          else
+            return false;
+        }),
+      edges.end());
+
+    for (Edge& edge : edges)
+    {
+      if (edge.start_idx > idx)
+        edge.start_idx--;
+      if (edge.end_idx > idx)
+        edge.end_idx--;
+    }
+    vertices.erase(vertices.begin() + idx);
+  }
+  return true;
+}
+
 void Level::get_selected_items(
   std::vector<Level::SelectedItem>& items)
 {

--- a/rmf_traffic_editor/gui/level.h
+++ b/rmf_traffic_editor/gui/level.h
@@ -145,6 +145,7 @@ public:
 
   bool can_delete_current_selection();
   bool delete_selected();
+  bool delete_lift_vertex(std::string lift_name);
   void calculate_scale(const CoordinateSystem& coordinate_system);
   void clear_selection();
 

--- a/rmf_traffic_editor/gui/lift_table.cpp
+++ b/rmf_traffic_editor/gui/lift_table.cpp
@@ -20,9 +20,9 @@
 #include <QtWidgets>
 
 LiftTable::LiftTable()
-: TableList()
+: TableList(3)
 {
-  const QStringList labels = { "Name", "" };
+  const QStringList labels = { "Name", "", ""};
   setHorizontalHeaderLabels(labels);
 }
 
@@ -45,6 +45,9 @@ void LiftTable::update(Building& building)
     QPushButton* edit_button = new QPushButton("Edit...", this);
     setCellWidget(i, 1, edit_button);
 
+    QPushButton* delete_button = new QPushButton("Delete", this);
+    setCellWidget(i, 2, delete_button);
+
     connect(
       edit_button,
       &QAbstractButton::clicked,
@@ -65,18 +68,41 @@ void LiftTable::update(Building& building)
           &LiftDialog::redraw,
           [this]() { emit redraw(); });
       });
+
+    connect(
+      delete_button,
+      &QAbstractButton::clicked,
+      [this, &building, i]()
+      {
+        for (size_t j = 0; j < building.lifts.size(); j++)
+        {
+          if (j == i)
+          {
+            auto lift_name = building.lifts[j].name;
+            for (auto& level : building.levels)
+            {
+              level.delete_lift_vertex(lift_name);
+            }
+            building.lifts.erase(building.lifts.begin() + i);
+            break;
+          }
+        }
+        update(building);
+        emit redraw();
+      });
   }
 
   // we'll use the last row for the "Add" button
   const int last_row_idx = static_cast<int>(building.lifts.size());
   setCellWidget(last_row_idx, 0, nullptr);
+  setCellWidget(last_row_idx, 1, nullptr);
   setItem(
     last_row_idx,
     0,
     new QTableWidgetItem(
       QString::fromStdString("")));
   QPushButton* add_button = new QPushButton("Add...", this);
-  setCellWidget(last_row_idx, 1, add_button);
+  setCellWidget(last_row_idx, 2, add_button);
   connect(
     add_button, &QAbstractButton::clicked,
     [this, &building]()


### PR DESCRIPTION
Continuation of #509 

### Implementation summary
- Delete button in `lift_table` to remove lift from map and yam
- Delete any lift cabin way point and any edges connected to said way point