### PR TITLE
Add a conditional check for level transformation

### DIFF
--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -524,6 +524,16 @@ Building::Transform Building::compute_transform(
 
   // calculate the rotation between each pair of fiducials
   vector<std::pair<double, double>> rotations;
+
+  if (fiducials.size() < 2)
+  {
+    printf(
+      "not enough fiducials to compute transform between levels %d and %d\n",
+      from_level_idx,
+      to_level_idx);
+    return Building::Transform();
+  }
+
   // we take the first fiducial as the reference point
   std::pair<Fiducial, Fiducial> ref_rotation = make_pair(fiducials[0].first,
       fiducials[0].second);


### PR DESCRIPTION
## Bug fix

### Fixed bug

From PR https://github.com/open-rmf/rmf_traffic_editor/pull/513, the `compute_transform` function is modified to take into consideration level rotations when doing inter-level transformation.

But a segmentation fault will occur when a new level is created because there are no fiducials.

### Fix applied

I've added a conditional check to make sure that the fiducials are 2 or more, before allowing the function to continue.