### PR TITLE
Remove redundant physics plugin

### DIFF
--- a/.github/workflows/pycodestyle.yaml
+++ b/.github/workflows/pycodestyle.yaml
@@ -2,7 +2,7 @@ name: style
 on: [push]
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v1
     - name: deps

--- a/rmf_building_map_tools/building_crowdsim/config/behavior_file.py
+++ b/rmf_building_map_tools/building_crowdsim/config/behavior_file.py
@@ -243,7 +243,7 @@ class GoalSet (Element):
         return True
 
     def add_goal(self, goal):
-        assert(isinstance(goal, Goal))
+        assert isinstance(goal, Goal)
         goal.attributes['id'] = len(self.goal_list)
         goal.attributes['capacity'] = self.capacity
         self.goal_list.append(goal)

--- a/rmf_building_map_tools/building_crowdsim/config/configfile_generator.py
+++ b/rmf_building_map_tools/building_crowdsim/config/configfile_generator.py
@@ -18,7 +18,7 @@ from building_crowdsim.building_yaml_parse import\
 
 class ConfigFileGenerator:
     def __init__(self, building_yaml_parse):
-        assert(isinstance(building_yaml_parse, BuildingYamlParse))
+        assert isinstance(building_yaml_parse, BuildingYamlParse)
         self.crowd_sim_yaml = building_yaml_parse.crowd_sim_config
         if 'enable' not in self.crowd_sim_yaml:
             raise ValueError(

--- a/rmf_building_map_tools/building_crowdsim/config/plugin_file.py
+++ b/rmf_building_map_tools/building_crowdsim/config/plugin_file.py
@@ -46,7 +46,7 @@ class Plugin (Element):
                 self.add_external_list(group['agents_name'])
 
     def add_model_type(self, model_type):
-        assert(isinstance(model_type, ModelType))
+        assert isinstance(model_type, ModelType)
         self.sub_elements.append(model_type)
 
     def add_external_agent(self, name):

--- a/rmf_building_map_tools/building_crowdsim/navmesh/connection.py
+++ b/rmf_building_map_tools/building_crowdsim/navmesh/connection.py
@@ -5,14 +5,14 @@ from .vector import Vector2d
 
 class ConnectionManager:
     def __init__(self, lane_vertex_manager, lane_manager):
-        assert(isinstance(lane_vertex_manager, Manager))
-        assert(isinstance(lane_manager, Manager))
+        assert isinstance(lane_vertex_manager, Manager)
+        assert isinstance(lane_manager, Manager)
 
         self.lane_vertex_manager = lane_vertex_manager
         self.lane_manager = lane_manager
 
     def build_connection(self):
-        assert(len(self.lane_manager.data) != 0)
+        assert len(self.lane_manager.data) != 0
         for lane_id in range(len(self.lane_manager.data)):
             lane = self.lane_manager.data[lane_id]
             v0_id = lane.lane_vertex_id[0]
@@ -25,8 +25,8 @@ class ConnectionManager:
     # check the generated polygon vertices (vertex0 and vertex1) is on the
     # same side of lane
     def is_on_same_side_of_lane(self, lane_id, vertex0, vertex1):
-        assert(isinstance(vertex0, Vertex))
-        assert(isinstance(vertex1, Vertex))
+        assert isinstance(vertex0, Vertex)
+        assert isinstance(vertex1, Vertex)
 
         lane = self.lane_manager.data[lane_id]
         base_vertex = self.lane_vertex_manager.data[lane.lane_vertex_id[0]]
@@ -54,7 +54,7 @@ class ConnectionManager:
         lane1 = self.lane_manager.data[id1]
         base_vertex_id_intersect = list(
             set(lane0.lane_vertex_id) & set(lane1.lane_vertex_id))
-        assert(len(base_vertex_id_intersect) == 1)
+        assert len(base_vertex_id_intersect) == 1
         base_vertex = self.lane_vertex_manager.data[
             base_vertex_id_intersect[0]]
 
@@ -64,7 +64,7 @@ class ConnectionManager:
         width1 = lane1.width
 
         # 2 lanes are nearly parallel case
-        if(abs(vector0.get_dot(vector1.get_normal_unit())) < 0.05):
+        if abs(vector0.get_dot(vector1.get_normal_unit())) < 0.05:
             length = 0.5 * (width0 + width1) / 2
             result_x = length * vector0.get_normal_unit().x
             result_y = length * vector0.get_normal_unit().y

--- a/rmf_building_map_tools/building_crowdsim/navmesh/edge.py
+++ b/rmf_building_map_tools/building_crowdsim/navmesh/edge.py
@@ -13,7 +13,7 @@ class Edge:
         self.cross_lane_id = -1
 
     def init_edge(self, v0_id, v1_id, node0_id, node1_id):
-        assert(v0_id != v1_id)
+        assert v0_id != v1_id
         self.v0_id = v0_id
         self.v1_id = v1_id
         self.node0_id = node0_id

--- a/rmf_building_map_tools/building_crowdsim/navmesh/file_writer.py
+++ b/rmf_building_map_tools/building_crowdsim/navmesh/file_writer.py
@@ -16,7 +16,7 @@ class FileWriter:
         self.filehandle = open(self.filename, mode)
 
     def write_line(self, content):
-        if(self.filehandle):
+        if self.filehandle:
             if isinstance(content, Iterable):
                 for item in content:
                     item_str = str(item) + " "
@@ -80,14 +80,14 @@ class FileWriter:
             # gradient
             self.write_line(result[2])
             # edges
-            if(len(result[3]) > 0):
+            if len(result[3]) > 0:
                 tmp = list(result[3])
                 tmp.insert(0, len(result[3]))
                 self.write_line(tmp)
             else:
                 self.write_line(0)
             # obstacle
-            if(len(result[4]) > 0):
+            if len(result[4]) > 0:
                 tmp = list(result[4])
                 tmp.insert(0, len(result[4]))
                 self.write_line(tmp)

--- a/rmf_building_map_tools/building_crowdsim/navmesh/lane.py
+++ b/rmf_building_map_tools/building_crowdsim/navmesh/lane.py
@@ -15,15 +15,15 @@ class Lane:
             self,
             lane_vertex_manager,
             base_vertex_id):
