### PR TITLE
Add flag to skip calculating and setting camera pose

### DIFF
--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -394,7 +394,7 @@ class Building:
                 nav_graphs[f'{i}'] = g
         return nav_graphs
 
-    def generate_sdf_world(self, template_file):
+    def generate_sdf_world(self, template_file, skip_camera_pose):
         """ Return an etree of this Building in SDF starting from a template"""
         if template_file == "":
             template_name = 'gz_world.sdf'
@@ -474,18 +474,20 @@ class Building:
             crs_ele.text = self.global_transform.crs_name
 
         gui_ele = world.find('gui')
-        c = self.center()
-        # Transforming camera to account for offsets if
-        # not in reference_image mode and when a floor polygon is defined.
-        if self.global_transform and c != (0, 0):
-            camera_pose = f'{c[0] - self.global_transform.x}  \
-            {c[1]-20 - self.global_transform.y} 10 0 0.6 1.57'
-        else:
-            camera_pose = f'{c[0]} {c[1]-20} 10 0 0.6 1.57'
-        # add floor-toggle GUI plugin parameters
-        plugin_ele = gui_ele.find('.//plugin[@filename="MinimalScene"]')
-        camera_pose_ele = plugin_ele.find('camera_pose')
-        camera_pose_ele.text = camera_pose
+
+        if not skip_camera_pose:
+            c = self.center()
+            # Transforming camera to account for offsets if
+            # not in reference_image mode and when a floor polygon is defined.
+            if self.global_transform and c != (0, 0):
+                camera_pose = f'{c[0] - self.global_transform.x}  \
+                {c[1]-20 - self.global_transform.y} 10 0 0.6 1.57'
+            else:
+                camera_pose = f'{c[0]} {c[1]-20} 10 0 0.6 1.57'
+            # add floor-toggle GUI plugin parameters
+            plugin_ele = gui_ele.find('.//plugin[@filename="MinimalScene"]')
+            camera_pose_ele = plugin_ele.find('camera_pose')
+            camera_pose_ele.text = camera_pose
 
         toggle_floors_ele = SubElement(
             gui_ele,

--- a/rmf_building_map_tools/building_map/generator.py
+++ b/rmf_building_map_tools/building_map/generator.py
@@ -22,7 +22,8 @@ class Generator:
         input_filename,
         output_filename,
         output_models_dir,
-        template_file
+        template_file,
+        skip_camera_pose
     ):
         print('generating {} from {}'.format(output_filename, input_filename))
 
@@ -41,7 +42,7 @@ class Generator:
         building.generate_sdf_models(output_models_dir)
 
         # generate a top-level SDF for convenience
-        sdf = building.generate_sdf_world(template_file)
+        sdf = building.generate_sdf_world(template_file, skip_camera_pose)
 
         indent_etree(sdf)
         sdf_str = str(ElementToString(sdf), 'utf-8')

--- a/rmf_building_map_tools/building_map_generator/_init_argparse.py
+++ b/rmf_building_map_tools/building_map_generator/_init_argparse.py
@@ -19,6 +19,11 @@ shared_parser.add_argument("OUTPUT_MODEL_DIR", type=str,
 shared_parser.add_argument("--TEMPLATE_WORLD_FILE", type=str, default="",
                            help="Specify the template for"
                            + " the base simulation.")
+shared_parser.add_argument("--SKIP_CAMERA_POSE", action="store_true",
+                           help="Skips calculating and setting the initial "
+                           + "camera view pose. This flag should only be used "
+                           + "if the template SDF file already has the camera "
+                           + "pose defined.")
 # Create subparsers for Gazebo and Nav generation
 gazebo_parser = subparsers.add_parser(
     'gazebo',

--- a/rmf_building_map_tools/building_map_generator/building_map_generator.py
+++ b/rmf_building_map_tools/building_map_generator/building_map_generator.py
@@ -17,7 +17,8 @@ def main():
             args.INPUT,
             args.OUTPUT_WORLD,
             args.OUTPUT_MODEL_DIR,
-            args.TEMPLATE_WORLD_FILE
+            args.TEMPLATE_WORLD_FILE,
+            args.SKIP_CAMERA_POSE
         )
 
     if args.command == "nav":


### PR DESCRIPTION
## New feature implementation

### Implemented feature

* Flag to skip calculating and setting initial world camera pose

### Implementation description

This flag allows users to set their preferred initial world camera pose in their template file, and skip our usual naive calculation and setting. Users can then ensure that their gazebo world will initialize and view the exact scene in simulation that they prefer.