### PR TITLE
Fix pit crew missing models and authorship logic

### DIFF
--- a/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
+++ b/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
@@ -97,7 +97,7 @@ def download_models(
     """Download models for a given input building yaml."""
     # Construct model set
 
-    IGN_FUEL_MODEL_PATH = "~/.ignition/fuel/"
+    IGN_FUEL_MODEL_PATH = "~/.gz/fuel/"
 
     model_set = set()
     stringent_dict = {}  # Dict to tighten download scope

--- a/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
+++ b/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
@@ -180,7 +180,7 @@ def download_models(
             if model_downloaded:
                 break
             else:
-                logger.warning("Retrying %d of 5 times...", i)
+                logger.warning("Retrying %d of 5 times..." % i)
 
         if not model_downloaded:
             logger.error(

--- a/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
+++ b/rmf_building_map_tools/building_map_model_downloader/building_map_model_downloader.py
@@ -176,7 +176,7 @@ def download_models(
                     sync_names=True, export_path=export_path)
             else:
                 model_downloaded = pit_crew.download_model(
-                    model_name, author_name, sync_names=True)
+                    model_name, author_name, sync_names=True)[0]
             if model_downloaded:
                 break
             else:

--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -225,7 +225,7 @@ def get_missing_models(model_names, model_path=None,
                                    " is not by the requested author %s!"
                                    % (model_name, author_name))
         elif model_name in fuel_models and \
-                fuel_models[model_name] == author_name:
+                author_name in fuel_models[model_name]:
             output['downloadable'].append((model_name_original,
                                           fuel_models[model_name]))
 
@@ -680,8 +680,8 @@ def download_model_fuel_tools(model_name, author_name,
         if sync_names:
             sync_sdf(model_name=model_name.lower(), extract_path=extract_path)
 
-        export_path = os.path.expanduser(export_path)
         if export_path is not None:
+            export_path = os.path.expanduser(export_path)
             # Make directory if missing
             if not os.path.isdir(export_path):
                 os.makedirs(export_path, exist_ok=True)

--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -671,6 +671,8 @@ def download_model_fuel_tools(model_name, author_name,
                         (subdirname))
                     pass
             break
+        if len(sub_dirs) == 0:
+            raise RuntimeError("Model not found in Fuel portal")
         latest_ver = max(sub_dirs)
         extract_path = os.path.join(extract_path, str(latest_ver))
 

--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -144,7 +144,7 @@ def get_missing_models(model_names, model_path=None,
             - Missing models are models that are not in your local directory
                 and also missing from Fuel.
     """
-    for key, model_name in enumerate(model_names):
+    for model_name in model_names:
         if isinstance(model_name, ModelNames) or isinstance(model_name, tuple):
             assert len(model_name) == 2, \
                 "Invalid model name tuple given: %s!" % model_name

--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -224,7 +224,7 @@ def get_missing_models(model_names, model_path=None,
                     logger.warning("Model %s in local model directory"
                                    " is not by the requested author %s!"
                                    % (model_name, author_name))
-        elif model_name in fuel_models:
+        elif model_name in fuel_models and fuel_models[model_name] == model_name_original:
             output['downloadable'].append((model_name_original,
                                           fuel_models[model_name]))
 

--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -224,7 +224,8 @@ def get_missing_models(model_names, model_path=None,
                     logger.warning("Model %s in local model directory"
                                    " is not by the requested author %s!"
                                    % (model_name, author_name))
-        elif model_name in fuel_models and fuel_models[model_name] == model_name_original:
+        elif model_name in fuel_models and \
+                fuel_models[model_name] == model_name_original:
             output['downloadable'].append((model_name_original,
                                           fuel_models[model_name]))
 

--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -626,13 +626,13 @@ def download_model_fuel_tools(model_name, author_name,
         # Currently, ignition fuel download can only download to this folder.
         # Fuel tools creates this folder if it does not yet exist
         download_path = os.path.expanduser(
-            "~/.ignition/fuel/fuel.gazebosim.org"
+            "~/.gz/fuel/fuel.gazebosim.org"
         )
         # Command line
         url_model_name = parse.quote(model_name)
         full_url = ("https://fuel.gazebosim.org/1.0" +
                     '/' + author_name + '/models' + '/' + url_model_name)
-        full_command = full_command = ("ign fuel download -u "
+        full_command = full_command = ("gz fuel download -u "
                                        + full_url + " -v 4")
         subprocess.call([full_command], shell=True)
         child = subprocess.Popen([full_command], shell=True,

--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -225,7 +225,7 @@ def get_missing_models(model_names, model_path=None,
                                    " is not by the requested author %s!"
                                    % (model_name, author_name))
         elif model_name in fuel_models and \
-                fuel_models[model_name] == model_name_original:
+                fuel_models[model_name] == author_name:
             output['downloadable'].append((model_name_original,
                                           fuel_models[model_name]))
 

--- a/rmf_building_map_tools/pit_crew/pit_crew.py
+++ b/rmf_building_map_tools/pit_crew/pit_crew.py
@@ -117,7 +117,7 @@ def get_missing_models(model_names, model_path=None,
             (model_name, author_name)!
         model_path (str, optional): Overall path to model directory.
             Defaults to None. If None, function will use "~/.gazebo/models" or
-            "~/.ignition/fuel" depending on the value of ign.
+            "~/.gz/fuel" depending on the value of ign.
         config_file (str, optional): Name of the config file to parse when
             checking local models. Defaults to "model.config".
         cache_file_path (str, optional): The path to the model cache file.
@@ -248,7 +248,7 @@ def get_local_model_name_tuples(path=None, config_file="model.config",
     Args:
         path (str, optional): Overall path to model directory.
             Defaults to None. If None, function will use "~/.gazebo/models" or
-            "~/.ignition/fuel" depending on the value of ign.
+            "~/.gz/fuel" depending on the value of ign.
         config_file (str, optional): Name of the config file to parse.
             Defaults to "model.config".
         default_author_name (str, optional): The author name to use if no
@@ -269,7 +269,7 @@ def get_local_model_name_tuples(path=None, config_file="model.config",
 
     if path is None:
         if ign:
-            path = "~/.ignition/fuel/"
+            path = "~/.gz/fuel/"
         else:
             path = "~/.gazebo/models/"
         logger.warning("No local model path given! Using default %s instead!"
@@ -504,7 +504,7 @@ def download_model(model_name, author_name, version="tip",
             "tip", which will download the latest model.
         download_path (str, optional): The root directory for downloading
             and unzipping the models into. Defaults to None. If None, function
-            will use "~/.ignition/fuel/fuel.gazebosim.org" or
+            will use "~/.gz/fuel/fuel.gazebosim.org" or
             "~/.gazebo/models" depending on the state of the ign argument.
         sync_names (bool, optional): Change downloaded model.sdf model name to
             match folder name. Defaults to False.
@@ -523,7 +523,7 @@ def download_model(model_name, author_name, version="tip",
         if download_path is None:
             if ign:
                 download_path = os.path.expanduser(
-                    "~/.ignition/fuel/fuel.gazebosim.org"
+                    "~/.gz/fuel/fuel.gazebosim.org"
                 )
             else:
                 download_path = os.path.expanduser("~/.gazebo/models")


### PR DESCRIPTION
## Bug fix

### Fixed bug

Ref https://github.com/open-rmf/rmf/discussions/578#discussioncomment-11713951, fuel pipeline wasn't used for some time, but while fixing it I bumped into several other issues that I bundled in this PR.

### Fix applied

A series of issues in pit_crew:

* The root cause of the issue, if a model with a different organization name is uploaded `pit_crew` will report it as downloadable, the pipeline will later try to download it but fail. Fixed the `downloadable` generation logic https://github.com/open-rmf/rmf_traffic_editor/pull/522/commits/d392b76d363d78933c8ea25daefdb4a3bf52b9a8.
* The above didn't quite bubble up because in the bare http pipeline (which is what we use) we check a _tuple_ for true / false, so returning `(False, None)` actually evaluates to True, fixed in https://github.com/open-rmf/rmf_traffic_editor/commit/8c3f40c4d5c6b69b1f5578b14f119ac616d4c76b. 
* Now of course the fuel pipeline uses `ign` instead of `gz` which doesn't exist anymore, https://github.com/open-rmf/rmf_traffic_editor/commit/1e6c04e23bcefc5eaec1bfcc1260cd1fa7bbf457 for the command and https://github.com/open-rmf/rmf_traffic_editor/commit/14ee9536fac8f40bfc9f7539170e7b7746ee90bf to fix the cache folder.
* The rest are minor fixes:
  * https://github.com/open-rmf/rmf_traffic_editor/commit/f4d35f9d301bb9fd75c48de156bfff280dfef9d0 the printing was not substituting the variable so would always print "%d".
  * https://github.com/open-rmf/rmf_traffic_editor/commit/0c74e73708405d11ce7e185720838f362f41345a We were enumerating but not using the index, remove the enumerate.
  * https://github.com/open-rmf/rmf_traffic_editor/commit/aaa7a835f0c7da6e52285cb056de0e862e1e4447 the pipeline was throwing an exception when using `max()` on an empty list, change it to a more informative exception.

All off this surfaced because of the following sequence of events: 
* Uploading the [TeleportIngestor](https://app.gazebosim.org/Open-RMF/models/TeleportIngestor) and [TelepotDispenser](https://app.gazebosim.org/Open-RMF/fuel/models/TeleportDispenser) to the `Open-RMF` organization.
* Fuel now has an `Open-RMF/TeleportIngestor` plugin, maps still require `OpenRobotics/TeleportIngestor`.
* The faulty logic makes `OpenRobotics/TeleportIngestor` map to `Open-RMF/TeleportIngestor`.
* Model download with the `http` pipeline fails, but the faulty boolean condition check makes the pipeline progress as usual
* The `fuel` pipeline has the correct check and aborts early.

All of these will be fixed by the above.
Note however, that `TeleportIngestor` and `TeleportDispenser` might be downloaded by fuel in the future, but I'll leave a detailed comment for this in the rmf_demos PR that introduces this risk https://github.com/open-rmf/rmf_demos/pull/272