### PR TITLE
Fix lift cabin graphics on rotated floor plans

### DIFF
--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -800,6 +800,16 @@ Polygon::EdgeDragPolygon Building::polygon_edge_drag_press(
   return levels[level_idx].polygon_edge_drag_press(polygon, x, y);
 }
 
+Lift Building::get_lift(const std::string& name) const
+{
+  for (const auto& lift : lifts)
+  {
+    if (lift.name == name)
+      return lift;
+  }
+  return Lift();
+}
+
 void Building::add_constraint(
   const int level_idx,
   const QUuid& a,

--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -429,7 +429,8 @@ void Building::draw_lifts(QGraphicsScene* scene, const int level_idx)
       true,
       t.scale,
       t.dx,
-      t.dy);
+      t.dy,
+      t.rotation);
   }
 }
 
@@ -499,6 +500,7 @@ Building::Transform Building::compute_transform(
     t.scale = 1.0;
     t.dx = 0.0;
     t.dy = 0.0;
+    t.rotation = 0.0;
     return t;
   }
 
@@ -519,6 +521,25 @@ Building::Transform Building::compute_transform(
       }
     }
   }
+
+  // calculate the rotation between each pair of fiducials
+  vector<std::pair<double, double>> rotations;
+  // we take the first fiducial as the reference point
+  std::pair<Fiducial, Fiducial> ref_rotation = make_pair(fiducials[0].first,
+      fiducials[0].second);
+  for (std::size_t f_idx = 1; f_idx < fiducials.size(); f_idx++)
+  {
+    rotations.push_back(
+      make_pair(
+        fiducials[f_idx].first.rotation(ref_rotation.first),
+        fiducials[f_idx].second.rotation(ref_rotation.second)));
+  }
+
+  // it is a crude method for now, but we will just compute the mean of the angles of all the fiducial pairs
+  double relative_rotation_sum = 0;
+  for (std::size_t i = 0; i < rotations.size(); i++)
+    relative_rotation_sum += rotations[i].first - rotations[i].second;
+  const double rotation = relative_rotation_sum / rotations.size();
 
   // calculate the distances between each fiducial on their levels
   vector<std::pair<double, double>> distances;
@@ -549,8 +570,12 @@ Building::Transform Building::compute_transform(
   double trans_y_sum = 0;
   for (const auto& fiducial : fiducials)
   {
-    trans_x_sum += fiducial.second.x - fiducial.first.x * scale;
-    trans_y_sum += fiducial.second.y - fiducial.first.y * scale;
+    trans_x_sum += fiducial.second.x -
+      (std::cos(rotation) * fiducial.first.x + std::sin(rotation) *
+      fiducial.first.y) * scale;
+    trans_y_sum += fiducial.second.y -
+      (-std::sin(rotation) * fiducial.first.x + std::cos(rotation) *
+      fiducial.first.y) * scale;
   }
   const double trans_x = trans_x_sum / fiducials.size();
   const double trans_y = trans_y_sum / fiducials.size();
@@ -559,13 +584,16 @@ Building::Transform Building::compute_transform(
   t.scale = scale;
   t.dx = trans_x;
   t.dy = trans_y;
+  t.rotation = rotation;
 
-  printf("transform %d->%d: scale = %.5f translation = (%.2f, %.2f)\n",
+  printf(
+    "transform %d->%d: scale = %.5f translation = (%.2f, %.2f) rotation = %.5f\n",
     from_level_idx,
     to_level_idx,
     t.scale,
     t.dx,
-    t.dy);
+    t.dy,
+    t.rotation);
 
   return t;
 }

--- a/rmf_traffic_editor/gui/building.h
+++ b/rmf_traffic_editor/gui/building.h
@@ -196,6 +196,8 @@ public:
     const double x,
     const double y);
 
+  Lift get_lift(const std::string& name) const;
+
 private:
   std::string filename;
 };

