### PR TITLE
Fix to Allow Numerically-Labelled Map

### DIFF
--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -278,7 +278,7 @@ class BuildingMapServer(Node):
         # transformation is already done in Lift class
         msg.ref_x, msg.ref_y = lift.x, lift.y
         msg.name = str(lift.name)
-        msg.levels = str(level_name) for level_name in lift.level_names
+        msg.levels = [str(level_name) for level_name in lift.level_names]
 
         msg.ref_yaw = lift.yaw
         msg.width = lift.width

--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -278,7 +278,7 @@ class BuildingMapServer(Node):
         # transformation is already done in Lift class
         msg.ref_x, msg.ref_y = lift.x, lift.y
         msg.name = str(lift.name)
-        msg.levels = lift.level_names
+        msg.levels = str(lift.level_names)
 
         msg.ref_yaw = lift.yaw
         msg.width = lift.width

--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -139,7 +139,7 @@ class BuildingMapServer(Node):
 
     def level_msg(self, level):
         msg = Level()
-        msg.name = level.name
+        msg.name = str(level.name)
         msg.elevation = level.elevation
         if level.drawing_name:
             image = AffineImage()

--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -278,7 +278,7 @@ class BuildingMapServer(Node):
         # transformation is already done in Lift class
         msg.ref_x, msg.ref_y = lift.x, lift.y
         msg.name = str(lift.name)
-        msg.levels = str(lift.level_names)
+        msg.levels = str(level_name) for level_name in lift.level_names
 
         msg.ref_yaw = lift.yaw
         msg.width = lift.width


### PR DESCRIPTION
## Bug Fix

### Fixed Bug :bug: 

The bug in this proposed fix is for allowing numerically-labelled map names.

Eg. If map name in `.building.yaml` is `L1`, no error when starting up RMF Traffic. Map can be displayed in `RViz` window.
Eg. If map anme in `.building.yaml` is `1`, RMF Traffic crashes. Map won't be displayed in `RViz` window.

### **Fix Applied** :hammer: 

Explicit-cast level name to string when generating `Level` msg.
Explicit-cast level name associated to lift when generating `Lift` msg.