-        assert(base_vertex_id in self.lane_vertex_id)
-        assert(isinstance(lane_vertex_manager, Manager))
+        assert base_vertex_id in self.lane_vertex_id
+        assert isinstance(lane_vertex_manager, Manager)
 
         base_vertex = lane_vertex_manager.data[base_vertex_id]
-        assert(len(self.lane_vertex_id) == 2)
+        assert len(self.lane_vertex_id) == 2
         to_vertex_id = self.lane_vertex_id[0]
         if base_vertex_id == self.lane_vertex_id[0]:
             to_vertex_id = self.lane_vertex_id[1]
-        assert(to_vertex_id != base_vertex_id)
+        assert to_vertex_id != base_vertex_id
         to_vertex = lane_vertex_manager.data[to_vertex_id]
 
         result = Vector2d()

--- a/rmf_building_map_tools/building_crowdsim/navmesh/navmesh_generator.py
+++ b/rmf_building_map_tools/building_crowdsim/navmesh/navmesh_generator.py
@@ -15,7 +15,7 @@ class NavmeshGenerator:
             level_with_human_lanes,
             level_name,
             default_graph_idx=9):
-        assert(isinstance(level_with_human_lanes, LevelWithHumanLanes))
+        assert isinstance(level_with_human_lanes, LevelWithHumanLanes)
         self.level = level_with_human_lanes
         self.level_name = level_name
         self.current_graph_idx = default_graph_idx

--- a/rmf_building_map_tools/building_crowdsim/navmesh/object_manager.py
+++ b/rmf_building_map_tools/building_crowdsim/navmesh/object_manager.py
@@ -4,6 +4,6 @@ class Manager:
         self.data = []
 
     def add_obj(self, obj):
-        assert(hasattr(obj, 'id')), "Adding object without id attribute!"
+        assert (hasattr(obj, 'id')), "Adding object without id attribute!"
         obj.id = len(self.data)
         self.data.append(obj)

--- a/rmf_building_map_tools/building_crowdsim/navmesh/polygon.py
+++ b/rmf_building_map_tools/building_crowdsim/navmesh/polygon.py
@@ -16,7 +16,7 @@ class Polygon:
         self.center = Vertex([0, 0])
 
     def add_vertex(self, vertex):
-        assert(isinstance(vertex, Vertex))
+        assert isinstance(vertex, Vertex)
         if vertex.id in self.vertex_ids:
             return
         self.vertex_ids.add(vertex.id)
@@ -24,7 +24,7 @@ class Polygon:
 
     def calulate_center(self):
         num = len(self.vertices)