--- a/rmf_traffic_editor/gui/building.h
+++ b/rmf_traffic_editor/gui/building.h
@@ -147,6 +147,7 @@ public:
     double scale = 1.0;
     double dx = 0.0;
     double dy = 0.0;
+    double rotation = 0.0;
   };
   typedef std::map<LevelPair, Transform> TransformMap;
   TransformMap transforms;

--- a/rmf_traffic_editor/gui/fiducial.cpp
+++ b/rmf_traffic_editor/gui/fiducial.cpp
@@ -90,3 +90,10 @@ double Fiducial::distance(const Fiducial& f)
   const double dy = f.y - y;
   return std::sqrt(dx*dx + dy*dy);
 }
+
+double Fiducial::rotation(const Fiducial& f)
+{
+  const double dx = x - f.x;
+  const double dy = y - f.y;
+  return std::atan2(dy, dx);
+}

--- a/rmf_traffic_editor/gui/fiducial.h
+++ b/rmf_traffic_editor/gui/fiducial.h
@@ -46,6 +46,7 @@ public:
   void draw(QGraphicsScene*, const double meters_per_pixel) const;
 
   double distance(const Fiducial& f);
+  double rotation(const Fiducial& f);
 };
 
 #endif

--- a/rmf_traffic_editor/gui/lift.cpp
+++ b/rmf_traffic_editor/gui/lift.cpp
@@ -145,7 +145,8 @@ void Lift::draw(
   const bool apply_transformation,
   const double scale,
   const double translate_x,
-  const double translate_y) const
+  const double translate_y,
+  const double rotation) const
 {
   if (elevation > highest_elevation || elevation < lowest_elevation)
     return;
@@ -216,8 +217,11 @@ void Lift::draw(
 
   if (apply_transformation)
   {
-    group->setRotation(-180.0 / 3.1415926 * yaw);
-    group->setPos(x * scale + translate_x, y * scale + translate_y);
+    auto rotated_x = std::cos(-rotation)*x - std::sin(-rotation)*y;
+    auto rotated_y = std::sin(-rotation)*x + std::cos(-rotation)*y;
+    group->setRotation(-180.0 / 3.1415926 * (yaw + rotation));
+    group->setPos(rotated_x * scale + translate_x,
+      rotated_y * scale + translate_y);
   }
 }
 

--- a/rmf_traffic_editor/gui/lift.h
+++ b/rmf_traffic_editor/gui/lift.h
@@ -92,7 +92,8 @@ public:
     const bool apply_transformation = true,
     const double scale = 1.0,
     const double translate_x = 0.0,
-    const double translate_y = 0.0) const;
+    const double translate_y = 0.0,
+    const double rotation = 0.0) const;
 
   bool level_door_opens(
     const std::string& level_name,


### PR DESCRIPTION
## Bug 

This PR aims to solve the lift alignment issue presented in https://github.com/open-rmf/rmf_traffic_editor/issues/505.

There are two issues to resolve.

Firstly is the graphics of the lift cabin itself, and secondly is the vertex within the lift.

### Fix

For the lift cabin, the methodology is straight forward.

We defined a function to calculate a mean rotation based on the fiducials available and store it as a new variable in the transform class. Then when a `compute_transform` function is called, the rotation will be used to calculate the correct translation between levels. Then the transform will flow down to the `draw` function of the lift, which will use the same rotation to calculate the position of the cabin in the level.

### Outstanding

We still need to shift the `lift_cabin` vertex. Right now, all vertices are transformed using the same translation and scale method across all levels. But for lifts, there is a reference level for each level.

The transformation of the `lift_cabin` vertex should bypass the typical vertex transform, get the transform between the current level and the reference level, and apply accordingly.

We can either do a filter and skip transform for vertices with `lift_cabin` properties, and implement the drawing of `lift_cabin` vertex within the `draw` function of the lifts, or pass the transform function of all the lifts from the respective reference levels to the current viewport level down to the `vertex.draw` function.