### PR TITLE
Allowing deletion of lift cabin vertices

### DIFF
--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -810,6 +810,14 @@ Lift Building::get_lift(const std::string& name) const
   return Lift();
 }
 
+void Building::purge_lift_cabin_vertices(std::string lift_name)
+{
+  for (auto& level : levels)
+  {
+    level.delete_lift_vertex(lift_name);
+  }
+}
+
 void Building::add_constraint(
   const int level_idx,
   const QUuid& a,

--- a/rmf_traffic_editor/gui/building.h
+++ b/rmf_traffic_editor/gui/building.h
@@ -198,6 +198,8 @@ public:
 
   Lift get_lift(const std::string& name) const;
 
+  void purge_lift_cabin_vertices(std::string lift_name);
+
 private:
   std::string filename;
 };

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -975,7 +975,8 @@ void Editor::keyPressEvent(QKeyEvent* e)
       {
         // Get the selected vertex index
         int selected_vertex_idx = -1;
-        for (int i = 0; i < static_cast<int>(building.levels[level_idx].vertices.size()); i++)
+        for (int i = 0;
+          i < static_cast<int>(building.levels[level_idx].vertices.size()); i++)
         {
           if (building.levels[level_idx].vertices[i].selected)
           {
@@ -987,7 +988,8 @@ void Editor::keyPressEvent(QKeyEvent* e)
         if (selected_vertex_idx != -1)
         {
           // Get the selected vertex
-          const auto v = building.levels[level_idx].vertices[selected_vertex_idx];
+          const auto v =
+            building.levels[level_idx].vertices[selected_vertex_idx];
           auto it = v.params.find("lift_cabin");
           if ((it != v.params.end()))
           {

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -973,6 +973,29 @@ void Editor::keyPressEvent(QKeyEvent* e)
     case Qt::Key_Delete:
       if (building.can_delete_current_selection(level_idx))
       {
+        // Get the selected vertex index
+        int selected_vertex_idx = -1;
+        for (int i = 0; i < static_cast<int>(building.levels[level_idx].vertices.size()); i++)
+        {
+          if (building.levels[level_idx].vertices[i].selected)
+          {
+            selected_vertex_idx = i;
+            break;
+          }
+        }
+
+        if (selected_vertex_idx != -1)
+        {
+          // Get the selected vertex
+          const auto v = building.levels[level_idx].vertices[selected_vertex_idx];
+          auto it = v.params.find("lift_cabin");
+          if ((it != v.params.end()))
+          {
+            // Remove all vertices with a lift cabin property that matches the selected vertex
+            building.purge_lift_cabin_vertices(v.lift_cabin());
+          }
+        }
+
         undo_stack.push(new DeleteCommand(&building, level_idx));
         create_scene();
       }

--- a/rmf_traffic_editor/gui/level.cpp
+++ b/rmf_traffic_editor/gui/level.cpp
@@ -353,15 +353,6 @@ bool Level::can_delete_current_selection()
   if (vertex_used)
     return false;// don't try to delete a vertex used in a shape
 
-  /// check if this is a lift_cabin waypoint
-  const auto v = vertices[selected_vertex_idx];
-  auto it = v.params.find("lift_cabin");
-  if ((it != v.params.end()))
-  {
-    printf("This waypoint is used by a lift cabin!!");
-    return false;
-  }
-
   return true;
 }
 


### PR DESCRIPTION
## Allow deletion of lift cabin vertices

### Background and motivation

At the current state, when lift cabin vertices are generated, users are unable to directly delete them from the `traffic editor`. The way to go around currently is to manually go into the `building.yaml` file to delete them, but that might lead to undesirable results like failed deletion of a dangling edge or indexing issues.

This PR introduces the ability to delete lift cabin vertices. Users will be able to directly delete the lift cabin vertices from the `traffic editor` itself and have the application automatically re-index all the vertices as well as take care of any potential dangling edges.

### Feature implementation

The implementation is straightforward.

When a deletion command is issued, the algorithm will check if there are any lanes connected to the selected vertex at the viewport level. As usual, an error message will surface if the vertex is used in any edge or polygon.

If the vertex is free, the algorithm will then check if it is a `lift cabin` vertex, and if true, will proceed to purge all the vertices that share the same `lift cabin` parameter with the same `value_string`, in this case, will be the lift's name.


