### PR TITLE
Cherry-pick Shapely 1.8.0 deprecations (#496, #476)

### DIFF
--- a/rmf_building_map_tools/building_map/floor.py
+++ b/rmf_building_map_tools/building_map/floor.py
@@ -133,7 +133,7 @@ class Floor:
                         plt.plot(poly_x, poly_y, 'b', linewidth=4)
 
             elif geom.geom_type == 'MultiPolygon':
-                for poly in list(geom):
+                for poly in list(geom.geoms):
                     self.triangulate_polygon(poly, triangles)
 
             elif geom.geom_type == 'GeometryCollection':

--- a/rmf_building_map_tools/building_map/floor.py
+++ b/rmf_building_map_tools/building_map/floor.py
@@ -141,7 +141,7 @@ class Floor:
                 # to be clipped to lie within the original floor polygon
                 # for example, if a long triangle crossed a concave region
                 # and you end up with >=1 polygons and >=1 points or edges.
-                for item in geom:
+                for item in geom.geoms:
                     if item.geom_type == 'Polygon':
                         self.triangulate_polygon(item, triangles)
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

Cherry pick #496 to `humble`, _from what I understand_ the version that is shipped in [Ubuntu 22.04 is 1.8.0](https://packages.ubuntu.com/jammy/python3-shapely). Also from what I understand shapely 1.8.0 prints a deprecation warning https://shapely.readthedocs.io/en/stable/migration.html#multi-part-geometries-will-no-longer-be-sequences-length-iterable-indexable so this should be OK to backport (and avoid issues for people that might have a newer version of shapely but are using the `humble` repos).

Note that I don't have a 22.04 machine so I couldn't really test this