-        assert(num >= 3), "Polygon has less than 3 vertices"
+        assert (num >= 3), "Polygon has less than 3 vertices"
         x = 0.0
         y = 0.0
         for vtx in self.vertices:
@@ -66,11 +66,11 @@ class PolygonManager (Manager):
         self.polygon_map = dict()
 
     def update_polygon_set(self, polygon):
-        assert(polygon.id >= 0)
-        if(isinstance(polygon, HubPolygon)):
+        assert polygon.id >= 0
+        if isinstance(polygon, HubPolygon):
             self.polygon_map[polygon.hub_vertex_id] = polygon.id
 
     def get_hub_polygon_from_hub_vertex(self, hub_vertex_id):
-        if(hub_vertex_id in self.polygon_map):
+        if hub_vertex_id in self.polygon_map:
             return self.polygon_map[hub_vertex_id]
         return -1

--- a/rmf_building_map_tools/building_crowdsim/navmesh/polygon_factory.py
+++ b/rmf_building_map_tools/building_crowdsim/navmesh/polygon_factory.py
@@ -49,8 +49,8 @@ class PolygonFactory:
         self.dead_end_extension = 0.1
 
     def hub_polygon_update(self, polygon):
-        assert(isinstance(polygon, HubPolygon))
-        assert(polygon.hub_vertex_id != -1)
+        assert isinstance(polygon, HubPolygon)
+        assert polygon.hub_vertex_id != -1
 
         self.polygon_manager.update_polygon_set(polygon)
 
@@ -61,22 +61,22 @@ class PolygonFactory:
             self.hub_polygon_general_case(polygon)
 
     def lane_polygon_update(self, polygon):
-        assert(isinstance(polygon, LanePolygon))
+        assert isinstance(polygon, LanePolygon)
         # add already generated polygon vertices to this lane polygon
         lane = self.lane_manager.data[polygon.related_lane_id]
         already_vertex_ids = lane.polygon_vertex_id
 
-        if(len(already_vertex_ids) == 0):
+        if len(already_vertex_ids) == 0:
             raise ValueError(
                 "You are getting a lane not connected with any other hub." +
                 "Please check the building.yaml")
 
-        if(len(already_vertex_ids) > 2):
+        if len(already_vertex_ids) > 2:
             self.lane_polygon_general_case(polygon, already_vertex_ids)
         else:
             self.lane_polygon_dead_end_case(polygon, already_vertex_ids)
 
-        assert(len(polygon.vertex_ids) == 4)
+        assert len(polygon.vertex_ids) == 4
         self.link_polygon_edge(polygon)
         # only lane polygon has obstacles
         self.set_polygon_obstacle(polygon)
@@ -91,7 +91,7 @@ class PolygonFactory:
         in orientation sequence
         """
         base_vertex = self.lane_vertex_manager.data[intersect_vertex_id]
-        if(len(base_vertex.related_lane_ids) == 0):
+        if len(base_vertex.related_lane_ids) == 0:
             print(
                 "This lane vertex: ",
                 base_vertex.id,
@@ -113,7 +113,7 @@ class PolygonFactory:
         Return with the polygon vertices instance in sequence.
         """
         polygon = self.polygon_manager.data[polygon_id]
-        if(isinstance(polygon, LanePolygon)):
+        if isinstance(polygon, LanePolygon):
             print(
                 "Only HubPolygon constructs polygon vertices.",
                 "Current processing polygon: [",
@@ -144,9 +144,9 @@ class PolygonFactory:
         self.construct_vertices()
         This function added additional 2 polygon vertices for the HubPolygon
         """
-        assert(isinstance(polygon, HubPolygon))
+        assert isinstance(polygon, HubPolygon)
         vertices = self.construct_vertices(polygon.id)
-        assert(len(vertices) == 2)
+        assert len(vertices) == 2
         intersect_vertex = self.lane_vertex_manager.data[polygon.hub_vertex_id]
         v0 = vertices[0]
         v1 = vertices[1]
@@ -155,7 +155,7 @@ class PolygonFactory:
         lane_vectors =\
             self.cal_unit_lane_vector_in_sequence_on_intersect_vertex(
                 intersect_vertex.id)
-        assert(len(lane_vectors) == 2)
+        assert len(lane_vectors) == 2
         vector0 = lane_vectors[0][1]
         vector1 = lane_vectors[1][1]
 
@@ -215,7 +215,7 @@ class PolygonFactory:
             common_lane = vertices[idx].related_lane_ids.intersection(
                 vertices[idx - 1].related_lane_ids)
             # only 1 common_lane expected
-            assert(len(common_lane) == 1)
+            assert len(common_lane) == 1
             edge = Edge()
             edge.init_edge(vertices[idx].id,
                            vertices[idx - 1].id,
@@ -263,8 +263,8 @@ class PolygonFactory:
         The sequence of polygon vertices will also be taken care of
         as general case.
         """
-        assert(isinstance(polygon, LanePolygon))
-        assert(len(already_vertices) == 2)
+        assert isinstance(polygon, LanePolygon)
+        assert len(already_vertices) == 2
 
         lane = self.lane_manager.data[polygon.related_lane_id]
         construct_vertices = []
@@ -297,7 +297,7 @@ class PolygonFactory:
         """
         polygon = self.polygon_manager.data[polygon_id]
         # must be a lane node
-        assert(isinstance(polygon, LanePolygon))
+        assert isinstance(polygon, LanePolygon)
         lane = self.lane_manager.data[polygon.related_lane_id]
 
         lane_vector = self.connection_manager.get_lane_vector(
@@ -330,8 +330,8 @@ class PolygonFactory:
         be called after all the 4 polygon vertices are added. This function
         aims to update the edge information between LanePolygon and HubPolygon
         """
-        assert(isinstance(lane_polygon, LanePolygon))
-        assert(len(lane_polygon.vertex_ids) == 4)
+        assert isinstance(lane_polygon, LanePolygon)
+        assert len(lane_polygon.vertex_ids) == 4
         lane = self.lane_manager.data[lane_polygon.related_lane_id]
 
         for v_id in lane.lane_vertex_id:
@@ -339,7 +339,7 @@ class PolygonFactory:
             neighbor_polygon_id = \
                 self.polygon_manager.get_hub_polygon_from_hub_vertex(v_id)
             # ignore dead end case
-            if(neighbor_polygon_id < 0):
+            if neighbor_polygon_id < 0:
                 continue
 
             connection_edge = -1
@@ -347,10 +347,10 @@ class PolygonFactory:
                     self.polygon_manager\
                         .data[neighbor_polygon_id]\
                         .edge_ids:
-                if(self.edge_manager.data[edge_id].cross_lane_id == lane.id):
+                if self.edge_manager.data[edge_id].cross_lane_id == lane.id:
                     connection_edge = edge_id
                     break
-            assert(connection_edge >= 0)
+            assert connection_edge >= 0
 
             edge = self.edge_manager.data[connection_edge]
             edge.init_edge(
@@ -369,9 +369,9 @@ class PolygonFactory:
         The idea is 1 obstacle is constructed by 2 polygon vertices that
         on the same side of lane. 2 cases by checking v0-v1 pair and v0-v3 pair
         """
-        assert(isinstance(lane_polygon, LanePolygon))
-        assert(len(lane_polygon.vertex_ids) == 4)
-        assert(len(lane_polygon.edge_ids) != 0)
+        assert isinstance(lane_polygon, LanePolygon)
+        assert len(lane_polygon.vertex_ids) == 4
+        assert len(lane_polygon.edge_ids) != 0
 
         lane = self.lane_manager.data[lane_polygon.related_lane_id]
         polygon_vertices = lane_polygon.vertices
@@ -380,10 +380,12 @@ class PolygonFactory:
         v2 = polygon_vertices[2]
         v3 = polygon_vertices[3]
 
-        assert(v0.id >= 0
-               and v1.id >= 0
-               and v2.id >= 0
-               and v3.id >= 0)
+        assert (
+            v0.id >= 0
+            and v1.id >= 0
+            and v2.id >= 0
+            and v3.id >= 0
+        )
 
         obstacle_pairs = []
         # v0-v1 pair on the same side

--- a/rmf_building_map_tools/building_crowdsim/navmesh/vector.py
+++ b/rmf_building_map_tools/building_crowdsim/navmesh/vector.py
@@ -9,8 +9,8 @@ class Vector2d:
 
     def init_with_2_vertex(self, v0, v1):
         # pointing from v0 to v1
-        assert(isinstance(v0, Vertex))
-        assert(isinstance(v1, Vertex))
+        assert isinstance(v0, Vertex)
+        assert isinstance(v1, Vertex)
         self.x = v1.x - v0.x
         self.y = v1.y - v0.y
 
@@ -26,12 +26,12 @@ class Vector2d:
         return Vector2d([-unit.y, unit.x])
 
     def get_dot(self, vector2d):
-        assert(isinstance(vector2d, Vector2d))
+        assert isinstance(vector2d, Vector2d)
         return self.x * vector2d.x + self.y * vector2d.y
 
     def get_orientation(self):
         return math.atan2(self.y, self.x)
 
     def get_cross(self, vector2d):
-        assert(isinstance(vector2d, Vector2d))
+        assert isinstance(vector2d, Vector2d)
         return self.x * vector2d.y - self.y * vector2d.x

--- a/rmf_building_map_tools/building_map/doors/door.py
+++ b/rmf_building_map_tools/building_map/doors/door.py
@@ -1,5 +1,5 @@
 from xml.etree.ElementTree import Element, SubElement
-from..utils import door_material, box_link, joint
+from ..utils import door_material, box_link, joint
 
 
 class Door:

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -441,16 +441,16 @@ class Level:
         next_idx = 0
         vidx_to_mapped_idx = {}
         mapped_idx_to_vidx = {}
-        for l in self.lanes:
-            if l.params['graph_idx'].value != graph_idx:
+        for lane in self.lanes:
+            if lane.params['graph_idx'].value != graph_idx:
                 continue
-            if l.start_idx not in vidx_to_mapped_idx:
-                vidx_to_mapped_idx[l.start_idx] = next_idx
-                mapped_idx_to_vidx[next_idx] = l.start_idx
+            if lane.start_idx not in vidx_to_mapped_idx:
+                vidx_to_mapped_idx[lane.start_idx] = next_idx
+                mapped_idx_to_vidx[next_idx] = lane.start_idx
                 next_idx += 1
-            if l.end_idx not in vidx_to_mapped_idx:
-                vidx_to_mapped_idx[l.end_idx] = next_idx
-                mapped_idx_to_vidx[next_idx] = l.end_idx
+            if lane.end_idx not in vidx_to_mapped_idx:
+                vidx_to_mapped_idx[lane.end_idx] = next_idx
+                mapped_idx_to_vidx[next_idx] = lane.end_idx
                 next_idx += 1
         # print(vidx_to_mapped_idx)
         # print(mapped_idx_to_vidx)
@@ -470,14 +470,14 @@ class Level:
             nav_data['vertices'].append([v.x, v.y, p])
 
         nav_data['lanes'] = []
-        for l in self.lanes:
-            if l.params['graph_idx'].value != graph_idx:
+        for lane in self.lanes:
+            if lane.params['graph_idx'].value != graph_idx:
                 continue
-            v1 = self.vertices[l.start_idx]
-            v2 = self.vertices[l.end_idx]
+            v1 = self.vertices[lane.start_idx]
+            v2 = self.vertices[lane.end_idx]
 
-            start_idx = vidx_to_mapped_idx[l.start_idx]
-            end_idx = vidx_to_mapped_idx[l.end_idx]
+            start_idx = vidx_to_mapped_idx[lane.start_idx]
+            end_idx = vidx_to_mapped_idx[lane.end_idx]
 
             p = {}  # params
 
@@ -489,26 +489,26 @@ class Level:
                     print(f'found intersection with door {door_name}!')
                     p['door_name'] = door_name
 
-            if l.orientation():
-                p['orientation_constraint'] = l.orientation()
+            if lane.orientation():
+                p['orientation_constraint'] = lane.orientation()
 
-            if 'speed_limit' in l.params and \
-                    l.params['speed_limit'].value > 0.0:
-                p['speed_limit'] = l.params['speed_limit'].value
+            if 'speed_limit' in lane.params and \
+                    lane.params['speed_limit'].value > 0.0:
+                p['speed_limit'] = lane.params['speed_limit'].value
 
-            if 'mutex' in l.params and \
-                    l.params['mutex'].value:
-                p['mutex'] = l.params['mutex'].value
+            if 'mutex' in lane.params and \
+                    lane.params['mutex'].value:
+                p['mutex'] = lane.params['mutex'].value
 
-            if 'demo_mock_floor_name' in l.params and \
-                    l.params['demo_mock_floor_name'].value:
+            if 'demo_mock_floor_name' in lane.params and \
+                    lane.params['demo_mock_floor_name'].value:
                 p['demo_mock_floor_name'] = \
-                    l.params['demo_mock_floor_name'].value
+                    lane.params['demo_mock_floor_name'].value
 
-            if 'demo_mock_lift_name' in l.params and \
-                    l.params['demo_mock_lift_name'].value:
+            if 'demo_mock_lift_name' in lane.params and \
+                    lane.params['demo_mock_lift_name'].value:
                 p['demo_mock_lift_name'] = \
-                    l.params['demo_mock_lift_name'].value
+                    lane.params['demo_mock_lift_name'].value
 
             beginning_dock = None
             end_dock = None
@@ -517,7 +517,7 @@ class Level:
             if 'dock_name' in v1.params:  # lane segment begins at dock
                 beginning_dock = v1.params['dock_name'].value
 
-            if always_unidirectional and l.is_bidirectional():
+            if always_unidirectional and lane.is_bidirectional():
                 # now flip things around and make the second link
                 forward_params = copy.deepcopy(p)
                 backward_params = copy.deepcopy(p)
@@ -532,13 +532,13 @@ class Level:
 
                 nav_data['lanes'].append([start_idx, end_idx, forward_params])
 
-                if l.orientation():
+                if lane.orientation():
                     backward_params['orientation_constraint'] = \
-                        l.reverse_orientation()
+                        lane.reverse_orientation()
                 nav_data['lanes'].append([end_idx, start_idx, backward_params])
             else:
                 # ensure the directionality parameter is set
-                p['is_bidirectional'] = l.is_bidirectional()
+                p['is_bidirectional'] = lane.is_bidirectional()
                 if end_dock:
                     p['dock_name'] = end_dock
                 if beginning_dock:

--- a/rmf_building_map_tools/building_map/templates/gz_world.sdf
+++ b/rmf_building_map_tools/building_map/templates/gz_world.sdf
@@ -6,10 +6,6 @@
       <real_time_factor>1.0</real_time_factor>
     </physics>
     <plugin
-      filename="libgz-sim-physics-system.so"
-      name="gz::sim::systems::Physics">
-    </plugin>
-    <plugin
       filename="libgz-sim-user-commands-system.so"
       name="gz::sim::systems::UserCommands">
     </plugin>

--- a/rmf_building_map_tools/building_map/templates/gz_world.sdf
+++ b/rmf_building_map_tools/building_map/templates/gz_world.sdf
@@ -6,14 +6,6 @@
       <real_time_factor>1.0</real_time_factor>
     </physics>
     <plugin
-      filename="libgz-sim-user-commands-system.so"
-      name="gz::sim::systems::UserCommands">
-    </plugin>
-    <plugin
-      filename="libgz-sim-scene-broadcaster-system.so"
-      name="gz::sim::systems::SceneBroadcaster">
-    </plugin>
-    <plugin
       filename="libdoor.so"
       name="door">
     </plugin>
@@ -66,46 +58,6 @@
           <camera_pose>-6 0 6 0 0.5 0</camera_pose>
       </plugin>
 
-      <!-- Plugins that add functionality to the scene -->
-      <plugin filename="EntityContextMenuPlugin" name="Entity context menu">
-          <gz-gui>
-              <property key="state" type="string">floating</property>
-              <property key="width" type="double">5</property>
-              <property key="height" type="double">5</property>
-              <property key="showTitleBar" type="bool">false</property>
-          </gz-gui>
-      </plugin>
-
-      <plugin filename="GzSceneManager" name="Scene Manager">
-          <gz-gui>
-              <property key="resizable" type="bool">false</property>
-              <property key="width" type="double">5</property>
-              <property key="height" type="double">5</property>
-              <property key="state" type="string">floating</property>
-              <property key="showTitleBar" type="bool">false</property>
-          </gz-gui>
-      </plugin>
-
-      <plugin filename="InteractiveViewControl" name="Interactive view control">
-          <gz-gui>
-              <property key="resizable" type="bool">false</property>
-              <property key="width" type="double">5</property>
-              <property key="height" type="double">5</property>
-              <property key="state" type="string">floating</property>
-              <property key="showTitleBar" type="bool">false</property>
-          </gz-gui>
-      </plugin>
-
-      <plugin filename="CameraTracking" name="Camera Tracking">
-          <gz-gui>
-              <property key="resizable" type="bool">false</property>
-              <property key="width" type="double">5</property>
-              <property key="height" type="double">5</property>
-              <property key="state" type="string">floating</property>
-              <property key="showTitleBar" type="bool">false</property>
-          </gz-gui>
-      </plugin>
-
       <plugin filename="MarkerManager" name="Marker manager">
           <gz-gui>
               <property key="resizable" type="bool">false</property>
@@ -144,47 +96,6 @@
               <property key="state" type="string">floating</property>
               <property key="showTitleBar" type="bool">false</property>
           </gz-gui>
-      </plugin>
-
-      <!-- World control -->
-      <plugin filename="WorldControl" name="World control">
-          <gz-gui>
-              <title>World control</title>
-              <property type="bool" key="showTitleBar">false</property>
-              <property type="bool" key="resizable">false</property>
-              <property type="double" key="height">72</property>
-              <property type="double" key="z">1</property>
-              <property type="string" key="state">floating</property>
-              <anchors target="3D View">
-                  <line own="left" target="left"/>
-                  <line own="bottom" target="bottom"/>
-              </anchors>
-          </gz-gui>
-          <play_pause>true</play_pause>
-          <step>true</step>
-          <start_paused>true</start_paused>
-          <use_event>true</use_event>
-      </plugin>
-
-      <!-- World statistics -->
-      <plugin filename="WorldStats" name="World stats">
-          <gz-gui>
-              <title>World stats</title>
-              <property type="bool" key="showTitleBar">false</property>
-              <property type="bool" key="resizable">false</property>
-              <property type="double" key="height">110</property>
-              <property type="double" key="width">290</property>
-              <property type="double" key="z">1</property>
-              <property type="string" key="state">floating</property>
-              <anchors target="3D View">
-                  <line own="right" target="right"/>
-                  <line own="bottom" target="bottom"/>
-              </anchors>
-          </gz-gui>
-          <sim_time>true</sim_time>
-          <real_time>true</real_time>
-          <real_time_factor>true</real_time_factor>
-          <iterations>true</iterations>
       </plugin>
 
       <!-- Insert simple shapes -->

--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -221,19 +221,19 @@ class BuildingMapServer(Node):
 
                 graph_msg.vertices.append(gn)
 
-            for l in g['lanes']:
+            for lane in g['lanes']:
                 ge = GraphEdge()
-                ge.v1_idx = l[0]
-                ge.v2_idx = l[1]
-                if l[2]['is_bidirectional']:
+                ge.v1_idx = lane[0]
+                ge.v2_idx = lane[1]
+                if lane[2]['is_bidirectional']:
                     ge.edge_type = GraphEdge.EDGE_TYPE_BIDIRECTIONAL
                 else:
                     ge.edge_type = GraphEdge.EDGE_TYPE_UNIDIRECTIONAL
-                if "speed_limit" in l[2]:
+                if "speed_limit" in lane[2]:
                     p = Param()
                     p.name = "speed_limit"
                     p.type = p.TYPE_DOUBLE
-                    p.value_float = float(l[2]["speed_limit"])
+                    p.value_float = float(lane[2]["speed_limit"])
                     ge.params.append(p)
                 graph_msg.edges.append(ge)
             msg.nav_graphs.append(graph_msg)

--- a/rmf_building_map_tools/building_map_server/test/test_map_client.py
+++ b/rmf_building_map_tools/building_map_server/test/test_map_client.py
@@ -26,8 +26,8 @@ class BuildingMapClient(Node):
 
     def print_door(self, door):
         print(f'        {door.name}, ' +
-              f'v1:[{round(door.v1_x, 2)},{round(door.v1_y,2)}], ' +
-              f'v2:[{round(door.v2_x, 2)},{round(door.v2_y,2)}], ' +
+              f'v1:[{round(door.v1_x, 2)},{round(door.v1_y, 2)}], ' +
+              f'v2:[{round(door.v2_x, 2)},{round(door.v2_y, 2)}], ' +
               f'type:{door.door_type}, range:{round(door.motion_range, 2)}, ' +
               f'dir:{door.motion_direction}')
 

--- a/rmf_building_map_tools/test/building_crowdsim/test_build_navmesh.py
+++ b/rmf_building_map_tools/test/building_crowdsim/test_build_navmesh.py
@@ -30,7 +30,7 @@ def test():
                 standard_result)
 
     os.remove(generate_file)
-    assert(result)
+    assert result
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In gz-sim 9, the physics plugin is automatically added. By adding it explicitly in our worlds, we end up creating two competing physics plugins that can end up clashing with each other.

This PR removes the physics plugin from the template so that we don't have that clash.