### PR TITLE
Zone editing UI and YAML serialization for GoToZone feature

### DIFF
--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -7,6 +7,7 @@ import os
 import requests
 import sqlite3
 import tempfile
+import copy 
 import yaml
 
 from ament_index_python.packages import get_package_share_directory
@@ -20,6 +21,7 @@ from .etree_utils import indent_etree
 from .geopackage import GeoPackage
 from .level import Level
 from .lift import Lift
+from .zone import Zone
 from .material_utils import copy_texture
 from .param_value import ParamValue
 from .passthrough_transform import PassthroughTransform
@@ -162,6 +164,14 @@ class Building:
                          self.coordinate_system)
 
         self.set_lift_vert_lists()
+
+        self.zones = {}
+        if 'zones' in yaml_node:
+            transform = self.ref_level.transform
+            for zone_name, zone_yaml in yaml_node['zones'].items():
+                transform = self.levels[str(zone_yaml['level'])].transform
+                self.zones[zone_name] = \
+                    Zone(zone_yaml, zone_name, transform, self.coordinate_system)
 
     def parse_geojson(self, json_node):
         self.levels = {}
@@ -370,6 +380,7 @@ class Building:
             g['levels'] = {}
             g['lifts'] = {}
             g['doors'] = {}
+            g['zones'] = {}
 
             if self.coordinate_system == CoordinateSystem.web_mercator:
                 g['crs_name'] = self.global_transform.crs_name
@@ -390,6 +401,7 @@ class Building:
                 g['levels'][level_name] = level_graph
                 if level_graph['lanes']:
                     empty = False
+                    self.generate_zone_vertices_and_lanes(level_name,level_graph)
 
                 for door_edge in level.doors:
                     door_edge.calc_statistics(level.transformed_vertices)
@@ -406,9 +418,96 @@ class Building:
                     'position': [lift.x, lift.y, lift.yaw],
                     'dims': [lift.width, lift.depth]
                 }
+
+            for zone_name, zone in self.zones.items():
+                g['zones'][zone_name] = {
+                    'dims': [zone.depth, zone.width],
+                    'position': [zone.x, zone.y],
+                    'orientation': zone.yaw,
+                    'level': zone.level,
+                    'type': zone.type,
+                    'transition_lanes': [
+                        {
+                            'internal_vertex': tl['internal_vertex'],
+                            'external_vertex': tl['external_vertex'],
+                            'is_entry_lane': tl['is_entry_lane'],
+                            'is_exit_lane': tl['is_exit_lane']
+                        }
+                        for tl in zone.transition_lanes
+                    ],
+                    'internal_vertices': [
+                        {
+                            'name': v['name'],
+                            'x': v['location'][0],
+                            'y': v['location'][1],
+                            'priority': v['priority'],
+                            'group': v['group']
+                        }
+                        for v in zone.vertices.values()
+                    ]
+                }
+                
             if not empty:
                 nav_graphs[f'{i}'] = g
         return nav_graphs
+
+    def generate_zone_vertices_and_lanes(self, level_name, level_yaml):
+        vertex_names = {v[2]['name'] for v in level_yaml['vertices'] if v[2] != ""}
+
+        for zone_name, zone in self.zones.items():
+            if zone.level != level_name:
+                continue
+
+            # Check if any external point from transition lanes is in this level's vertices
+            external_points = {tl['external_vertex'] for tl in zone.transition_lanes}
+            if not external_points & vertex_names:
+                continue
+
+            # Append zone internal vertices to levels
+            for v in zone.vertices.values():
+                v_property = {
+                    'name': v['name'],
+                    'priority': v['priority'],
+                    'group': v['group']
+                }
+                level_yaml['vertices'].append([v['location'][0], v['location'][1], v_property])
+
+            # Search for transition lane connections
+            for tl in zone.transition_lanes:
+                connecting_lane = []
+
+                # Find index of external vertex
+                for i, vertex in enumerate(level_yaml['vertices']):
+                    if tl['external_vertex'] == vertex[2]['name']:
+                        connecting_lane.append(i)
+                        break
+
+                # Find index of internal vertex
+                for i, vertex in enumerate(level_yaml['vertices']):
+                    name = vertex[2].get('name', '')
+                    if zone_name in name and tl['internal_vertex'] in name:
+                        connecting_lane.append(i)
+                        break
+
+                # To not generate a transition lane if the internal or external entry point is not found
+                if len(connecting_lane) != 2:
+                    continue
+
+                if tl['is_entry_lane']:
+                    level_yaml['lanes'].append(
+                        copy.deepcopy(
+                            [connecting_lane[0],connecting_lane[1],
+                            {'speed_limit': 0,
+                             'zone': {'name': zone.name,
+                                      'transition_type': 'entry'}}]))
+
+                if tl['is_exit_lane']:
+                    level_yaml['lanes'].append(
+                        copy.deepcopy(
+                            [connecting_lane[1],connecting_lane[0],
+                            {'speed_limit': 0,
+                             'zone': {'name': zone.name,
+                                      'transition_type': 'exit'}}]))
 
     def generate_sdf_world(self, template_file, skip_camera_pose):
         """ Return an etree of this Building in SDF starting from a template"""

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -7,7 +7,6 @@ import os
 import requests
 import sqlite3
 import tempfile
-import copy 
 import yaml
 
 from ament_index_python.packages import get_package_share_directory
@@ -173,6 +172,8 @@ class Building:
                 self.zones[zone_name] = \
                     Zone(zone_yaml, zone_name, transform, self.coordinate_system)
 
+        self.set_level_zones()
+
     def parse_geojson(self, json_node):
         self.levels = {}
         self.lifts = {}
@@ -321,6 +322,10 @@ class Building:
         for level_name, level in self.levels.items():
             level.set_lift_vert_lists(lift_vert_lists, self.lifts)
 
+    def set_level_zones(self):
+        for zone_name, zone in self.zones.items():
+            self.levels[zone.level].zones[zone_name] = zone
+
     def transform_all_vertices(self):
         """ Transform all vertices on all levels to a unified system """
         for level_name, level in self.levels.items():
@@ -396,12 +401,16 @@ class Building:
                 g['offset'] = [tx, ty]
 
             empty = True
+            reachable_zones = []
             for level_name, level in self.levels.items():
                 level_graph = level.generate_nav_graph(i)
                 g['levels'][level_name] = level_graph
                 if level_graph['lanes']:
                     empty = False
-                    self.generate_zone_vertices_and_lanes(level_name, level_graph, i)
+
+                for vertex in level_graph['vertices']:
+                    if 'zone' in vertex[2]:
+                        reachable_zones.append(vertex[2]['zone'])
 
                 for door_edge in level.doors:
                     door_edge.calc_statistics(level.transformed_vertices)
@@ -420,109 +429,20 @@ class Building:
                 }
 
             for zone_name, zone in self.zones.items():
+                if zone_name not in reachable_zones:
+                    continue
+
                 g['zones'][zone_name] = {
                     'dims': [zone.depth, zone.width],
                     'position': [zone.x, zone.y],
                     'orientation': zone.yaw,
                     'level': zone.level,
                     'type': zone.type,
-                    'transition_lanes': [
-                        {
-                            'internal_vertex': tl['internal_vertex'],
-                            'external_vertex': tl['external_vertex'],
-                            'is_entry_lane': tl['is_entry_lane'],
-                            'is_exit_lane': tl['is_exit_lane']
-                        }
-                        for tl in zone.transition_lanes
-                    ],
-                    'internal_vertices': [
-                        {
-                            'name': v['name'],
-                            'x': v['location'][0],
-                            'y': v['location'][1],
-                            'priority': v['priority'],
-                            'group': v['group']
-                        }
-                        for v in zone.vertices.values()
-                    ]
                 }
-                
+
             if not empty:
                 nav_graphs[f'{i}'] = g
         return nav_graphs
-
-    def generate_zone_vertices_and_lanes(self, level_name, level_yaml, graph_idx):
-        vertex_names = {v[2]['name'] for v in level_yaml['vertices'] if v[2] != ""}
-
-        for zone_name, zone in self.zones.items():
-            if zone.level != level_name:
-                continue
-
-            # Check if any external point from transition lanes is in this level's vertices
-            external_points = {tl['external_vertex'] for tl in zone.transition_lanes}
-            if not external_points & vertex_names:
-                continue
-
-            # Warn about non-zone vertices that fall inside this zone.
-            for idx, vertex in enumerate(list(level_yaml['vertices'])):
-                if zone.contains_point(vertex[0], vertex[1]):
-                    name = vertex[2].get('name', '')
-                    label = name if name else '(unnamed)'
-                    print(
-                        f'WARNING: regular vertex [{label}] at index [{idx}] in '
-                        f'nav graph [{graph_idx}] lies inside zone [{zone.name}]')
-
-            # Append zone internal vertices to levels
-            for v in zone.vertices.values():
-                # Warn if an internal vertex was placed outside the zone bounds.
-                if not zone.contains_point(v['location'][0], v['location'][1]):
-                    print(
-                        f'WARNING: zone [{zone.name}] internal vertex '
-                        f'[{v["name"]}] lies outside the zone bounds')
-
-                v_property = {
-                    'name': v['name'],
-                    'priority': v['priority'],
-                    'group': v['group']
-                }
-                level_yaml['vertices'].append([v['location'][0], v['location'][1], v_property])
-
-            # Search for transition lane connections
-            for tl in zone.transition_lanes:
-                connecting_lane = []
-
-                # Find index of external vertex
-                for i, vertex in enumerate(level_yaml['vertices']):
-                    if tl['external_vertex'] == vertex[2]['name']:
-                        connecting_lane.append(i)
-                        break
-
-                # Find index of internal vertex
-                for i, vertex in enumerate(level_yaml['vertices']):
-                    name = vertex[2].get('name', '')
-                    if zone_name in name and tl['internal_vertex'] in name:
-                        connecting_lane.append(i)
-                        break
-
-                # To not generate a transition lane if the internal or external entry point is not found
-                if len(connecting_lane) != 2:
-                    continue
-
-                if tl['is_entry_lane']:
-                    level_yaml['lanes'].append(
-                        copy.deepcopy(
-                            [connecting_lane[0],connecting_lane[1],
-                            {'speed_limit': 0,
-                             'zone': {'name': zone.name,
-                                      'transition_type': 'entry'}}]))
-
-                if tl['is_exit_lane']:
-                    level_yaml['lanes'].append(
-                        copy.deepcopy(
-                            [connecting_lane[1],connecting_lane[0],
-                            {'speed_limit': 0,
-                             'zone': {'name': zone.name,
-                                      'transition_type': 'exit'}}]))
 
     def generate_sdf_world(self, template_file, skip_camera_pose):
         """ Return an etree of this Building in SDF starting from a template"""

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -401,7 +401,7 @@ class Building:
                 g['levels'][level_name] = level_graph
                 if level_graph['lanes']:
                     empty = False
-                    self.generate_zone_vertices_and_lanes(level_name,level_graph)
+                    self.generate_zone_vertices_and_lanes(level_name, level_graph, i)
 
                 for door_edge in level.doors:
                     door_edge.calc_statistics(level.transformed_vertices)
@@ -451,7 +451,7 @@ class Building:
                 nav_graphs[f'{i}'] = g
         return nav_graphs
 
-    def generate_zone_vertices_and_lanes(self, level_name, level_yaml):
+    def generate_zone_vertices_and_lanes(self, level_name, level_yaml, graph_idx):
         vertex_names = {v[2]['name'] for v in level_yaml['vertices'] if v[2] != ""}
 
         for zone_name, zone in self.zones.items():
@@ -463,8 +463,23 @@ class Building:
             if not external_points & vertex_names:
                 continue
 
+            # Warn about non-zone vertices that fall inside this zone.
+            for idx, vertex in enumerate(list(level_yaml['vertices'])):
+                if zone.contains_point(vertex[0], vertex[1]):
+                    name = vertex[2].get('name', '')
+                    label = name if name else '(unnamed)'
+                    print(
+                        f'WARNING: regular vertex [{label}] at index [{idx}] in '
+                        f'nav graph [{graph_idx}] lies inside zone [{zone.name}]')
+
             # Append zone internal vertices to levels
             for v in zone.vertices.values():
+                # Warn if an internal vertex was placed outside the zone bounds.
+                if not zone.contains_point(v['location'][0], v['location'][1]):
+                    print(
+                        f'WARNING: zone [{zone.name}] internal vertex '
+                        f'[{v["name"]}] lies outside the zone bounds')
+
                 v_property = {
                     'name': v['name'],
                     'priority': v['priority'],

--- a/rmf_building_map_tools/building_map/building.py
+++ b/rmf_building_map_tools/building_map/building.py
@@ -433,7 +433,7 @@ class Building:
                     continue
 
                 g['zones'][zone_name] = {
-                    'dims': [zone.depth, zone.width],
+                    'dims': [zone.width, zone.depth],
                     'position': [zone.x, zone.y],
                     'orientation': zone.yaw,
                     'level': zone.level,

--- a/rmf_building_map_tools/building_map/level.py
+++ b/rmf_building_map_tools/building_map/level.py
@@ -35,6 +35,7 @@ class Level:
         self.vertices = []
         self.transformed_vertices = []  # will be calculated in a later pass
         self.lift_vert_lists = {}  # will be calculated in a later pass
+        self.zones = {}  # will be set by the building in a later pass
         self.meas = []
         self.lanes = []
         self.walls = []
@@ -81,6 +82,8 @@ class Level:
         self.transformed_vertices = []  # will be calculated in a later pass
 
         self.lift_vert_lists = {}  # will be calculated in a later pass
+
+        self.zones = {}  # will be set by the building in a later pass
 
         self.meas = []
         if 'measurements' in yaml_node:
@@ -546,7 +549,85 @@ class Level:
                     p['undock_name'] = beginning_dock
                 nav_data['lanes'].append([start_idx, end_idx, p])
 
+        if nav_data['lanes']:
+            self.generate_zone_vertices_and_lanes(nav_data, graph_idx)
+
         return nav_data
+
+    def generate_zone_vertices_and_lanes(self, nav_data, graph_idx):
+        """ Append each zone's internal vertices and its derived transition
+        lanes to the nav graph for this level. """
+        num_level_vertices = len(nav_data['vertices'])
+
+        for zone_name, zone in self.zones.items():
+            external_idx = {}
+
+            for ev_name, ev in zone.external_vertices.items():
+                for idx in range(num_level_vertices):
+                    vertex = nav_data['vertices'][idx]
+                    name = vertex[2].get('name', '')
+                    if ev_name and name == ev_name:
+                        external_idx[ev_name] = idx
+                        break
+
+            # the zone is not reachable from this nav graph
+            if not external_idx:
+                continue
+
+            for idx in range(num_level_vertices):
+                vertex = nav_data['vertices'][idx]
+                if zone.contains_point(vertex[0], vertex[1]):
+                    name = vertex[2].get('name', '')
+                    label = name if name else '(unnamed)'
+                    print(
+                        f'WARNING: regular vertex [{label}] at index [{idx}] in '
+                        f'nav graph [{graph_idx}] lies inside zone [{zone_name}]')
+
+            internal_idx = []
+            for v in zone.internal_vertices.values():
+                x, y = v['location']
+                if not zone.contains_point(x, y):
+                    print(
+                        f'WARNING: zone [{zone_name}] internal vertex '
+                        f'[{v["name"]}] lies outside the zone bounds')
+
+                internal_idx.append(len(nav_data['vertices']))
+                nav_data['vertices'].append([x, y, {
+                    'name': v['name'],
+                    'group': v['group'],
+                    'priority': v['priority'],
+                    'zone': zone_name}])
+
+            entry_lanes = 0
+            exit_lanes = 0
+            for ev_name, ev in zone.external_vertices.items():
+                if ev_name not in external_idx:
+                    continue
+                ev_idx = external_idx[ev_name]
+
+                for iv_idx in internal_idx:
+                    if ev['is_entry_point']:
+                        nav_data['lanes'].append([ev_idx, iv_idx, {
+                            'speed_limit': 0,
+                            'zone': {'name': zone_name,
+                                     'transition_type': 'entry'}}])
+                        entry_lanes += 1
+
+                    if ev['is_exit_point']:
+                        nav_data['lanes'].append([iv_idx, ev_idx, {
+                            'speed_limit': 0,
+                            'zone': {'name': zone_name,
+                                     'transition_type': 'exit'}}])
+                        exit_lanes += 1
+
+            if not entry_lanes:
+                print(
+                    f'WARNING: zone [{zone_name}] has no entry lane in nav '
+                    f'graph [{graph_idx}]')
+            if not exit_lanes:
+                print(
+                    f'WARNING: zone [{zone_name}] has no exit lane in nav '
+                    f'graph [{graph_idx}]')
 
     def edge_heading(self, edge):
         vs_x, vs_y = self.transformed_vertices[edge.start_idx].xy()

--- a/rmf_building_map_tools/building_map/zone.py
+++ b/rmf_building_map_tools/building_map/zone.py
@@ -18,12 +18,15 @@ class Zone:
         )
         self.x, self.y = transform.transform_point(self.raw_pos)
         self.type = 'Default'
-        self.vertices = {}
-        if 'vertices' in yaml_node:
-            self.vertices = self.parse_vertices(yaml_node)
 
-        if 'transition_lanes' in yaml_node:
-            self.transition_lanes = self.parse_transition_lanes(yaml_node)
+        self.internal_vertices = {}
+        if 'internal_vertices' in yaml_node:
+            self.internal_vertices = self.parse_internal_vertices(yaml_node['internal_vertices'])
+
+        self.external_vertices = {}
+        if 'external_vertices' in yaml_node:
+            self.external_vertices = self.parse_external_vertices(
+                yaml_node['external_vertices'])
 
     def contains_point(self, x, y):
         # Test whether a point in global coordinates lies inside the zone
@@ -36,28 +39,12 @@ class Zone:
         local_y = -s * dx + c * dy
         return abs(local_x) <= self.width / 2 and abs(local_y) <= self.depth / 2
 
-    def parse_transition_lanes(self, yaml_node):
-        transition_lanes = []
-        for transition_lane in yaml_node['transition_lanes']:
-            internal_vertex = self.construct_unique_vertex_name(
-                transition_lane['internal_vertex'], yaml_node['vertices']
-            )
-            transition_lanes.append(
-                {
-                    'internal_vertex': internal_vertex,
-                    'external_vertex': transition_lane['external_vertex'],
-                    'is_entry_lane': transition_lane['is_entry_lane'],
-                    'is_exit_lane': transition_lane['is_exit_lane'],
-                }
-            )
-        return transition_lanes
-
-    def construct_unique_vertex_name(self, desired_vertex_name, vertices_yaml):
+    def construct_unique_vertex_name(self, vertex_name, vertices_yaml):
         # Defining the name of the vertices.
         # The formatting for now is:
-        # <zone_name>_<vertex_name>_<group>_<priority>
+        # <zone_name>#<group>#<priority>#<vertex_name>
 
-        vertex_yaml = vertices_yaml[desired_vertex_name]
+        vertex_yaml = vertices_yaml[vertex_name]
         return (
             self.name
             + '#'
@@ -65,14 +52,12 @@ class Zone:
             + '#p'
             + str(vertex_yaml['priority'])
             + '#'
-            + desired_vertex_name
+            + vertex_name
         )
 
-    def parse_vertices(self, yaml_node):
+    def parse_internal_vertices(self, yaml_node):
         vertices = {}
-        for vertice_name, vertex_yaml in yaml_node['vertices'].items():
-            # Calculating the location of vertices, transforming it from zone 
-            # local coordinate to global coordinate
+        for vertex_name, vertex_yaml in yaml_node.items():
             x = (
                 vertex_yaml['x'] * np.cos(self.yaw)
                 + vertex_yaml['y'] * np.sin(self.yaw)
@@ -84,16 +69,23 @@ class Zone:
                 + self.y
             )
             unique_vertex_name = self.construct_unique_vertex_name(
-                vertice_name, yaml_node['vertices']
+                vertex_name, yaml_node
             )
 
-            p = {}
-            p['name'] = unique_vertex_name
-
-            vertices[vertice_name] = {
+            vertices[vertex_name] = {
                 'name': unique_vertex_name,
                 'location': [float(x), float(y)],
-                'priority': str(vertex_yaml['priority']),
+                'priority': int(vertex_yaml['priority']),
                 'group': vertex_yaml['group'],
+            }
+        return vertices
+
+    def parse_external_vertices(self, yaml_node):
+        vertices = {}
+        for vertex_name, vertex_yaml in yaml_node.items():
+            vertices[vertex_name] = {
+                'name': vertex_name,
+                'is_entry_point': bool(vertex_yaml['is_entry_point']),
+                'is_exit_point': bool(vertex_yaml['is_exit_point']),
             }
         return vertices

--- a/rmf_building_map_tools/building_map/zone.py
+++ b/rmf_building_map_tools/building_map/zone.py
@@ -9,7 +9,7 @@ class Zone:
         self.level = str(yaml_node['level'])
         self.depth = float(yaml_node['depth'])
         self.width = float(yaml_node['width'])
-        self.yaw = float(yaml_node['yaw']) + np.pi / 2
+        self.yaw = float(yaml_node['yaw'])
 
         # Calculating the center of the zone
         self.raw_pos = (
@@ -32,8 +32,8 @@ class Zone:
         dy = y - self.y
         s = np.sin(self.yaw)
         c = np.cos(self.yaw)
-        local_x = s * dx - c * dy
-        local_y = -c * dx - s * dy
+        local_x = c * dx + s * dy
+        local_y = -s * dx + c * dy
         return abs(local_x) <= self.width / 2 and abs(local_y) <= self.depth / 2
 
     def parse_transition_lanes(self, yaml_node):
@@ -71,15 +71,16 @@ class Zone:
     def parse_vertices(self, yaml_node):
         vertices = {}
         for vertice_name, vertex_yaml in yaml_node['vertices'].items():
-            # Calculating the location of vertices, transforming it from zone local coordinate to global coordinate
+            # Calculating the location of vertices, transforming it from zone 
+            # local coordinate to global coordinate
             x = (
-                vertex_yaml['x'] * np.sin(self.yaw)
-                - vertex_yaml['y'] * np.cos(self.yaw)
+                vertex_yaml['x'] * np.cos(self.yaw)
+                + vertex_yaml['y'] * np.sin(self.yaw)
                 + self.x
             )
             y = (
-                -vertex_yaml['y'] * np.sin(self.yaw)
-                - vertex_yaml['x'] * np.cos(self.yaw)
+                vertex_yaml['x'] * np.sin(self.yaw)
+                - vertex_yaml['y'] * np.cos(self.yaw)
                 + self.y
             )
             unique_vertex_name = self.construct_unique_vertex_name(

--- a/rmf_building_map_tools/building_map/zone.py
+++ b/rmf_building_map_tools/building_map/zone.py
@@ -9,7 +9,7 @@ class Zone:
         self.level = str(yaml_node['level'])
         self.depth = float(yaml_node['depth'])
         self.width = float(yaml_node['width'])
-        self.yaw = float(yaml_node['yaw'])
+        self.yaw = (float(yaml_node['yaw']) + transform.rotation)
 
         # Calculating the center of the zone
         self.raw_pos = (

--- a/rmf_building_map_tools/building_map/zone.py
+++ b/rmf_building_map_tools/building_map/zone.py
@@ -39,22 +39,6 @@ class Zone:
         local_y = -s * dx + c * dy
         return abs(local_x) <= self.width / 2 and abs(local_y) <= self.depth / 2
 
-    def construct_unique_vertex_name(self, vertex_name, vertices_yaml):
-        # Defining the name of the vertices.
-        # The formatting for now is:
-        # <zone_name>#<group>#<priority>#<vertex_name>
-
-        vertex_yaml = vertices_yaml[vertex_name]
-        return (
-            self.name
-            + '#'
-            + vertex_yaml['group']
-            + '#p'
-            + str(vertex_yaml['priority'])
-            + '#'
-            + vertex_name
-        )
-
     def parse_internal_vertices(self, yaml_node):
         vertices = {}
         for vertex_name, vertex_yaml in yaml_node.items():
@@ -68,12 +52,8 @@ class Zone:
                 - vertex_yaml['y'] * np.cos(self.yaw)
                 + self.y
             )
-            unique_vertex_name = self.construct_unique_vertex_name(
-                vertex_name, yaml_node
-            )
-
             vertices[vertex_name] = {
-                'name': unique_vertex_name,
+                'name': vertex_name,
                 'location': [float(x), float(y)],
                 'priority': int(vertex_yaml['priority']),
                 'group': vertex_yaml['group'],

--- a/rmf_building_map_tools/building_map/zone.py
+++ b/rmf_building_map_tools/building_map/zone.py
@@ -25,6 +25,17 @@ class Zone:
         if 'transition_lanes' in yaml_node:
             self.transition_lanes = self.parse_transition_lanes(yaml_node)
 
+    def contains_point(self, x, y):
+        # Test whether a point in global coordinates lies inside the zone
+        # rectangle.
+        dx = x - self.x
+        dy = y - self.y
+        s = np.sin(self.yaw)
+        c = np.cos(self.yaw)
+        local_x = s * dx - c * dy
+        local_y = -c * dx - s * dy
+        return abs(local_x) <= self.width / 2 and abs(local_y) <= self.depth / 2
+
     def parse_transition_lanes(self, yaml_node):
         transition_lanes = []
         for transition_lane in yaml_node['transition_lanes']:

--- a/rmf_building_map_tools/building_map/zone.py
+++ b/rmf_building_map_tools/building_map/zone.py
@@ -1,0 +1,87 @@
+import numpy as np
+
+
+class Zone:
+    def __init__(self, yaml_node, name, transform, coordinate_system):
+        self.name = name
+        print(f'parsing zone {name}')
+
+        self.level = str(yaml_node['level'])
+        self.depth = float(yaml_node['depth'])
+        self.width = float(yaml_node['width'])
+        self.yaw = float(yaml_node['yaw']) + np.pi / 2
+
+        # Calculating the center of the zone
+        self.raw_pos = (
+            float(yaml_node['x']),
+            float(yaml_node['y'] * coordinate_system.y_flip_scalar()),
+        )
+        self.x, self.y = transform.transform_point(self.raw_pos)
+        self.type = 'Default'
+        self.vertices = {}
+        if 'vertices' in yaml_node:
+            self.vertices = self.parse_vertices(yaml_node)
+
+        if 'transition_lanes' in yaml_node:
+            self.transition_lanes = self.parse_transition_lanes(yaml_node)
+
+    def parse_transition_lanes(self, yaml_node):
+        transition_lanes = []
+        for transition_lane in yaml_node['transition_lanes']:
+            internal_vertex = self.construct_unique_vertex_name(
+                transition_lane['internal_vertex'], yaml_node['vertices']
+            )
+            transition_lanes.append(
+                {
+                    'internal_vertex': internal_vertex,
+                    'external_vertex': transition_lane['external_vertex'],
+                    'is_entry_lane': transition_lane['is_entry_lane'],
+                    'is_exit_lane': transition_lane['is_exit_lane'],
+                }
+            )
+        return transition_lanes
+
+    def construct_unique_vertex_name(self, desired_vertex_name, vertices_yaml):
+        # Defining the name of the vertices.
+        # The formatting for now is:
+        # <zone_name>_<vertex_name>_<group>_<priority>
+
+        vertex_yaml = vertices_yaml[desired_vertex_name]
+        return (
+            self.name
+            + '#'
+            + vertex_yaml['group']
+            + '#p'
+            + str(vertex_yaml['priority'])
+            + '#'
+            + desired_vertex_name
+        )
+
+    def parse_vertices(self, yaml_node):
+        vertices = {}
+        for vertice_name, vertex_yaml in yaml_node['vertices'].items():
+            # Calculating the location of vertices, transforming it from zone local coordinate to global coordinate
+            x = (
+                vertex_yaml['x'] * np.sin(self.yaw)
+                - vertex_yaml['y'] * np.cos(self.yaw)
+                + self.x
+            )
+            y = (
+                -vertex_yaml['y'] * np.sin(self.yaw)
+                - vertex_yaml['x'] * np.cos(self.yaw)
+                + self.y
+            )
+            unique_vertex_name = self.construct_unique_vertex_name(
+                vertice_name, yaml_node['vertices']
+            )
+
+            p = {}
+            p['name'] = unique_vertex_name
+
+            vertices[vertice_name] = {
+                'name': unique_vertex_name,
+                'location': [float(x), float(y)],
+                'priority': str(vertex_yaml['priority']),
+                'group': vertex_yaml['group'],
+            }
+        return vertices

--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -226,7 +226,7 @@ class BuildingMapServer(Node):
                 ge = GraphEdge()
                 ge.v1_idx = lane[0]
                 ge.v2_idx = lane[1]
-                if lane[2]['is_bidirectional']:
+                if lane[2].get('is_bidirectional', False):
                     ge.edge_type = GraphEdge.EDGE_TYPE_BIDIRECTIONAL
                 else:
                     ge.edge_type = GraphEdge.EDGE_TYPE_UNIDIRECTIONAL

--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -21,6 +21,8 @@ from rmf_building_map_msgs.msg import Level
 from rmf_building_map_msgs.msg import Graph
 from rmf_building_map_msgs.msg import GraphNode
 from rmf_building_map_msgs.msg import GraphEdge
+from rmf_building_map_msgs.msg import GraphZone
+from rmf_building_map_msgs.msg import ZoneVertex
 from rmf_building_map_msgs.msg import Place
 from rmf_building_map_msgs.msg import AffineImage
 from rmf_building_map_msgs.msg import Door
@@ -193,6 +195,7 @@ class BuildingMapServer(Node):
                 continue  # empty graph :(
             graph_msg = Graph()
             graph_msg.name = str(i)  # todo: someday, string names...
+            zone_vertices = {}
             print(f"graph {i} has {len(g['vertices'])} vertices")
             for v in g['vertices']:
                 gn = self.create_graph_node(v[0], v[1], v[2]['name'])
@@ -222,6 +225,18 @@ class BuildingMapServer(Node):
 
                 graph_msg.vertices.append(gn)
 
+                if 'zone' in v[2]:
+                    zv = ZoneVertex()
+                    zv.name = str(v[2]['name'])
+                    zv.group = str(v[2]['group'])
+                    zv.priority = v[2]['priority']
+
+                    zone_name = v[2]['zone']
+                    if zone_name not in zone_vertices:
+                        zone_vertices[zone_name] = []
+
+                    zone_vertices[zone_name].append(zv)
+
             for lane in g['lanes']:
                 ge = GraphEdge()
                 ge.v1_idx = lane[0]
@@ -243,6 +258,13 @@ class BuildingMapServer(Node):
                     p.value_string = lane[2]["mutex"]
                     ge.params.append(p)
                 graph_msg.edges.append(ge)
+
+            for zone_name, zone_data in level.zones.items():
+                if zone_name not in zone_vertices:
+                    continue  # zone is not reachable from this graph
+                graph_msg.zones.append(
+                    self.zone_msg(zone_data, zone_vertices[zone_name]))
+
             msg.nav_graphs.append(graph_msg)
 
         # Populate the wall graph
@@ -317,6 +339,20 @@ class BuildingMapServer(Node):
             door_msg.motion_range = 1.571
             door_msg.motion_direction = -1
             msg.doors.append(door_msg)
+        return msg
+
+    def zone_msg(self, zone, vertices):
+        msg = GraphZone()
+        # transformation is already done in Zone class
+        msg.center_x, msg.center_y = zone.x, zone.y
+        msg.name = str(zone.name)
+        msg.level = str(zone.level)
+        msg.type = str(zone.type)
+
+        msg.yaw = zone.yaw
+        msg.length = zone.depth
+        msg.width = zone.width
+        msg.vertices = vertices
         return msg
 
     def get_building_map(self, request, response):

--- a/rmf_traffic_editor/CMakeLists.txt
+++ b/rmf_traffic_editor/CMakeLists.txt
@@ -85,6 +85,9 @@ set(gui_sources
   gui/transform.cpp
   gui/vertex.cpp
   gui/yaml_utils.cpp
+  gui/zone.cpp
+  gui/zone_dialog.cpp
+  gui/zone_table.cpp
 
   #crowd_sim related
   gui/multi_select_combo_box.cpp

--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -152,6 +152,18 @@ bool Building::load(const string& _filename)
     }
   }
 
+  zones.clear();
+  if (y["zones"] && y["zones"].IsMap())
+  {
+    const YAML::Node& y_zones = y["zones"];
+    for (YAML::const_iterator it = y_zones.begin(); it != y_zones.end(); ++it)
+    {
+      Zone zone;
+      zone.from_yaml(it->first.as<string>(), it->second, levels);
+      zones.push_back(zone);
+    }
+  }
+
   if (y["graphs"] && y["graphs"].IsMap())
   {
     const YAML::Node& g_map = y["graphs"];
@@ -199,6 +211,12 @@ bool Building::save()
     y["lifts"][lift.name] = lift.to_yaml();
   if (lifts.empty())
     y["lifts"].SetStyle(YAML::EmitterStyle::Flow);
+
+  y["zones"] = YAML::Node(YAML::NodeType::Map);
+  for (const auto& zone : zones)
+    y["zones"][zone.name] = zone.to_yaml();
+  if (zones.empty())
+    y["zones"].SetStyle(YAML::EmitterStyle::Flow);
 
   if (crowd_sim_impl)
     y["crowd_sim"] = crowd_sim_impl->to_yaml();
@@ -433,6 +451,150 @@ void Building::draw_lifts(QGraphicsScene* scene, const int level_idx)
       t.dx,
       t.dy,
       t.rotation);
+  }
+}
+
+void Building::draw_zones(const RenderingOptions& rendering_options,
+  QGraphicsScene* scene, const int level_idx)
+{
+  const Level& level = levels[level_idx];
+  for (const auto& zone : zones)
+  {
+    // find the level index referenced by the zone
+    int reference_floor_idx = -1;
+    for (std::size_t i = 0; i < levels.size(); i++)
+    {
+      if (levels[i].name == zone.level)
+      {
+        reference_floor_idx = static_cast<int>(i);
+        break;
+      }
+    }
+
+    Transform t;
+    if (reference_floor_idx >= 0)
+      t = get_transform(reference_floor_idx, level_idx);
+
+    zone.draw(
+      scene,
+      level.drawing_meters_per_pixel,
+      level.name,
+      level.elevation,
+      true,
+      t.scale,
+      t.dx,
+      t.dy);
+
+    if (level.name == zone.level)
+    {
+
+      if (!zone.show_zone)
+        continue;
+
+      for (const auto& lane : zone.transition_lanes)
+      {
+        double internal_x;
+        double internal_y;
+        double external_x;
+        double external_y;
+        for (const auto& vertex : zone.vertices)
+        {
+          if (lane.internal_vertex == vertex.name)
+          {
+            double rotation;
+            rotation = - zone.yaw - M_PI/2;
+            internal_x =
+              (-vertex.y/level.drawing_meters_per_pixel*
+              cos(rotation) -
+              vertex.x/level.drawing_meters_per_pixel
+              *sin(rotation) + zone.x) * t.scale + t.dx;
+            internal_y =
+              (vertex.x/level.drawing_meters_per_pixel*
+              cos(rotation) -
+              vertex.y/level.drawing_meters_per_pixel*
+              sin(rotation) + zone.y) * t.scale + t.dy;
+            break;
+          }
+        }
+
+        for (const auto& vertex : level.vertices)
+        {
+          if (lane.external_vertex == vertex.name)
+          {
+            external_x = vertex.x;
+            external_y = vertex.y;
+            break;
+          }
+        }
+
+        const double lane_pen_width = 0.5 / level.drawing_meters_per_pixel;
+        const QPen arrow_pen(QBrush(QColor::fromRgbF(0.0, 0.0, 0.0, 0.4)),
+          lane_pen_width, Qt::SolidLine, Qt::RoundCap);
+        QGraphicsLineItem* transition_lane = scene->addLine(internal_x,
+            internal_y,
+            external_x,
+            external_y,
+            arrow_pen);
+
+        if (!lane.is_exit_lane || !lane.is_entry_lane)
+        {
+          double dx;
+          double dy;
+          if (!lane.is_exit_lane)
+          {
+            dx = internal_x - external_x;
+            dy = internal_y - external_y;
+          }
+          if (!lane.is_entry_lane)
+          {
+            dx = external_x - internal_x;
+            dy = external_y - internal_y;
+          }
+          const double len = std::sqrt(dx*dx + dy*dy);
+          const double lane_pen_width = 0.5 / level.drawing_meters_per_pixel;
+          const double norm_x = dx / len;
+          const double norm_y = dy / len;
+
+          const QPen arrow_pen(
+            QBrush(QColor::fromRgbF(0.0, 0.0, 0.0, 0.5)),
+            lane_pen_width / 8);
+
+          // dimensions for the direction indicators along this path
+          const double arrow_w = lane_pen_width / 2.5;  // width of arrowheads
+          const double arrow_l = lane_pen_width / 2.5;  // length of arrowheads
+          const double arrow_spacing = lane_pen_width * 4.0;
+
+          for (double d = 0.0; d < len; d += arrow_spacing)
+          {
+            // first calculate the center vertex of this arrowhead
+            double cx;
+            double cy;
+            if (!lane.is_entry_lane)
+            {
+              cx = internal_x + d * norm_x;
+              cy = internal_y + d * norm_y;
+            }
+            if (!lane.is_exit_lane)
+            {
+              cx = external_x + d * norm_x;
+              cy = external_y + d * norm_y;
+            }
+            // one edge vertex of arrowhead
+            const double e1x = cx - arrow_w * norm_y;
+            const double e1y = cy + arrow_w * norm_x;
+            // another edge vertex of arrowhead
+            const double e2x = cx + arrow_w * norm_y;
+            const double e2y = cy - arrow_w * norm_x;
+            // tip of arrowhead
+            const double tx = cx + arrow_l * norm_x;
+            const double ty = cy + arrow_l * norm_y;
+            // now add arrowhead lines
+            scene->addLine(e1x, e1y, tx, ty, arrow_pen);
+            scene->addLine(e2x, e2y, tx, ty, arrow_pen);
+          }
+        }
+      }
+    }
   }
 }
 
@@ -790,6 +952,7 @@ void Building::draw(
     coordinate_system);
 
   draw_lifts(scene, level_idx);
+  draw_zones(rendering_options, scene, level_idx);
 }
 
 Polygon* Building::get_selected_polygon(const int level_idx)

--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -460,141 +460,15 @@ void Building::draw_zones(const RenderingOptions& rendering_options,
   const Level& level = levels[level_idx];
   for (const auto& zone : zones)
   {
-    // find the level index referenced by the zone
-    int reference_floor_idx = -1;
-    for (std::size_t i = 0; i < levels.size(); i++)
-    {
-      if (levels[i].name == zone.level)
-      {
-        reference_floor_idx = static_cast<int>(i);
-        break;
-      }
-    }
-
-    Transform t;
-    if (reference_floor_idx >= 0)
-      t = get_transform(reference_floor_idx, level_idx);
+    if (zone.level != level.name)
+      continue;
 
     zone.draw(
       scene,
       level.drawing_meters_per_pixel,
       level.name,
-      level.elevation,
       true,
-      t.scale,
-      t.dx,
-      t.dy);
-
-    if (level.name == zone.level)
-    {
-
-      if (!zone.show_zone)
-        continue;
-
-      for (const auto& lane : zone.transition_lanes)
-      {
-        double internal_x;
-        double internal_y;
-        double external_x;
-        double external_y;
-        for (const auto& vertex : zone.vertices)
-        {
-          if (lane.internal_vertex == vertex.name)
-          {
-            double rotation;
-            rotation = - zone.yaw - M_PI/2;
-            internal_x =
-              (-vertex.y/level.drawing_meters_per_pixel*
-              cos(rotation) -
-              vertex.x/level.drawing_meters_per_pixel
-              *sin(rotation) + zone.x) * t.scale + t.dx;
-            internal_y =
-              (vertex.x/level.drawing_meters_per_pixel*
-              cos(rotation) -
-              vertex.y/level.drawing_meters_per_pixel*
-              sin(rotation) + zone.y) * t.scale + t.dy;
-            break;
-          }
-        }
-
-        for (const auto& vertex : level.vertices)
-        {
-          if (lane.external_vertex == vertex.name)
-          {
-            external_x = vertex.x;
-            external_y = vertex.y;
-            break;
-          }
-        }
-
-        const double lane_pen_width = 0.5 / level.drawing_meters_per_pixel;
-        const QPen arrow_pen(QBrush(QColor::fromRgbF(0.0, 0.0, 0.0, 0.4)),
-          lane_pen_width, Qt::SolidLine, Qt::RoundCap);
-        QGraphicsLineItem* transition_lane = scene->addLine(internal_x,
-            internal_y,
-            external_x,
-            external_y,
-            arrow_pen);
-
-        if (!lane.is_exit_lane || !lane.is_entry_lane)
-        {
-          double dx;
-          double dy;
-          if (!lane.is_exit_lane)
-          {
-            dx = internal_x - external_x;
-            dy = internal_y - external_y;
-          }
-          if (!lane.is_entry_lane)
-          {
-            dx = external_x - internal_x;
-            dy = external_y - internal_y;
-          }
-          const double len = std::sqrt(dx*dx + dy*dy);
-          const double lane_pen_width = 0.5 / level.drawing_meters_per_pixel;
-          const double norm_x = dx / len;
-          const double norm_y = dy / len;
-
-          const QPen arrow_pen(
-            QBrush(QColor::fromRgbF(0.0, 0.0, 0.0, 0.5)),
-            lane_pen_width / 8);
-
-          // dimensions for the direction indicators along this path
-          const double arrow_w = lane_pen_width / 2.5;  // width of arrowheads
-          const double arrow_l = lane_pen_width / 2.5;  // length of arrowheads
-          const double arrow_spacing = lane_pen_width * 4.0;
-
-          for (double d = 0.0; d < len; d += arrow_spacing)
-          {
-            // first calculate the center vertex of this arrowhead
-            double cx;
-            double cy;
-            if (!lane.is_entry_lane)
-            {
-              cx = internal_x + d * norm_x;
-              cy = internal_y + d * norm_y;
-            }
-            if (!lane.is_exit_lane)
-            {
-              cx = external_x + d * norm_x;
-              cy = external_y + d * norm_y;
-            }
-            // one edge vertex of arrowhead
-            const double e1x = cx - arrow_w * norm_y;
-            const double e1y = cy + arrow_w * norm_x;
-            // another edge vertex of arrowhead
-            const double e2x = cx + arrow_w * norm_y;
-            const double e2y = cy - arrow_w * norm_x;
-            // tip of arrowhead
-            const double tx = cx + arrow_l * norm_x;
-            const double ty = cy + arrow_l * norm_y;
-            // now add arrowhead lines
-            scene->addLine(e1x, e1y, tx, ty, arrow_pen);
-            scene->addLine(e2x, e2y, tx, ty, arrow_pen);
-          }
-        }
-      }
-    }
+      level.vertices);
   }
 }
 

--- a/rmf_traffic_editor/gui/building.h
+++ b/rmf_traffic_editor/gui/building.h
@@ -33,6 +33,7 @@ class QGraphicsScene;
 #include "graph.h"
 #include "level.h"
 #include "lift.h"
+#include "zone.h"
 #include "param.h"
 #include <traffic_editor/crowd_sim/crowd_sim_impl.h>
 #include "rendering_options.h"
@@ -47,6 +48,7 @@ public:
   std::string reference_level_name;
   std::vector<Level> levels;
   std::vector<Lift> lifts;
+  std::vector<Zone> zones;
   std::vector<Graph> graphs;
   std::map<std::string, Param> params;
   CoordinateSystem coordinate_system;
@@ -115,6 +117,8 @@ public:
     const double yaw);
 
   void draw_lifts(QGraphicsScene* scene, const int level_idx);
+  void draw_zones(const RenderingOptions& rendering_options,
+    QGraphicsScene* scene, const int level_idx);
 
   bool transform_between_levels(
     const std::string& from_level_name,

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -62,7 +62,7 @@
 #include "traffic_table.h"
 #include "ui_new_building_dialog.h"
 #include "ui_transform_dialog.h"
-
+#include "zone_table.h"
 
 using std::string;
 using std::isnan;
@@ -179,6 +179,12 @@ Editor::Editor()
     &TableList::redraw,
     [this]() { this->create_scene(); });
 
+  zone_table = new ZoneTable;
+  connect(
+    zone_table,
+    &TableList::redraw,
+    [this]() { this->create_scene(); });
+
   traffic_table = new TrafficTable;
   connect(
     traffic_table,
@@ -210,6 +216,7 @@ Editor::Editor()
   right_tab_widget->addTab(level_table, "levels");
   right_tab_widget->addTab(layer_table, "layers");
   right_tab_widget->addTab(lift_table, "lifts");
+  right_tab_widget->addTab(zone_table, "zones");
   right_tab_widget->addTab(traffic_table, "graphs");
   right_tab_widget->addTab(crowd_sim_table, "crowds");
 
@@ -2849,6 +2856,7 @@ void Editor::update_tables()
 {
   level_table->update(building);
   lift_table->update(building);
+  zone_table->update(building);
   traffic_table->update(rendering_options);
   crowd_sim_table->update();
   layer_table->update(building, level_idx, layer_idx);

--- a/rmf_traffic_editor/gui/editor.h
+++ b/rmf_traffic_editor/gui/editor.h
@@ -49,6 +49,7 @@ class LevelTable;
 class MapView;
 class Level;
 class LiftTable;
+class ZoneTable;
 class TrafficTable;
 class CrowdSimTable;
 
@@ -117,7 +118,6 @@ private:
     TOOL_ROTATE,
     TOOL_ADD_FLOOR,
     TOOL_EDIT_POLYGON,
-    TOOL_ADD_ZONE,
     TOOL_ADD_FEATURE,
     TOOL_ADD_CONSTRAINT,
     TOOL_ADD_FIDUCIAL,
@@ -210,6 +210,7 @@ private:
   LevelTable* level_table = nullptr;
   LayerTable* layer_table = nullptr;
   LiftTable* lift_table = nullptr;
+  ZoneTable* zone_table = nullptr;
   TrafficTable* traffic_table = nullptr;
   CrowdSimEditorTable* crowd_sim_table = nullptr;
 

--- a/rmf_traffic_editor/gui/zone.cpp
+++ b/rmf_traffic_editor/gui/zone.cpp
@@ -25,7 +25,7 @@
 #include "zone.h"
 using std::string;
 
-YAML::Node ZoneVertex::to_yaml() const
+YAML::Node InternalVertex::to_yaml() const
 {
   YAML::Node n;
   n["x"] = std::round(x * 1000.0) / 1000.0;
@@ -36,34 +36,33 @@ YAML::Node ZoneVertex::to_yaml() const
   return n;
 }
 
-void ZoneVertex::from_yaml(const std::string& _name, const YAML::Node& data)
+void InternalVertex::from_yaml(const std::string& _name, const YAML::Node& data)
 {
   if (!data.IsMap())
-    throw std::runtime_error("ZoneVertex::from_yaml() expected a map");
+    throw std::runtime_error("InternalVertex::from_yaml() expected a map");
   name = _name;
   x = data["x"].as<double>();
   y = data["y"].as<double>();
-  priority = data["priority"].as<std::size_t>();
+  priority = data["priority"].as<uint>();
   group = data["group"].as<std::string>();
 }
 
-YAML::Node ZoneTransitionLane::to_yaml() const
+YAML::Node ExternalVertex::to_yaml() const
 {
   YAML::Node n;
-  n["internal_vertex"] = internal_vertex;
-  n["external_vertex"] = external_vertex;
-  n["is_exit_lane"] = is_exit_lane;
-  n["is_entry_lane"] = is_entry_lane;
+  n["is_entry_point"] = is_entry_point;
+  n["is_exit_point"] = is_exit_point;
 
   return n;
 }
 
-void ZoneTransitionLane::from_yaml(const YAML::Node& data)
+void ExternalVertex::from_yaml(const std::string& _name, const YAML::Node& data)
 {
-  is_exit_lane = data["is_exit_lane"].as<bool>();
-  is_entry_lane = data["is_entry_lane"].as<bool>();
-  external_vertex = data["external_vertex"].as<std::string>();
-  internal_vertex = data["internal_vertex"].as<std::string>();
+  if (!data.IsMap())
+    throw std::runtime_error("ExternalVertex::from_yaml() expected a map");
+  name = _name;
+  is_entry_point = data["is_entry_point"].as<bool>();
+  is_exit_point = data["is_exit_point"].as<bool>();
 }
 
 Zone::Zone()
@@ -87,7 +86,7 @@ void Zone::from_yaml(
   {
     if (map_level.name == level)
     {
-      zone_elevation = map_level.elevation;
+      elevation = map_level.elevation;
       break;
     }
   }
@@ -95,27 +94,27 @@ void Zone::from_yaml(
   width = data["width"].as<double>();
   depth = data["depth"].as<double>();
 
-  if (data["vertices"] && data["vertices"].IsMap())
+  if (data["internal_vertices"] && data["internal_vertices"].IsMap())
   {
-    const YAML::Node& yd = data["vertices"];
-    for (YAML::const_iterator it = yd.begin(); it != yd.end(); ++it)
+    const YAML::Node& v = data["internal_vertices"];
+    for (YAML::const_iterator it = v.begin(); it != v.end(); ++it)
     {
-      ZoneVertex vertex;
-      vertex.from_yaml(it->first.as<string>(), it->second);
-      vertices.push_back(vertex);
+      InternalVertex iv;
+      iv.from_yaml(it->first.as<string>(), it->second);
+      internal_vertices.push_back(iv);
     }
   }
 
-  if (data["transition_lanes"] && data["transition_lanes"].IsSequence())
+  if (data["external_vertices"] && data["external_vertices"].IsMap())
   {
-    for (const auto& lane : data["transition_lanes"])
+    const YAML::Node& v = data["external_vertices"];
+    for (YAML::const_iterator it = v.begin(); it != v.end(); ++it)
     {
-      ZoneTransitionLane transition_lane;
-      transition_lane.from_yaml(lane);
-      transition_lanes.push_back(transition_lane);
+      ExternalVertex ev;
+      ev.from_yaml(it->first.as<string>(), it->second);
+      external_vertices.push_back(ev);
     }
   }
-
 }
 
 YAML::Node Zone::to_yaml() const
@@ -129,12 +128,13 @@ YAML::Node Zone::to_yaml() const
   n["width"] = std::round(width * 1000.0) / 1000.0;
   n["depth"] = std::round(depth * 1000.0) / 1000.0;
 
-  n["vertices"] = YAML::Node(YAML::NodeType::Map);
-  for (const auto& vertex : vertices)
-    n["vertices"][vertex.name] = vertex.to_yaml();
-  n["transition_lanes"] = YAML::Node(YAML::NodeType::Sequence);
-  for (const auto& transition_lane : transition_lanes)
-    n["transition_lanes"].push_back(transition_lane.to_yaml());
+  n["internal_vertices"] = YAML::Node(YAML::NodeType::Map);
+  for (const auto& iv : internal_vertices)
+    n["internal_vertices"][iv.name] = iv.to_yaml();
+
+  n["external_vertices"] = YAML::Node(YAML::NodeType::Map);
+  for (const auto& ev : external_vertices)
+    n["external_vertices"][ev.name] = ev.to_yaml();
   return n;
 }
 
@@ -142,33 +142,31 @@ void Zone::draw(
   QGraphicsScene* scene,
   const double meters_per_pixel,
   const string& level_name,
-  const double elevation,
   const bool apply_transformation,
-  const double scale,
-  const double translate_x,
-  const double translate_y) const
+  const std::vector<Vertex>& level_vertices) const
 {
-  if (!show_zone)
+  if (!show_zone && apply_transformation)
     return;
 
-  if (elevation != zone_elevation)
+  if (level_name != level && apply_transformation)
     return;
-  const double cabin_w = width / meters_per_pixel;
-  const double cabin_d = depth / meters_per_pixel;
-  QPen cabin_pen(Qt::black);
-  cabin_pen.setWidth(0.05 / meters_per_pixel);
 
-  QGraphicsRectItem* cabin_rect = new QGraphicsRectItem(
-    -cabin_w / 2.0,
-    -cabin_d / 2.0,
-    cabin_w,
-    cabin_d);
-  cabin_rect->setPen(cabin_pen);
-  cabin_rect->setBrush(QBrush(QColor::fromRgbF(0.3, 0.3, 1.0, 0.2)));
-  scene->addItem(cabin_rect);
+  const double zone_w = width / meters_per_pixel;
+  const double zone_d = depth / meters_per_pixel;
+  QPen zone_pen(Qt::black);
+  zone_pen.setWidth(0.05 / meters_per_pixel);
+
+  QGraphicsRectItem* zone_rect = new QGraphicsRectItem(
+    -zone_w / 2.0,
+    -zone_d / 2.0,
+    zone_w,
+    zone_d);
+  zone_rect->setPen(zone_pen);
+  zone_rect->setBrush(QBrush(QColor::fromRgbF(0.3, 0.3, 1.0, 0.2)));
+  scene->addItem(zone_rect);
 
   QList<QGraphicsItem*> items;
-  items.append(cabin_rect);
+  items.append(zone_rect);
 
   if (!name.empty())
   {
@@ -177,64 +175,180 @@ void Zone::draw(
     QGraphicsSimpleTextItem* text_item = scene->addSimpleText(
       QString::fromStdString(name), font);
     text_item->setBrush(QColor(255, 0, 0, 255));
-    text_item->setPos(-cabin_w / 3.0, 0.0);
+    text_item->setPos(-zone_w / 3.0, 0.0);
     items.append(text_item);
   }
 
-  for (const auto& vertex : vertices)
+  const double radius = 0.1 / meters_per_pixel;
+
+  QFont name_font("Helvetica");
+  name_font.setPointSize(0.1 / meters_per_pixel);
+  QFont annotate_font("Helvetica");
+  annotate_font.setPointSize(0.15 / meters_per_pixel);
+  QPen vertex_pen(Qt::black);
+  vertex_pen.setWidthF(radius / 2.0);
+  const QBrush vertex_brush = QBrush(
+    QColor::fromRgbF(0.0, 0.0, 0.0, 0.5));
+
+  if (apply_transformation)
   {
     if (show_vertices)
     {
-      QPen vertex_pen(Qt::black);
-      double radius = 0.1 / meters_per_pixel;
-      vertex_pen.setWidthF(radius / 2.0);
+      for (const auto& iv : internal_vertices)
+      {
+        QGraphicsEllipseItem* ellipse_item = scene->addEllipse(
+          iv.x /meters_per_pixel - radius,
+          iv.y /meters_per_pixel - radius,
+          2 * radius,
+          2 * radius,
+          vertex_pen,
+          vertex_brush);
+        ellipse_item->setZValue(20.0);
+        items.append(ellipse_item);
 
-      QColor nonselected_color(QColor::fromRgbF(0.0, 0.0, 0.0));
-      nonselected_color.setAlphaF(0.5);
+        QGraphicsSimpleTextItem* annotate_text_item = scene->addSimpleText(
+          QString::fromStdString(iv.group + "/p" + std::to_string(iv.priority)),
+          annotate_font);
+        annotate_text_item->setBrush(QColor(255, 0, 0, 255));
+        annotate_text_item->setPos(
+          iv.x /meters_per_pixel + radius,
+          iv.y /meters_per_pixel - 3.0 * radius);
+        annotate_text_item->setZValue(95.0);
+        items.append(annotate_text_item);
 
-      const QBrush vertex_brush = QBrush(nonselected_color);
+        QGraphicsSimpleTextItem* name_text_item = scene->addSimpleText(
+          QString::fromStdString(iv.name),
+          name_font);
+        name_text_item->setBrush(QColor(255, 0, 0, 255));
+        name_text_item->setPos(
+          iv.x /meters_per_pixel + radius,
+          iv.y /meters_per_pixel + radius);
+        name_text_item->setZValue(95.0);
+        items.append(name_text_item);
+      }
+    }
+
+    if (show_lanes)
+    {
+      const double lane_pen_width = 0.5 / meters_per_pixel;
+      QPen lane_pen(QBrush(QColor::fromRgbF(0.0, 0.0, 0.0, 0.3)),
+        lane_pen_width);
+      lane_pen.setCapStyle(Qt::RoundCap);
+      const QPen arrow_pen(
+        QBrush(QColor::fromRgbF(0.0, 0.0, 0.0, 0.3)), lane_pen_width / 8.0);
+
+      for (const auto& ev : external_vertices)
+      {
+        if (!ev.is_entry_point && !ev.is_exit_point)
+          continue;
+
+        const Vertex* v = nullptr;
+        for (const auto& lv : level_vertices)
+        {
+          if (lv.name == ev.name)
+          {
+            v = &lv;
+            break;
+          }
+        }
+        if (v == nullptr)
+          continue;
+
+        const double dx = v->x - x;
+        const double dy = v->y - y;
+        const double ex = std::cos(yaw) * dx - std::sin(yaw) * dy;
+        const double ey = std::sin(yaw) * dx + std::cos(yaw) * dy;
+
+        for (const auto& iv : internal_vertices)
+        {
+          const double ix = iv.x / meters_per_pixel;
+          const double iy = iv.y / meters_per_pixel;
+
+          QGraphicsLineItem* lane_item = scene->addLine(ex, ey, ix, iy,
+              lane_pen);
+          items.append(lane_item);
+
+          // only draw arrows if it's a unidirectional lane
+          if (ev.is_entry_point == ev.is_exit_point)
+            continue;
+
+          const double start_x = ev.is_entry_point ? ex : ix;
+          const double start_y = ev.is_entry_point ? ey : iy;
+          const double end_x = ev.is_entry_point ? ix : ex;
+          const double end_y = ev.is_entry_point ? iy : ey;
+          const double len = std::sqrt(
+            (end_x - start_x) * (end_x - start_x)
+            + (end_y - start_y) * (end_y - start_y));
+          if (len < 1e-6)
+            continue;
+
+          const double norm_x = (end_x - start_x) / len;
+          const double norm_y = (end_y - start_y) / len;
+          const double arrow_w = lane_pen_width / 2.5;
+          const double arrow_l = lane_pen_width / 2.5;
+          const double arrow_spacing = lane_pen_width * 4.0;
+
+          for (double d = 0.0; d < len; d += arrow_spacing)
+          {
+            // first calculate the center vertex of this arrowhead
+            const double cx = start_x + d * norm_x;
+            const double cy = start_y + d * norm_y;
+            // one edge vertex of arrowhead
+            const double e1x = cx - arrow_w * norm_y;
+            const double e1y = cy + arrow_w * norm_x;
+            // another edge vertex of arrowhead
+            const double e2x = cx + arrow_w * norm_y;
+            const double e2y = cy - arrow_w * norm_x;
+            // tip of arrowhead
+            const double tx = cx + arrow_l * norm_x;
+            const double ty = cy + arrow_l * norm_y;
+            // now add arrowhead lines
+            items.append(scene->addLine(e1x, e1y, tx, ty, arrow_pen));
+            items.append(scene->addLine(e2x, e2y, tx, ty, arrow_pen));
+          }
+        }
+      }
+    }
+
+    QGraphicsItemGroup* group = scene->createItemGroup(items);
+    group->setZValue(95.0);
+    group->setPos(x, y);
+    group->setRotation(-180.0 / 3.1415926 * yaw);
+  }
+  else if (show_vertices)
+  {
+    for (std::size_t i = 0; i < internal_vertices.size(); i++)
+    {
+      const InternalVertex& vertex = internal_vertices[i];
+      const double px = vertex.x / meters_per_pixel;
+      const double py = vertex.y / meters_per_pixel;
 
       QGraphicsEllipseItem* ellipse_item = scene->addEllipse(
-        vertex.x /meters_per_pixel - radius,
-        vertex.y /meters_per_pixel - radius,
+        px - radius,
+        py - radius,
         2 * radius,
         2 * radius,
         vertex_pen,
         vertex_brush);
-      ellipse_item->setZValue(20.0);  // above all lane/wall edges
+      ellipse_item->setZValue(20.0);
 
-      // add some icons depending on the superpowers of this vertex
-      QPen annotation_pen(Qt::black);
-      annotation_pen.setWidthF(radius / 4.0);
+      QGraphicsSimpleTextItem* name_item = scene->addSimpleText(
+        QString::fromStdString(vertex.name),
+        name_font);
+      name_item->setBrush(QColor(255, 0, 0, 255));
+      name_item->setPos(px + radius, py + radius);
+      name_item->setZValue(30.0);
 
-      items.append(ellipse_item);
-
-      QFont font("Helvetica");
-      font.setPointSize(0.15 / meters_per_pixel);
-      QGraphicsSimpleTextItem* priority_text_item = scene->addSimpleText(
-        QString::number(vertex.priority), font);
-      priority_text_item->setBrush(QColor(255, 0, 0, 255));
-      priority_text_item->setPos(vertex.x /meters_per_pixel - radius,
-        vertex.y /meters_per_pixel - radius);
-      priority_text_item->setZValue(30.0);
-      items.append(priority_text_item);
-
-      font.setPointSize(0.1 / meters_per_pixel);
-      QGraphicsSimpleTextItem* name_text_item = scene->addSimpleText(
-        QString::fromStdString(vertex.name), font);
-      name_text_item->setBrush(QColor(255, 0, 0, 255));
-      name_text_item->setPos(vertex.x /meters_per_pixel + radius,
-        vertex.y /meters_per_pixel + radius);
-      name_text_item->setZValue(30.0);
-      items.append(name_text_item);
+      if (!vertex.group.empty())
+      {
+        QGraphicsSimpleTextItem* annotate_text_item = scene->addSimpleText(
+          QString::fromStdString(
+            vertex.group + "/p" + std::to_string(vertex.priority)),
+          annotate_font);
+        annotate_text_item->setBrush(QColor(255, 0, 0, 255));
+        annotate_text_item->setPos(px + radius, py - 3.0 * radius);
+        annotate_text_item->setZValue(30.0);
+      }
     }
-  }
-
-  QGraphicsItemGroup* group = scene->createItemGroup(items);
-  group->setZValue(95.0);
-  if (apply_transformation)
-  {
-    group->setPos(x * scale + translate_x, y * scale + translate_y);
-    group->setRotation(-180.0 / 3.1415926 * yaw);
   }
 }

--- a/rmf_traffic_editor/gui/zone.cpp
+++ b/rmf_traffic_editor/gui/zone.cpp
@@ -189,7 +189,7 @@ void Zone::draw(
       double radius = 0.1 / meters_per_pixel;
       vertex_pen.setWidthF(radius / 2.0);
 
-      QColor nonselected_color(QColor::fromRgbF(0.0, 0.5, 0.0));
+      QColor nonselected_color(QColor::fromRgbF(0.0, 0.0, 0.0));
       nonselected_color.setAlphaF(0.5);
 
       const QBrush vertex_brush = QBrush(nonselected_color);

--- a/rmf_traffic_editor/gui/zone.cpp
+++ b/rmf_traffic_editor/gui/zone.cpp
@@ -101,8 +101,6 @@ void Zone::from_yaml(
     for (YAML::const_iterator it = yd.begin(); it != yd.end(); ++it)
     {
       ZoneVertex vertex;
-      std::cout << "Loading vertex " << it->first.as<string>() <<
-        " for zone " << name << std::endl;
       vertex.from_yaml(it->first.as<string>(), it->second);
       vertices.push_back(vertex);
     }

--- a/rmf_traffic_editor/gui/zone.cpp
+++ b/rmf_traffic_editor/gui/zone.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2019-2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+
+#include <QGraphicsScene>
+#include <QGraphicsSimpleTextItem>
+
+#include "zone.h"
+using std::string;
+
+YAML::Node ZoneVertex::to_yaml() const
+{
+  YAML::Node n;
+  n["x"] = std::round(x * 1000.0) / 1000.0;
+  n["y"] = std::round(y * 1000.0) / 1000.0;
+  n["priority"] = priority;
+  n["group"] = group;
+
+  return n;
+}
+
+void ZoneVertex::from_yaml(const std::string& _name, const YAML::Node& data)
+{
+  if (!data.IsMap())
+    throw std::runtime_error("ZoneVertex::from_yaml() expected a map");
+  name = _name;
+  x = data["x"].as<double>();
+  y = data["y"].as<double>();
+  priority = data["priority"].as<std::size_t>();
+  group = data["group"].as<std::string>();
+}
+
+YAML::Node ZoneTransitionLane::to_yaml() const
+{
+  YAML::Node n;
+  n["internal_vertex"] = internal_vertex;
+  n["external_vertex"] = external_vertex;
+  n["is_exit_lane"] = is_exit_lane;
+  n["is_entry_lane"] = is_entry_lane;
+
+  return n;
+}
+
+void ZoneTransitionLane::from_yaml(const YAML::Node& data)
+{
+  is_exit_lane = data["is_exit_lane"].as<bool>();
+  is_entry_lane = data["is_entry_lane"].as<bool>();
+  external_vertex = data["external_vertex"].as<std::string>();
+  internal_vertex = data["internal_vertex"].as<std::string>();
+}
+
+Zone::Zone()
+{
+}
+
+void Zone::from_yaml(
+  const std::string& _name,
+  const YAML::Node& data,
+  const std::vector<Level>& levels)
+{
+  if (!data.IsMap())
+    throw std::runtime_error("Zone::from_yaml() expected a map");
+  name = _name;
+  x = data["x"].as<double>();
+  y = data["y"].as<double>();
+  yaw = data["yaw"].as<double>();
+  level = data["level"].as<string>();
+
+  for (const auto& map_level : levels)
+  {
+    if (map_level.name == level)
+    {
+      zone_elevation = map_level.elevation;
+      break;
+    }
+  }
+
+  width = data["width"].as<double>();
+  depth = data["depth"].as<double>();
+
+  if (data["vertices"] && data["vertices"].IsMap())
+  {
+    const YAML::Node& yd = data["vertices"];
+    for (YAML::const_iterator it = yd.begin(); it != yd.end(); ++it)
+    {
+      ZoneVertex vertex;
+      std::cout << "Loading vertex " << it->first.as<string>() <<
+        " for zone " << name << std::endl;
+      vertex.from_yaml(it->first.as<string>(), it->second);
+      vertices.push_back(vertex);
+    }
+  }
+
+  if (data["transition_lanes"] && data["transition_lanes"].IsSequence())
+  {
+    for (const auto& lane : data["transition_lanes"])
+    {
+      ZoneTransitionLane transition_lane;
+      transition_lane.from_yaml(lane);
+      transition_lanes.push_back(transition_lane);
+    }
+  }
+
+}
+
+YAML::Node Zone::to_yaml() const
+{
+  YAML::Node n;
+  n["x"] = std::round(x * 1000.0) / 1000.0;
+  n["y"] = std::round(y * 1000.0) / 1000.0;
+  // let's give yaw another decimal place because, I don't know, reasons (?)
+  n["yaw"] = std::round(yaw * 10000.0) / 10000.0;
+  n["level"] = level;
+  n["width"] = std::round(width * 1000.0) / 1000.0;
+  n["depth"] = std::round(depth * 1000.0) / 1000.0;
+
+  n["vertices"] = YAML::Node(YAML::NodeType::Map);
+  for (const auto& vertex : vertices)
+    n["vertices"][vertex.name] = vertex.to_yaml();
+  n["transition_lanes"] = YAML::Node(YAML::NodeType::Sequence);
+  for (const auto& transition_lane : transition_lanes)
+    n["transition_lanes"].push_back(transition_lane.to_yaml());
+  return n;
+}
+
+void Zone::draw(
+  QGraphicsScene* scene,
+  const double meters_per_pixel,
+  const string& level_name,
+  const double elevation,
+  const bool apply_transformation,
+  const double scale,
+  const double translate_x,
+  const double translate_y) const
+{
+  if (!show_zone)
+    return;
+
+  if (elevation != zone_elevation)
+    return;
+  const double cabin_w = width / meters_per_pixel;
+  const double cabin_d = depth / meters_per_pixel;
+  QPen cabin_pen(Qt::black);
+  cabin_pen.setWidth(0.05 / meters_per_pixel);
+
+  QGraphicsRectItem* cabin_rect = new QGraphicsRectItem(
+    -cabin_w / 2.0,
+    -cabin_d / 2.0,
+    cabin_w,
+    cabin_d);
+  cabin_rect->setPen(cabin_pen);
+  cabin_rect->setBrush(QBrush(QColor::fromRgbF(0.3, 0.3, 1.0, 0.2)));
+  scene->addItem(cabin_rect);
+
+  QList<QGraphicsItem*> items;
+  items.append(cabin_rect);
+
+  if (!name.empty())
+  {
+    QFont font("Helvetica");
+    font.setPointSize(0.2 / meters_per_pixel);
+    QGraphicsSimpleTextItem* text_item = scene->addSimpleText(
+      QString::fromStdString(name), font);
+    text_item->setBrush(QColor(255, 0, 0, 255));
+    text_item->setPos(-cabin_w / 3.0, 0.0);
+    items.append(text_item);
+  }
+
+  for (const auto& vertex : vertices)
+  {
+    if (show_vertices)
+    {
+      QPen vertex_pen(Qt::black);
+      double radius = 0.1 / meters_per_pixel;
+      vertex_pen.setWidthF(radius / 2.0);
+
+      QColor nonselected_color(QColor::fromRgbF(0.0, 0.5, 0.0));
+      nonselected_color.setAlphaF(0.5);
+
+      const QBrush vertex_brush = QBrush(nonselected_color);
+
+      QGraphicsEllipseItem* ellipse_item = scene->addEllipse(
+        vertex.x /meters_per_pixel - radius,
+        vertex.y /meters_per_pixel - radius,
+        2 * radius,
+        2 * radius,
+        vertex_pen,
+        vertex_brush);
+      ellipse_item->setZValue(20.0);  // above all lane/wall edges
+
+      // add some icons depending on the superpowers of this vertex
+      QPen annotation_pen(Qt::black);
+      annotation_pen.setWidthF(radius / 4.0);
+
+      items.append(ellipse_item);
+
+      QFont font("Helvetica");
+      font.setPointSize(0.15 / meters_per_pixel);
+      QGraphicsSimpleTextItem* priority_text_item = scene->addSimpleText(
+        QString::number(vertex.priority), font);
+      priority_text_item->setBrush(QColor(255, 0, 0, 255));
+      priority_text_item->setPos(vertex.x /meters_per_pixel - radius,
+        vertex.y /meters_per_pixel - radius);
+      priority_text_item->setZValue(30.0);
+      items.append(priority_text_item);
+
+      font.setPointSize(0.1 / meters_per_pixel);
+      QGraphicsSimpleTextItem* name_text_item = scene->addSimpleText(
+        QString::fromStdString(vertex.name), font);
+      name_text_item->setBrush(QColor(255, 0, 0, 255));
+      name_text_item->setPos(vertex.x /meters_per_pixel + radius,
+        vertex.y /meters_per_pixel + radius);
+      name_text_item->setZValue(30.0);
+      items.append(name_text_item);
+    }
+  }
+
+  QGraphicsItemGroup* group = scene->createItemGroup(items);
+  group->setZValue(95.0);
+  if (apply_transformation)
+  {
+    group->setPos(x * scale + translate_x, y * scale + translate_y);
+    group->setRotation(-180.0 / 3.1415926 * yaw);
+  }
+}

--- a/rmf_traffic_editor/gui/zone.h
+++ b/rmf_traffic_editor/gui/zone.h
@@ -60,8 +60,6 @@ class Zone
 {
 public:
   std::string name;                           // Name of the zone
-  std::string entry_point;                    // Name of the vertex used as an zone entry point
-  std::string external_entry_point;           // Name of the vertex used as an zone entry point from the outside
   std::string level;                          // Which level the zone is at
   std::string type;                           // What kind of zone it is
 
@@ -76,9 +74,6 @@ public:
 
   bool show_vertices = true;                  // Visual marker. Used to hide or show verticse in the zone
   bool show_zone = true;                      // Visual marker. Used to hide or show the zone
-
-  double external_entry_point_x = 0.0;              // x coordinate of the external entry point in the global frame in pixels
-  double external_entry_point_y = 0.0;              // y coordinate of the external entry point in the global frame in pixels
 
   std::vector<ZoneVertex> vertices;           // Vertices in the zone
 

--- a/rmf_traffic_editor/gui/zone.h
+++ b/rmf_traffic_editor/gui/zone.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2019-2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef ZONE_H
+#define ZONE_H
+
+class QGraphicsScene;
+class QGraphicsView;
+
+#include <string>
+#include <vector>
+#include <yaml-cpp/yaml.h>
+#include <cfloat>
+#include "level.h"
+
+class ZoneVertex
+{
+public:
+
+  std::string name;
+
+  double x = 0.0;  // x location of vertex in meters
+  double y = 0.0;  // y location of vertex in meters
+  std::size_t priority = 0; // Priority of vertex
+  std::string group = "Default";  // group label of the vertex
+
+  YAML::Node to_yaml() const;
+  void from_yaml(const std::string& _name, const YAML::Node& data);
+};
+
+class ZoneTransitionLane
+{
+public:
+
+  std::string internal_vertex;
+  std::string external_vertex;
+
+  bool is_entry_lane = true;
+  bool is_exit_lane = true;
+
+  YAML::Node to_yaml() const;
+  void from_yaml(const YAML::Node& data);
+};
+
+class Zone
+{
+public:
+  std::string name;                           // Name of the zone
+  std::string entry_point;                    // Name of the vertex used as an zone entry point
+  std::string external_entry_point;           // Name of the vertex used as an zone entry point from the outside
+  std::string level;                          // Which level the zone is at
+  std::string type;                           // What kind of zone it is
+
+  double x = 0.0;                             // x coordinate of the zone in the global frame
+  double y = 0.0;                             // y coordinate of the zone in the global frame
+  double yaw = 0.0;                           // yaw of the zone in the global frame
+
+  double width = 1.0;                         // Width of the zone in meters
+  double depth = 1.0;                         // Depth of the zone in meters
+
+  double zone_elevation = DBL_MAX;            // Zone elevation. Used to check which level the zone is at
+
+  bool show_vertices = true;                  // Visual marker. Used to hide or show verticse in the zone
+  bool show_zone = true;                      // Visual marker. Used to hide or show the zone
+
+  double external_entry_point_x = 0.0;              // x coordinate of the external entry point in the global frame in pixels
+  double external_entry_point_y = 0.0;              // y coordinate of the external entry point in the global frame in pixels
+
+  std::vector<ZoneVertex> vertices;           // Vertices in the zone
+
+  std::vector<ZoneTransitionLane> transition_lanes;           // Transition lanes in the zone
+
+  ////////////////////////////////////////////////////////////////////////
+
+  Zone();
+
+  // Function that parse to YAML
+  YAML::Node to_yaml() const;
+
+  // Function that parse from YAML
+  void from_yaml(const std::string& _name, const YAML::Node& data,
+    const std::vector<Level>& levels);
+
+  // Function to draw the zone graphically
+  void draw(
+    QGraphicsScene* scene,
+    const double meters_per_pixel,
+    const std::string& level_name,
+    const double elevation,
+    const bool apply_transformation = true,
+    const double scale = 1.0,
+    const double translate_x = 0.0,
+    const double translate_y = 0.0) const;
+};
+
+#endif

--- a/rmf_traffic_editor/gui/zone.h
+++ b/rmf_traffic_editor/gui/zone.h
@@ -19,7 +19,6 @@
 #define ZONE_H
 
 class QGraphicsScene;
-class QGraphicsView;
 
 #include <string>
 #include <vector>
@@ -27,7 +26,7 @@ class QGraphicsView;
 #include <cfloat>
 #include "level.h"
 
-class ZoneVertex
+class InternalVertex
 {
 public:
 
@@ -35,25 +34,23 @@ public:
 
   double x = 0.0;  // x location of vertex in meters
   double y = 0.0;  // y location of vertex in meters
-  std::size_t priority = 0; // Priority of vertex
-  std::string group = "Default";  // group label of the vertex
+  uint priority = 0; // Priority of vertex
+  std::string group = "Default";  // Group label of vertex
 
   YAML::Node to_yaml() const;
   void from_yaml(const std::string& _name, const YAML::Node& data);
 };
 
-class ZoneTransitionLane
+class ExternalVertex
 {
 public:
 
-  std::string internal_vertex;
-  std::string external_vertex;
-
-  bool is_entry_lane = true;
-  bool is_exit_lane = true;
+  std::string name;
+  bool is_entry_point = false;
+  bool is_exit_point = false;
 
   YAML::Node to_yaml() const;
-  void from_yaml(const YAML::Node& data);
+  void from_yaml(const std::string& _name, const YAML::Node& data);
 };
 
 class Zone
@@ -70,36 +67,30 @@ public:
   double width = 1.0;                         // Width of the zone in meters
   double depth = 1.0;                         // Depth of the zone in meters
 
-  double zone_elevation = DBL_MAX;            // Zone elevation. Used to check which level the zone is at
+  double elevation = DBL_MAX;                 // Zone elevation. Used to check which level the zone is at
 
   bool show_vertices = true;                  // Visual marker. Used to hide or show verticse in the zone
   bool show_zone = true;                      // Visual marker. Used to hide or show the zone
+  bool show_lanes = true;                     // Visual marker. Used to hide or show the zone's transition lanes
 
-  std::vector<ZoneVertex> vertices;           // Vertices in the zone
-
-  std::vector<ZoneTransitionLane> transition_lanes;           // Transition lanes in the zone
+  std::vector<InternalVertex> internal_vertices;
+  std::vector<ExternalVertex> external_vertices;
 
   ////////////////////////////////////////////////////////////////////////
 
   Zone();
 
-  // Function that parse to YAML
   YAML::Node to_yaml() const;
 
-  // Function that parse from YAML
   void from_yaml(const std::string& _name, const YAML::Node& data,
     const std::vector<Level>& levels);
 
-  // Function to draw the zone graphically
   void draw(
     QGraphicsScene* scene,
     const double meters_per_pixel,
     const std::string& level_name,
-    const double elevation,
     const bool apply_transformation = true,
-    const double scale = 1.0,
-    const double translate_x = 0.0,
-    const double translate_y = 0.0) const;
+    const std::vector<Vertex>& level_vertices = {}) const;
 };
 
 #endif

--- a/rmf_traffic_editor/gui/zone_dialog.cpp
+++ b/rmf_traffic_editor/gui/zone_dialog.cpp
@@ -535,16 +535,6 @@ void ZoneDialog::update_transition_lane_table()
       &QAbstractButton::clicked,
       [this, i]()
       {
-        if (_zone.transition_lanes.size() <= 2 &&
-          transition_lane_vertices_valid(_zone.transition_lanes[i]))
-        {
-          QMessageBox::warning(
-            this,
-            "Cannot delete",
-            "At least two transition lanes are required "
-            "(internal ↔ external vertex each).");
-          return;
-        }
         _zone.transition_lanes.erase(_zone.transition_lanes.begin() + i);
         set_transition_lane_cell(_zone.transition_lanes.size(), 1, nullptr);
         set_transition_lane_cell(_zone.transition_lanes.size(), 2, nullptr);

--- a/rmf_traffic_editor/gui/zone_dialog.cpp
+++ b/rmf_traffic_editor/gui/zone_dialog.cpp
@@ -16,11 +16,11 @@
 */
 
 #include "zone_dialog.h"
+#include <algorithm>
 #include <cfloat>
 #include <cmath>
 #include <QtWidgets>
 using std::vector;
-
 
 ZoneDialog::ZoneDialog(Zone& zone, Building& building)
 : QDialog(),
@@ -29,18 +29,7 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
 {
   setWindowTitle("Zone Properties");
   for (const auto& level : building.levels)
-  {
     _level_names.push_back(QString::fromStdString(level.name));
-    _level_elevations.push_back(level.elevation);
-
-    for (const auto& vertex : level.vertices)
-    {
-      if (vertex.name != "")
-        _vertex_names.push_back(QString::fromStdString(vertex.name));
-      _vertex_x.push_back(vertex.x);
-      _vertex_y.push_back(vertex.y);
-    }
-  }
 
   _zone_copy = _zone;
 
@@ -79,9 +68,7 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
   level_hbox->addWidget(new QLabel("Zone level:"));
   _level_combo_box = new QComboBox;
   for (const QString& level_name : _level_names)
-  {
     _level_combo_box->addItem(level_name);
-  }
   _level_combo_box->setCurrentText(
     QString::fromStdString(_zone.level));
   connect(
@@ -90,13 +77,13 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
     [this](const QString& text)
     {
       _zone.level = text.toStdString();
-      for (std::size_t i = 0; i < _level_names.size(); i++)
+      for (const auto& level : _building.levels)
       {
-        if (text == _level_names[i])
-        {
-          _zone.zone_elevation = _level_elevations[i];
-        }
+        if (level.name == _zone.level)
+          _zone.elevation = level.elevation;
       }
+      update_ex_vertex_table();
+      update_zone_view();
       emit redraw();
     });
   _level_combo_box->setToolTip("Level which the zone is in.");
@@ -198,71 +185,86 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
     });
   show_vertices_hbox->addWidget(_vertexcheckbox);
 
-  _vertex_table = new QTableWidget;
-  _vertex_table->setMinimumSize(400, 200);
-  _vertex_table->verticalHeader()->setVisible(false);
-  _vertex_table->setColumnCount(6);
-  _vertex_table->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
+  QHBoxLayout* show_lanes_hbox = new QHBoxLayout;
+  show_lanes_hbox->addWidget(new QLabel("Show lanes:"));
+  _lanecheckbox = new QCheckBox;
+  _lanecheckbox->setChecked(_zone.show_lanes);
+  connect(
+    _lanecheckbox,
+    &QAbstractButton::clicked,
+    [this](bool box_checked)
+    {
+      _zone.show_lanes = box_checked;
+      emit redraw();
+    });
+  show_lanes_hbox->addWidget(_lanecheckbox);
 
-  _vertex_table->setHorizontalHeaderItem(0,
-    new QTableWidgetItem("Add Internal Vertex..."));
-  _vertex_table->horizontalHeader()->setSectionResizeMode(
-    0, QHeaderView::ResizeToContents);
+  _internal_vertex_table = new QTableWidget;
+  _internal_vertex_table->setMinimumSize(600, 200);
+  _internal_vertex_table->verticalHeader()->setVisible(false);
+  _internal_vertex_table->setColumnCount(6);
+  _internal_vertex_table->setSizeAdjustPolicy(
+    QAbstractScrollArea::AdjustToContents);
 
-  _vertex_table->setHorizontalHeaderItem(1,
-    new QTableWidgetItem("Vertex name"));
-  _vertex_table->horizontalHeader()->setSectionResizeMode(
-    1, QHeaderView::Stretch);
+  _internal_vertex_table->setHorizontalHeaderItem(0,
+    new QTableWidgetItem("Add/Remove"));
+  _internal_vertex_table->horizontalHeader()->setSectionResizeMode(
+    0, QHeaderView::Fixed);
+  _internal_vertex_table->setColumnWidth(0, 100);
 
-  _vertex_table->setHorizontalHeaderItem(2,
+  _internal_vertex_table->setHorizontalHeaderItem(1,
+    new QTableWidgetItem("Internal Vertex"));
+  _internal_vertex_table->horizontalHeader()->setSectionResizeMode(
+    1, QHeaderView::Fixed);
+  _internal_vertex_table->setColumnWidth(1, 250);
+
+  _internal_vertex_table->setHorizontalHeaderItem(2,
     new QTableWidgetItem("X (m)"));
-  _vertex_table->horizontalHeader()->setSectionResizeMode(
+  _internal_vertex_table->horizontalHeader()->setSectionResizeMode(
     2, QHeaderView::ResizeToContents);
 
-  _vertex_table->setHorizontalHeaderItem(3,
+  _internal_vertex_table->setHorizontalHeaderItem(3,
     new QTableWidgetItem("Y (m)"));
-  _vertex_table->horizontalHeader()->setSectionResizeMode(
+  _internal_vertex_table->horizontalHeader()->setSectionResizeMode(
     3, QHeaderView::ResizeToContents);
 
-  _vertex_table->setHorizontalHeaderItem(4,
+  _internal_vertex_table->setHorizontalHeaderItem(4,
     new QTableWidgetItem("Group"));
-  _vertex_table->horizontalHeader()->setSectionResizeMode(
-    4, QHeaderView::ResizeToContents);
+  _internal_vertex_table->horizontalHeader()->setSectionResizeMode(
+    4, QHeaderView::Stretch);
 
-  _vertex_table->setHorizontalHeaderItem(5,
+  _internal_vertex_table->setHorizontalHeaderItem(5,
     new QTableWidgetItem("Priority"));
-  _vertex_table->horizontalHeader()->setSectionResizeMode(
+  _internal_vertex_table->horizontalHeader()->setSectionResizeMode(
     5, QHeaderView::ResizeToContents);
 
-  _transition_lane_table = new QTableWidget;
-  _transition_lane_table->setMinimumSize(600, 200);
-  _transition_lane_table->verticalHeader()->setVisible(false);
-  _transition_lane_table->setColumnCount(5);
+  _external_vertex_table = new QTableWidget;
+  _external_vertex_table->setMinimumSize(600, 200);
+  _external_vertex_table->verticalHeader()->setVisible(false);
+  _external_vertex_table->setColumnCount(4);
+  _external_vertex_table->setSizeAdjustPolicy(
+    QAbstractScrollArea::AdjustToContents);
 
-  _transition_lane_table->setHorizontalHeaderItem(0,
-    new QTableWidgetItem("Add lane..."));
-  _transition_lane_table->horizontalHeader()->setSectionResizeMode(
-    0, QHeaderView::ResizeToContents);
+  _external_vertex_table->setHorizontalHeaderItem(0,
+    new QTableWidgetItem("Add/Remove"));
+  _external_vertex_table->horizontalHeader()->setSectionResizeMode(
+    0, QHeaderView::Fixed);
+  _external_vertex_table->setColumnWidth(0, 100);
 
-  _transition_lane_table->setHorizontalHeaderItem(1,
-    new QTableWidgetItem("Internal vertex"));
-  _transition_lane_table->horizontalHeader()->setSectionResizeMode(
+  _external_vertex_table->setHorizontalHeaderItem(1,
+    new QTableWidgetItem("External vertex"));
+  _external_vertex_table->horizontalHeader()->setSectionResizeMode(
     1, QHeaderView::Stretch);
 
-  _transition_lane_table->setHorizontalHeaderItem(2,
-    new QTableWidgetItem("External vertex"));
-  _transition_lane_table->horizontalHeader()->setSectionResizeMode(
+  _external_vertex_table->setHorizontalHeaderItem(2,
+    new QTableWidgetItem("is entry"));
+  _external_vertex_table->horizontalHeader()->setSectionResizeMode(
     2, QHeaderView::ResizeToContents);
 
-  _transition_lane_table->setHorizontalHeaderItem(3,
-    new QTableWidgetItem("is exit lane"));
-  _transition_lane_table->horizontalHeader()->setSectionResizeMode(
+  _external_vertex_table->setHorizontalHeaderItem(3,
+    new QTableWidgetItem("is exit"));
+  _external_vertex_table->horizontalHeader()->setSectionResizeMode(
     3, QHeaderView::ResizeToContents);
-
-  _transition_lane_table->setHorizontalHeaderItem(4,
-    new QTableWidgetItem("is entry lane"));
-  _transition_lane_table->horizontalHeader()->setSectionResizeMode(
-    4, QHeaderView::ResizeToContents);
 
   QVBoxLayout* left_vbox = new QVBoxLayout;
   left_vbox->addLayout(name_hbox);
@@ -272,19 +274,20 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
   left_vbox->addLayout(x_hbox);
   left_vbox->addLayout(y_hbox);
   left_vbox->addLayout(yaw_hbox);
-  left_vbox->addWidget(_transition_lane_table);
-  
+  left_vbox->addWidget(_internal_vertex_table);
+  left_vbox->addWidget(_external_vertex_table);
+
   QVBoxLayout* right_vbox = new QVBoxLayout;
   _zone_scene = new QGraphicsScene;
   _zone_view = new QGraphicsView;
   _zone_view->setScene(_zone_scene);
   _zone_view->setMinimumSize(400, 400);
   right_vbox->addWidget(_zone_view, 1);
-  right_vbox->addWidget(_vertex_table);
   right_vbox->addLayout(show_vertices_hbox);
+  right_vbox->addLayout(show_lanes_hbox);
 
   QHBoxLayout* top_hbox = new QHBoxLayout;
-  top_hbox->addLayout(left_vbox);
+  top_hbox->addLayout(left_vbox, 1);
   top_hbox->addLayout(right_vbox, 1);
 
   QVBoxLayout* top_vbox = new QVBoxLayout;
@@ -294,17 +297,12 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
 
   setLayout(top_vbox);
 
-  update_vertex_table();
-  update_transition_lane_table();
-
   connect(
-    _vertex_table, &QTableWidget::cellChanged,
-    this, &ZoneDialog::vertex_table_cell_changed);
+    _internal_vertex_table, &QTableWidget::cellChanged,
+    this, &ZoneDialog::in_vertex_table_cell_changed);
 
-  connect(
-    _transition_lane_table, &QTableWidget::cellChanged,
-    this, &ZoneDialog::transition_lane_table_cell_changed);
-
+  update_in_vertex_table();
+  update_ex_vertex_table();
   update_zone_view();
   adjustSize();
   _ok_button->setFocus(Qt::OtherFocusReason);
@@ -316,6 +314,7 @@ ZoneDialog::~ZoneDialog()
 {
 }
 
+// ======================================================================================================================
 bool ZoneDialog::is_zone_name_unique(const std::string& name) const
 {
   for (const auto& zone : _building.zones)
@@ -331,366 +330,22 @@ bool ZoneDialog::is_zone_name_unique(const std::string& name) const
 }
 
 // ======================================================================================================================
-void ZoneDialog::ok_button_clicked()
+bool ZoneDialog::level_has_vertex(
+  const std::string& level_name,
+  const std::string& vertex_name) const
 {
-  if (_name_line_edit->text().isEmpty())
+  for (const auto& level : _building.levels)
   {
-    QMessageBox::critical(this, "Error", "Zone name is empty");
-    return;
-  }
+    if (level.name != level_name)
+      continue;
 
-  if (!is_zone_name_unique(_name_line_edit->text().toStdString()))
-  {
-    QMessageBox::critical(this, "Error", "Zone name must be unique");
-    return;
-  }
-  
-  if (!has_valid_entry_and_exit_transition_lanes())
-  {
-    if (!confirm_warning(
-      "Current lanes configuration might cause issues when robots "
-      "enter/exit the zone"))
-      return;
-  }
-
-  const std::vector<std::string> outside = vertices_outside_zone();
-  if (!outside.empty())
-  {
-    QStringList names;
-    for (const auto& name : outside)
-      names.append(QString::fromStdString(name));
-
-    if (!confirm_warning(
-      "These internal vertices lie outside the zone bounds:\n  " +
-      names.join("\n  ")))
-      return;
-  }
-
-  update_zone_view();
-  emit redraw();
-  accept();
-}
-
-// ======================================================================================================================
-void ZoneDialog::cancel_button_clicked()
-{
-  _zone = _zone_copy;
-  update_zone_view();
-  emit redraw();
-  reject();
-}
-
-// ======================================================================================================================
-void ZoneDialog::update_vertex_table()
-{
-  _vertex_table->blockSignals(true);
-  _vertex_table->setRowCount(1 + _zone.vertices.size());
-  for (std::size_t i = 0; i < _zone.vertices.size(); i++)
-  {
-    const ZoneVertex& vertex = _zone.vertices[i];  // save some typing
-
-    // clear any lingering placeholder items (e.g. when a row was previously the Add row)
-    _vertex_table->setItem(i, 0, new QTableWidgetItem());
-    _vertex_table->setItem(i, 5, new QTableWidgetItem());
-
-    QPushButton* delete_button = new QPushButton("Delete...", this);
-    _vertex_table->setCellWidget(i, 0, delete_button);
-
-    set_vertex_cell(i, 1, QString::fromStdString(vertex.name));
-
-    // set the numeric fields
-    set_vertex_cell(i, 2, QString::number(vertex.x));
-    set_vertex_cell(i, 3, QString::number(vertex.y));
-
-    // set the group name
-    set_vertex_cell(i, 4, QString::fromStdString(vertex.group));
-
-    _priority_box = new QComboBox;
-    for (std::size_t j = 0; j < _zone.vertices.size(); j++)
+    for (const auto& v : level.vertices)
     {
-      _priority_box->addItem(QString::number(j+1));
-    }
-    _priority_box->setCurrentText(QString::number(vertex.priority));
-    connect(
-      _priority_box,
-      &QComboBox::currentTextChanged,
-      [this, i](const QString& text)
-      {
-        _zone.vertices[i].priority = text.toInt();
-        update_vertex_table();
-        update_zone_view();
-        emit redraw();
-      });
-    _vertex_table->setCellWidget(i, 5, _priority_box);
-
-    connect(
-      delete_button,
-      &QAbstractButton::clicked,
-      [this, i]()
-      {
-        _zone.vertices.erase(_zone.vertices.begin() + i);
-        update_vertex_table();
-        update_transition_lane_table();
-        update_zone_view();
-      });
-  }
-
-  // we'll use the last row for the "Add" button
-  const int last_row_idx = static_cast<int>(_zone.vertices.size());
-  QPushButton* add_button = new QPushButton("Add...", this);
-  _vertex_table->setCellWidget(last_row_idx, 0, add_button);
-  for (int col = 1; col <= 5; col++)
-  {
-    _vertex_table->setCellWidget(last_row_idx, col, nullptr);
-    auto* placeholder = new QTableWidgetItem();
-    placeholder->setFlags(Qt::NoItemFlags);
-    placeholder->setBackground(QColor(180, 180, 180));
-    _vertex_table->setItem(last_row_idx, col, placeholder);
-  }
-  connect(
-    add_button,
-    &QAbstractButton::clicked,
-    [this]()
-    {
-      if (!is_vertex_name_unique("name", -1))
-      {
-        QMessageBox::warning(this, "Duplicate name",
-        "A vertex with the name 'name' already exists."
-        " Please change the name of existing vertex first.");
-        return;
-      }
-      ZoneVertex vertex;
-      vertex.name = "name";
-      vertex.priority = _zone.vertices.size()+1;
-      _zone.vertices.push_back(vertex);
-      update_vertex_table();
-      update_transition_lane_table();
-      update_zone_view();
-    });
-  _vertex_table->blockSignals(false);
-}
-
-// ======================================================================================================================
-void ZoneDialog::update_transition_lane_table()
-{
-  _transition_lane_table->blockSignals(true);
-  _transition_lane_table->setRowCount(1 + _zone.transition_lanes.size());
-
-  for (std::size_t i = 0; i < _zone.transition_lanes.size(); i++)
-  {
-    const ZoneTransitionLane& lane = _zone.transition_lanes[i];  // save some typing
-
-    // clear any lingering placeholder items (e.g. when a row was previously the Add row)
-    for (int col = 0; col <= 4; col++)
-      _transition_lane_table->setItem(i, col, new QTableWidgetItem());
-
-    QPushButton* delete_button = new QPushButton("Delete...", this);
-    _transition_lane_table->setCellWidget(i, 0, delete_button);
-
-    _internal_vertex_combo_box = new QComboBox;
-    update_internal_vertex_combobox();
-    _internal_vertex_combo_box->setCurrentText(
-      QString::fromStdString(lane.internal_vertex));
-    connect(
-      _internal_vertex_combo_box,
-      &QComboBox::currentTextChanged,
-      [this, i](const QString& text)
-      {
-        _zone.transition_lanes[i].internal_vertex = text.toStdString();
-      });
-    _transition_lane_table->setCellWidget(i, 1, _internal_vertex_combo_box);
-
-    _external_vertex_combo_box = new QComboBox;
-    _external_vertex_combo_box->addItem("Select vertex");
-    for (const QString& vertex_name : _vertex_names)
-    {
-      _external_vertex_combo_box->addItem(vertex_name);
-    }
-    _external_vertex_combo_box->setCurrentText(
-      QString::fromStdString(lane.external_vertex));
-    connect(
-      _external_vertex_combo_box,
-      &QComboBox::currentTextChanged,
-      [this, i](const QString& text)
-      {
-        _zone.transition_lanes[i].external_vertex = text.toStdString();
-      });
-    _transition_lane_table->setCellWidget(i, 2, _external_vertex_combo_box);
-
-    _exit_lanecheckbox = new QCheckBox;
-    _exit_lanecheckbox->setChecked(lane.is_exit_lane);
-    connect(
-      _exit_lanecheckbox,
-      &QAbstractButton::clicked,
-      [this, i](bool box_checked)
-      {
-        _zone.transition_lanes[i].is_exit_lane = box_checked;
-      });
-    _transition_lane_table->setCellWidget(i, 3, _exit_lanecheckbox);
-
-    _entry_lanecheckbox = new QCheckBox;
-    _entry_lanecheckbox->setChecked(lane.is_entry_lane);
-    connect(
-      _entry_lanecheckbox,
-      &QAbstractButton::clicked,
-      [this, i](bool box_checked)
-      {
-        _zone.transition_lanes[i].is_entry_lane = box_checked;
-      });
-    _transition_lane_table->setCellWidget(i, 4, _entry_lanecheckbox);
-
-    connect(
-      delete_button,
-      &QAbstractButton::clicked,
-      [this, i]()
-      {
-        _zone.transition_lanes.erase(_zone.transition_lanes.begin() + i);
-        update_transition_lane_table();
-        update_zone_view();
-      });
-  }
-
-  // we'll use the last row for the "Add" button
-  const int last_row_idx = static_cast<int>(_zone.transition_lanes.size());
-  QPushButton* add_button = new QPushButton("Add...", this);
-  _transition_lane_table->setCellWidget(last_row_idx, 0, add_button);
-  for (int col = 1; col <= 4; col++)
-  {
-    _transition_lane_table->setCellWidget(last_row_idx, col, nullptr);
-    auto* placeholder = new QTableWidgetItem();
-    placeholder->setFlags(Qt::NoItemFlags);
-    placeholder->setBackground(QColor(180, 180, 180));
-    _transition_lane_table->setItem(last_row_idx, col, placeholder);
-  }
-  connect(
-    add_button,
-    &QAbstractButton::clicked,
-    [this]()
-    {
-      if (_zone.vertices.size() < 1)
-      {
-        QMessageBox::warning(
-          this,
-          "Cannot add lane",
-          "At least one internal vertex is required ");
-        return;
-      }
-      ZoneTransitionLane new_transition_lane;
-      _zone.transition_lanes.push_back(new_transition_lane);
-      update_transition_lane_table();
-      update_zone_view();
-    });
-  _transition_lane_table->blockSignals(false);
-}
-
-// ======================================================================================================================
-void ZoneDialog::update_internal_vertex_combobox()
-{
-  _internal_vertex_combo_box->clear();
-  _internal_vertex_combo_box->addItem(QString::fromStdString(
-      "<select vertex>"));
-  for (const auto& vertex : _zone.vertices)
-  {
-    _internal_vertex_combo_box->addItem(QString::fromStdString(vertex.name));
-  }
-}
-
-bool ZoneDialog::transition_lane_vertices_valid(const ZoneTransitionLane& lane)
-const
-{
-  static const char* const k_internal_placeholder = "<select vertex>";
-  static const char* const k_external_placeholder = "Select vertex";
-
-  if (lane.internal_vertex.empty() ||
-    lane.internal_vertex == k_internal_placeholder)
-  {
-    return false;
-  }
-  if (lane.external_vertex.empty() ||
-    lane.external_vertex == k_external_placeholder)
-  {
-    return false;
-  }
-
-  bool internal_ok = false;
-  for (const auto& vertex : _zone.vertices)
-  {
-    if (vertex.name == lane.internal_vertex)
-    {
-      internal_ok = true;
-      break;
-    }
-  }
-  if (!internal_ok)
-  {
-    return false;
-  }
-
-  const QString external_q = QString::fromStdString(lane.external_vertex);
-  for (const QString& name : _vertex_names)
-  {
-    if (name == external_q)
-    {
-      return true;
+      if (v.name == vertex_name)
+        return true;
     }
   }
   return false;
-}
-
-bool ZoneDialog::has_valid_entry_and_exit_transition_lanes() const
-{
-  for (const auto& vertex : _zone.vertices)
-  {
-    bool has_valid_pair = false;
-
-    for (const auto& entry_lane : _zone.transition_lanes)
-    {
-      if (!transition_lane_vertices_valid(entry_lane))
-        continue;
-      if (!entry_lane.is_entry_lane)
-        continue;
-      if (entry_lane.internal_vertex != vertex.name)
-        continue;
-
-      for (const auto& exit_lane : _zone.transition_lanes)
-      {
-        if (!transition_lane_vertices_valid(exit_lane))
-          continue;
-        if (!exit_lane.is_exit_lane)
-          continue;
-        if (exit_lane.internal_vertex != vertex.name)
-          continue;
-
-        if (entry_lane.external_vertex != exit_lane.external_vertex)
-        {
-          has_valid_pair = true;
-          break;
-        }
-      }
-
-      if (has_valid_pair)
-        break;
-    }
-
-    if (!has_valid_pair)
-      return false;
-  }
-
-  return true;
-}
-
-// ======================================================================================================================
-std::vector<std::string> ZoneDialog::vertices_outside_zone() const
-{
-  std::vector<std::string> outside;
-  const double half_w = _zone.width / 2.0;
-  const double half_d = _zone.depth / 2.0;
-  for (const auto& vertex : _zone.vertices)
-  {
-    if (std::abs(vertex.x) > half_w || std::abs(vertex.y) > half_d)
-      outside.push_back(vertex.name);
-  }
-  return outside;
 }
 
 // ======================================================================================================================
@@ -725,110 +380,374 @@ bool ZoneDialog::confirm_warning(const QString& text)
 }
 
 // ======================================================================================================================
-void ZoneDialog::set_vertex_cell(const int row, const int col,
-  const QString& text)
+void ZoneDialog::ok_button_clicked()
 {
-  _vertex_table->setItem(row, col, new QTableWidgetItem(text));
+  if (_name_line_edit->text().isEmpty())
+  {
+    QMessageBox::critical(this, "Error", "Zone name is empty");
+    return;
+  }
+
+  if (!is_zone_name_unique(_name_line_edit->text().toStdString()))
+  {
+    QMessageBox::critical(this, "Error", "Zone name must be unique");
+    return;
+  }
+
+  bool has_entry = false;
+  bool has_exit = false;
+  for (std::size_t i = 0; i < _zone.external_vertices.size(); i++)
+  {
+    const ExternalVertex& ev = _zone.external_vertices[i];
+    if (ev.name.empty())
+    {
+      QMessageBox::critical(this, "Error",
+        "Select a vertex for every external vertex row, or delete the row.");
+      return;
+    }
+
+    if (!level_has_vertex(_zone.level, ev.name))
+    {
+      QMessageBox::critical(this, "Error",
+        "Reset external vertices that were on a different level.");
+      return;
+    }
+
+    if (!is_vertex_name_unique(
+        _zone.external_vertices, ev.name, i))
+    {
+      QMessageBox::critical(this, "Error",
+        QString::fromStdString(
+          "Duplicate external vertex [" + ev.name + "]."));
+      return;
+    }
+
+    has_entry = has_entry || ev.is_entry_point;
+    has_exit = has_exit || ev.is_exit_point;
+  }
+
+  if (_zone.internal_vertices.empty())
+  {
+    if (!confirm_warning(
+        "This zone has no internal vertices, so a robot has nowhere to go "
+        "inside it."))
+      return;
+  }
+
+  for (std::size_t i = 0; i < _zone.internal_vertices.size(); i++)
+  {
+    const InternalVertex& iv = _zone.internal_vertices[i];
+    if (iv.name.empty())
+    {
+      QMessageBox::critical(this, "Error",
+        "Internal vertex name cannot be empty.");
+      return;
+    }
+
+    if (iv.group.empty())
+    {
+      QMessageBox::critical(this, "Error",
+        "Internal vertex group cannot be empty.");
+      return;
+    }
+
+    if (!is_vertex_name_unique(_zone.internal_vertices, iv.name, i))
+    {
+      QMessageBox::critical(this, "Error",
+        QString::fromStdString(
+          "Duplicate internal vertex [" + iv.name + "]."));
+      return;
+    }
+  }
+
+  if (!has_entry || !has_exit)
+  {
+    QStringList missing;
+    if (!has_entry)
+      missing.append("Zone has no entry point.");
+    if (!has_exit)
+      missing.append("Zone has no exit point.");
+
+    if (!confirm_warning(
+        missing.join("\n") +
+        "\nRobots will not be able to enter or leave this zone."))
+      return;
+  }
+
+  QStringList outside;
+  const double half_w = _zone.width / 2.0;
+  const double half_d = _zone.depth / 2.0;
+  for (const auto& iv: _zone.internal_vertices)
+  {
+    if (std::abs(iv.x) > half_w || std::abs(iv.y) > half_d)
+      outside.append(QString::fromStdString(iv.name));
+  }
+
+  if (!outside.isEmpty())
+  {
+    if (!confirm_warning(
+        "These internal vertices lie outside the zone bounds:\n  " +
+        outside.join("\n  ")))
+      return;
+  }
+
+  update_zone_view();
+  emit redraw();
+  accept();
 }
 
 // ======================================================================================================================
-bool ZoneDialog::is_vertex_name_unique(const std::string& name,
-  int ignore_index) const
+void ZoneDialog::cancel_button_clicked()
 {
-  for (std::size_t i = 0; i < _zone.vertices.size(); ++i)
-  {
-    // skip itself when editing
-    if (static_cast<int>(i) == ignore_index)
-      continue;
-
-    if (_zone.vertices[i].name == name)
-      return false;
-  }
-  return true;
+  _zone = _zone_copy;
+  update_zone_view();
+  emit redraw();
+  reject();
 }
+
 // ======================================================================================================================
-void ZoneDialog::vertex_table_cell_changed(int row, int col)
+void ZoneDialog::update_in_vertex_table()
 {
-  // printf("vertex_table_cell_changed(%d, %d)\n", row, col);
-  if (row >= static_cast<int>(_zone.vertices.size()))
+  _internal_vertex_table->blockSignals(true);
+  _internal_vertex_table->setRowCount(1 + _zone.internal_vertices.size());
+  for (std::size_t i = 0; i < _zone.internal_vertices.size(); i++)
   {
-    printf("invalid zone row: %d\n", row);
-    return;  // let's not crash
+    const InternalVertex& vertex = _zone.internal_vertices[i];  // save some typing
+
+    // clear any lingering placeholder items (e.g. when a row was previously the Add row)
+    _internal_vertex_table->setItem(i, 0, new QTableWidgetItem());
+    _internal_vertex_table->setItem(i, 5, new QTableWidgetItem());
+
+    _internal_vertex_table->setItem(
+      i, 1, new QTableWidgetItem(QString::fromStdString(vertex.name)));
+    _internal_vertex_table->setItem(
+      i, 2, new QTableWidgetItem(QString::number(vertex.x)));
+    _internal_vertex_table->setItem(
+      i, 3, new QTableWidgetItem(QString::number(vertex.y)));
+    _internal_vertex_table->setItem(
+      i, 4, new QTableWidgetItem(QString::fromStdString(vertex.group)));
+
+    QPushButton* delete_button = new QPushButton("Delete...", this);
+    _internal_vertex_table->setCellWidget(i, 0, delete_button);
+    connect(
+      delete_button,
+      &QAbstractButton::clicked,
+      [this, i]()
+      {
+        _zone.internal_vertices.erase(_zone.internal_vertices.begin() + i);
+        update_in_vertex_table();
+        update_zone_view();
+      });
+
+    QComboBox* priority_box = new QComboBox;
+    // include the vertex's own priority even when it exceeds the current
+    // vertex count, so a stale value is shown rather than silently clamped
+    const std::size_t priority_count = std::max(
+      _zone.internal_vertices.size(),
+      static_cast<std::size_t>(vertex.priority));
+    for (std::size_t j = 0; j < priority_count; j++)
+    {
+      priority_box->addItem(QString::number(j+1));
+    }
+    priority_box->setCurrentText(QString::number(vertex.priority));
+    connect(
+      priority_box,
+      &QComboBox::currentTextChanged,
+      [this, i](const QString& text)
+      {
+        _zone.internal_vertices[i].priority = text.toInt();
+        update_in_vertex_table();
+        update_zone_view();
+        emit redraw();
+      });
+    _internal_vertex_table->setCellWidget(i, 5, priority_box);
   }
 
-  // If a vertex name was changed, we need to update the options shown in all
-  // the level_table combo boxes
+  // we'll use the last row for the "Add" button
+  const int last_row_idx = static_cast<int>(_zone.internal_vertices.size());
+  QPushButton* add_button = new QPushButton("Add...", this);
+  _internal_vertex_table->setCellWidget(last_row_idx, 0, add_button);
+  for (int col = 1; col <= 5; col++)
+  {
+    _internal_vertex_table->setCellWidget(last_row_idx, col, nullptr);
+    auto* placeholder = new QTableWidgetItem();
+    placeholder->setFlags(Qt::NoItemFlags);
+    placeholder->setBackground(QColor(180, 180, 180));
+    _internal_vertex_table->setItem(last_row_idx, col, placeholder);
+  }
+  connect(
+    add_button,
+    &QAbstractButton::clicked,
+    [this]()
+    {
+      InternalVertex vertex;
+      vertex.name = "";
+      vertex.priority = _zone.internal_vertices.size()+1;
+      _zone.internal_vertices.push_back(vertex);
+      update_in_vertex_table();
+      update_zone_view();
+    });
+  _internal_vertex_table->blockSignals(false);
+}
+
+// ======================================================================================================================
+void ZoneDialog::update_ex_vertex_table()
+{
+  _external_vertex_table->blockSignals(true);
+  _external_vertex_table->setRowCount(1 + _zone.external_vertices.size());
+
+  for (std::size_t i = 0; i < _zone.external_vertices.size(); i++)
+  {
+    const ExternalVertex& ev = _zone.external_vertices[i];  // save some typing
+
+    // clear any lingering placeholder items (e.g. when a row was previously the Add row)
+    for (int col = 0; col <= 3; col++)
+      _external_vertex_table->setItem(i, col, new QTableWidgetItem());
+
+    QPushButton* delete_button = new QPushButton("Delete...", this);
+    _external_vertex_table->setCellWidget(i, 0, delete_button);
+    connect(
+      delete_button,
+      &QAbstractButton::clicked,
+      [this, i]()
+      {
+        _zone.external_vertices.erase(_zone.external_vertices.begin() + i);
+        update_ex_vertex_table();
+        update_zone_view();
+      });
+
+    QComboBox* vertex_combo_box = new QComboBox;
+    vertex_combo_box->addItem("Select vertex");
+    for (const auto& level : _building.levels)
+    {
+      if (level.name != _zone.level)
+        continue;
+
+      for (const auto& v : level.vertices)
+      {
+        if (!v.name.empty())
+          vertex_combo_box->addItem(QString::fromStdString(v.name));
+      }
+    }
+    vertex_combo_box->setCurrentText(
+      QString::fromStdString(ev.name));
+    connect(
+      vertex_combo_box,
+      &QComboBox::currentTextChanged,
+      [this, i, vertex_combo_box](const QString& text)
+      {
+        if (text == "Select vertex")
+        {
+          _zone.external_vertices[i].name.clear();
+          return;
+        }
+        _zone.external_vertices[i].name = text.toStdString();
+      });
+    _external_vertex_table->setCellWidget(i, 1, vertex_combo_box);
+
+    QCheckBox* is_entry_checkbox = new QCheckBox;
+    is_entry_checkbox->setChecked(ev.is_entry_point);
+    connect(
+      is_entry_checkbox,
+      &QAbstractButton::clicked,
+      [this, i](bool checked)
+      {
+        _zone.external_vertices[i].is_entry_point = checked;
+      });
+    QWidget* is_entry_container = new QWidget;
+    QHBoxLayout* is_entry_layout = new QHBoxLayout(is_entry_container);
+    is_entry_layout->addWidget(is_entry_checkbox);
+    is_entry_layout->setAlignment(Qt::AlignCenter);
+    is_entry_layout->setContentsMargins(0, 0, 0, 0);
+    _external_vertex_table->setCellWidget(i, 2, is_entry_container);
+
+    QCheckBox* is_exit_checkbox = new QCheckBox;
+    is_exit_checkbox->setChecked(ev.is_exit_point);
+    connect(
+      is_exit_checkbox,
+      &QAbstractButton::clicked,
+      [this, i](bool checked)
+      {
+        _zone.external_vertices[i].is_exit_point = checked;
+      });
+    QWidget* is_exit_container = new QWidget;
+    QHBoxLayout* is_exit_layout = new QHBoxLayout(is_exit_container);
+    is_exit_layout->addWidget(is_exit_checkbox);
+    is_exit_layout->setAlignment(Qt::AlignCenter);
+    is_exit_layout->setContentsMargins(0, 0, 0, 0);
+    _external_vertex_table->setCellWidget(i, 3, is_exit_container);
+  }
+
+  // we'll use the last row for the "Add" button
+  const int last_row_idx = static_cast<int>(_zone.external_vertices.size());
+  QPushButton* add_button = new QPushButton("Add...", this);
+  _external_vertex_table->setCellWidget(last_row_idx, 0, add_button);
+  for (int col = 1; col <= 3; col++)
+  {
+    _external_vertex_table->setCellWidget(last_row_idx, col, nullptr);
+    auto* placeholder = new QTableWidgetItem();
+    placeholder->setFlags(Qt::NoItemFlags);
+    placeholder->setBackground(QColor(180, 180, 180));
+    _external_vertex_table->setItem(last_row_idx, col, placeholder);
+  }
+  connect(
+    add_button,
+    &QAbstractButton::clicked,
+    [this]()
+    {
+      ExternalVertex new_ev;
+      _zone.external_vertices.push_back(new_ev);
+      update_ex_vertex_table();
+      update_zone_view();
+    });
+  _external_vertex_table->blockSignals(false);
+}
+
+// ======================================================================================================================
+void ZoneDialog::in_vertex_table_cell_changed(int row, int col)
+{
+  if (row < 0 || row >= static_cast<int>(_zone.internal_vertices.size()))
+    return;
+
+  InternalVertex& vertex = _zone.internal_vertices[row];
+
   if (col == 1)  // name
   {
-    std::string new_name =
-      _vertex_table->item(row, col)->text().toStdString();
-
-    if (new_name.empty())
-    {
-      QMessageBox::warning(this, "Invalid name", "Vertex name cannot be empty");
-      return;
-    }
-
-    if (!is_vertex_name_unique(new_name, row))
-    {
-      QMessageBox::warning(this, "Duplicate name",
-        "Vertex name must be unique");
-
-      // revert to previous value
-      _vertex_table->item(row, col)->setText(
-        QString::fromStdString(_zone.vertices[row].name));
-      return;
-    }
-
-    _zone.vertices[row].name = new_name;
+    const std::string name = _internal_vertex_table->
+      item(row, col)->text().toStdString();
+    vertex.name = name;
   }
-  else if (col == 2) // x
-    _zone.vertices[row].x = _vertex_table->item(row, col)->text().toDouble();
-  else if (col == 3) // y
-    _zone.vertices[row].y = _vertex_table->item(row, col)->text().toDouble();
-  else if (col == 4) // group
-    _zone.vertices[row].group =
-      _vertex_table->item(row, col)->text().toStdString();
-  else if (col == 5) // priority
-    _zone.vertices[row].priority =
-      _vertex_table->item(row, col)->text().toInt();
-
-  update_transition_lane_table();
-  update_zone_view();
-  emit redraw();
-}
-// ======================================================================================================================
-void ZoneDialog::transition_lane_table_cell_changed(int row, int col)
-{
-  // printf("vertex_table_cell_changed(%d, %d)\n", row, col);
-  if (row >= static_cast<int>(_zone.transition_lanes.size()))
+  if (col == 2)  // x
+    vertex.x = _internal_vertex_table->item(row, col)->text().toDouble();
+  if (col == 3)  // y
+    vertex.y = _internal_vertex_table->item(row, col)->text().toDouble();
+  if (col == 4)  // group
+    vertex.group = _internal_vertex_table->item(row, col)->text().toStdString();
+  if (col == 5)  // priority
   {
-    printf("invalid zone row: %d\n", row);
-    return;  // let's not crash
+    const uint priority = _internal_vertex_table->
+      item(row, col)->text().toUInt();
+    if (priority < 1)
+    {
+      QMessageBox::warning(this, "Invalid priority",
+        "Priority must be a positive integer");
+      _internal_vertex_table->blockSignals(true);
+      _internal_vertex_table->item(row, col)->setText(
+        QString::number(vertex.priority));
+      _internal_vertex_table->blockSignals(false);
+      return;
+    }
+    vertex.priority = priority;
   }
 
-  // If a vertex name was changed, we need to update the options shown in all
-  // the level_table combo boxes
-  if (col == 1) // internal vertex
-    _zone.transition_lanes[row].internal_vertex = _transition_lane_table->item(
-      row, col)->text().toStdString();
-  else if (col == 2) // external vertex
-    _zone.transition_lanes[row].external_vertex = _transition_lane_table->item(
-      row, col)->text().toStdString();
-  else if (col == 3) // is exit lane
-    _zone.transition_lanes[row].is_exit_lane = _transition_lane_table->item(
-      row, col)->text().toInt();
-  else if (col == 4) // is entry lane
-    _zone.transition_lanes[row].is_entry_lane = _transition_lane_table->item(
-      row, col)->text().toInt();
-
-  update_internal_vertex_combobox();
+  update_in_vertex_table();
   update_zone_view();
   emit redraw();
 }
+
 // ======================================================================================================================
 void ZoneDialog::update_zone_view()
 {
   _zone_scene->clear();
-  _zone.draw(_zone_scene, 0.01, std::string(), _zone.zone_elevation, false);
+  _zone.draw(_zone_scene, 0.01, std::string(), false);
 }

--- a/rmf_traffic_editor/gui/zone_dialog.cpp
+++ b/rmf_traffic_editor/gui/zone_dialog.cpp
@@ -1,0 +1,887 @@
+/*
+ * Copyright (C) 2019-2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "zone_dialog.h"
+#include <cfloat>
+#include <QtWidgets>
+using std::vector;
+
+
+ZoneDialog::ZoneDialog(Zone& zone, Building& building)
+: QDialog(),
+  _zone(zone),
+  _building(building)
+{
+  setWindowTitle("Zone Properties");
+  for (const auto& level : building.levels)
+  {
+    _level_names.push_back(QString::fromStdString(level.name));
+    _level_elevations.push_back(level.elevation);
+
+    for (const auto& vertex : level.vertices)
+    {
+      if (vertex.name != "")
+        _vertex_names.push_back(QString::fromStdString(vertex.name));
+      _vertex_x.push_back(vertex.x);
+      _vertex_y.push_back(vertex.y);
+    }
+  }
+
+  _zone_copy = _zone;
+
+  QHBoxLayout* bottom_buttons_hbox = new QHBoxLayout;
+  _ok_button = new QPushButton("OK", this);  // first button = [enter] button
+  bottom_buttons_hbox->addWidget(_ok_button);
+  connect(
+    _ok_button, &QAbstractButton::clicked,
+    this, &ZoneDialog::ok_button_clicked);
+
+  _cancel_button = new QPushButton("Cancel", this);
+  bottom_buttons_hbox->addWidget(_cancel_button);
+  connect(
+    _cancel_button,
+    &QAbstractButton::clicked,
+    this,
+    &ZoneDialog::cancel_button_clicked);
+
+  QHBoxLayout* name_hbox = new QHBoxLayout;
+  name_hbox->addWidget(new QLabel("Name:"));
+  _name_line_edit =
+    new QLineEdit(QString::fromStdString(_zone.name), this);
+  connect(
+    _name_line_edit,
+    &QLineEdit::textEdited,
+    [this](const QString& text)
+    {
+      _zone.name = text.toStdString();
+      update_zone_view();
+      emit redraw();
+    });
+  _name_line_edit->setToolTip("Name of the zone. (must be unique)");
+  name_hbox->addWidget(_name_line_edit);
+
+  QHBoxLayout* level_hbox = new QHBoxLayout;
+  level_hbox->addWidget(new QLabel("Zone level:"));
+  _level_combo_box = new QComboBox;
+  for (const QString& level_name : _level_names)
+  {
+    _level_combo_box->addItem(level_name);
+  }
+  _level_combo_box->setCurrentText(
+    QString::fromStdString(_zone.level));
+  connect(
+    _level_combo_box,
+    &QComboBox::currentTextChanged,
+    [this](const QString& text)
+    {
+      _zone.level = text.toStdString();
+      for (std::size_t i = 0; i < _level_names.size(); i++)
+      {
+        if (text == _level_names[i])
+        {
+          _zone.zone_elevation = _level_elevations[i];
+        }
+      }
+      emit redraw();
+
+    });
+  _level_combo_box->setToolTip("Level which the zone is in.");
+  level_hbox->addWidget(_level_combo_box);
+
+  QHBoxLayout* x_hbox = new QHBoxLayout;
+  x_hbox->addWidget(new QLabel("X (pixel):"));
+  _x_line_edit =
+    new QLineEdit(QString::number(_zone.x), this);
+  connect(
+    _x_line_edit,
+    &QLineEdit::textEdited,
+    [this](const QString& text)
+    {
+      _zone.x = text.toDouble();
+      emit redraw();
+    });
+  _x_line_edit->setToolTip(
+    "This <X> refers to either the global <X> of the zone");
+  x_hbox->addWidget(_x_line_edit);
+
+  QHBoxLayout* y_hbox = new QHBoxLayout;
+  y_hbox->addWidget(new QLabel("Y (pixel):"));
+  _y_line_edit =
+    new QLineEdit(QString::number(_zone.y), this);
+  connect(
+    _y_line_edit,
+    &QLineEdit::textEdited,
+    [this](const QString& text)
+    {
+      _zone.y = text.toDouble();
+      emit redraw();
+    });
+  _y_line_edit->setToolTip(
+    "This <Y> refers to either the global <Y> of the zone");
+  y_hbox->addWidget(_y_line_edit);
+
+  QHBoxLayout* yaw_hbox = new QHBoxLayout;
+  yaw_hbox->addWidget(new QLabel("Yaw (rad):"));
+  _yaw_line_edit =
+    new QLineEdit(QString::number(_zone.yaw), this);
+  connect(
+    _yaw_line_edit,
+    &QLineEdit::textEdited,
+    [this](const QString& text)
+    {
+      _zone.yaw = text.toDouble();
+      update_zone_view();
+      emit redraw();
+    });
+  _yaw_line_edit->setToolTip(
+    "This <Yaw> refers to either the global <Yaw> of the zone.\n The yaw is in radians.");
+  yaw_hbox->addWidget(_yaw_line_edit);
+
+  QHBoxLayout* width_hbox = new QHBoxLayout;
+  width_hbox->addWidget(new QLabel("Zone width (m):"));
+  _width_line_edit =
+    new QLineEdit(QString::number(_zone.width), this);
+  connect(
+    _width_line_edit,
+    &QLineEdit::textEdited,
+    [this](const QString& text)
+    {
+      _zone.width = text.toDouble();
+      update_zone_view();
+      emit redraw();
+    });
+  _width_line_edit->setToolTip("Width of the zone.");
+  width_hbox->addWidget(_width_line_edit);
+
+  QHBoxLayout* depth_hbox = new QHBoxLayout;
+  depth_hbox->addWidget(new QLabel("Zone depth (m):"));
+  _depth_line_edit =
+    new QLineEdit(QString::number(_zone.depth), this);
+  connect(
+    _depth_line_edit,
+    &QLineEdit::textEdited,
+    [this](const QString& text)
+    {
+      _zone.depth = text.toDouble();
+      update_zone_view();
+      emit redraw();
+    });
+  _depth_line_edit->setToolTip("Width of the zone.");
+  depth_hbox->addWidget(_depth_line_edit);
+
+
+  QHBoxLayout* entry_hbox = new QHBoxLayout;
+  entry_hbox->addWidget(new QLabel("Entry point:"));
+  _entry_combo_box = new QComboBox;
+  update_entry_combobox();
+  _entry_combo_box->setCurrentText(
+    QString::fromStdString(_zone.entry_point));
+  connect(
+    _entry_combo_box,
+    &QComboBox::currentTextChanged,
+    [this](const QString& text)
+    {
+      _zone.entry_point = text.toStdString();
+    });
+  entry_hbox->addWidget(_entry_combo_box);
+
+  QHBoxLayout* external_entry_hbox = new QHBoxLayout;
+  external_entry_hbox->addWidget(new QLabel("External entry point:"));
+  _external_entry_combo_box = new QComboBox;
+  for (const QString& vertex_name : _vertex_names)
+  {
+    _external_entry_combo_box->addItem(vertex_name);
+  }
+  _external_entry_combo_box->setCurrentText(
+    QString::fromStdString(_zone.external_entry_point));
+  connect(
+    _external_entry_combo_box,
+    &QComboBox::currentTextChanged,
+    [this](const QString& text)
+    {
+      _zone.external_entry_point = text.toStdString();
+      for (std::size_t i = 0; i < _vertex_names.size(); i++)
+      {
+        if (_vertex_names[i].toStdString() == _zone.external_entry_point)
+        {
+          _zone.external_entry_point_x = _vertex_x[i];
+          _zone.external_entry_point_y = _vertex_y[i];
+        }
+      }
+
+    });
+  _external_entry_combo_box->setToolTip("Level which the zone is in.");
+  external_entry_hbox->addWidget(_external_entry_combo_box);
+
+  QHBoxLayout* show_vertices_hbox = new QHBoxLayout;
+  show_vertices_hbox->addWidget(new QLabel("Show vertices:"));
+  _vertexcheckbox = new QCheckBox;
+  _vertexcheckbox->setChecked(_zone.show_vertices);
+  connect(
+    _vertexcheckbox,
+    &QAbstractButton::clicked,
+    [this](bool box_checked)
+    {
+      _zone.show_vertices = box_checked;
+      update_zone_view();
+      emit redraw();
+    });
+  show_vertices_hbox->addWidget(_vertexcheckbox);
+
+  _level_table = new QTableWidget;
+  _level_table->setMinimumSize(200, 200);
+  _level_table->verticalHeader()->setVisible(false);
+  _level_table->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
+  _level_table->setHorizontalHeaderItem(0, new QTableWidgetItem("Level name"));
+
+  _vertex_table = new QTableWidget;
+  _vertex_table->setMinimumSize(400, 200);
+  _vertex_table->verticalHeader()->setVisible(false);
+  _vertex_table->setColumnCount(6);
+  _vertex_table->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
+
+  _vertex_table->setHorizontalHeaderItem(0,
+    new QTableWidgetItem("Vertex name"));
+  _vertex_table->horizontalHeader()->setSectionResizeMode(
+    0, QHeaderView::Stretch);
+
+  _vertex_table->setHorizontalHeaderItem(1,
+    new QTableWidgetItem("X (m)"));
+  _vertex_table->horizontalHeader()->setSectionResizeMode(
+    1, QHeaderView::ResizeToContents);
+
+  _vertex_table->setHorizontalHeaderItem(2,
+    new QTableWidgetItem("Y (m)"));
+  _vertex_table->horizontalHeader()->setSectionResizeMode(
+    2, QHeaderView::ResizeToContents);
+
+  _vertex_table->setHorizontalHeaderItem(3,
+    new QTableWidgetItem("Group"));
+  _vertex_table->horizontalHeader()->setSectionResizeMode(
+    3, QHeaderView::ResizeToContents);
+
+  _vertex_table->setHorizontalHeaderItem(4,
+    new QTableWidgetItem("Priority"));
+  _vertex_table->horizontalHeader()->setSectionResizeMode(
+    4, QHeaderView::ResizeToContents);
+
+  _vertex_table->setHorizontalHeaderItem(5,
+    new QTableWidgetItem("Add Vertex..."));
+  _vertex_table->horizontalHeader()->setSectionResizeMode(
+    5, QHeaderView::ResizeToContents);
+
+  _transition_lane_table = new QTableWidget;
+  _transition_lane_table->setMinimumSize(600, 200);
+  _transition_lane_table->verticalHeader()->setVisible(false);
+  _transition_lane_table->setColumnCount(5);
+
+  _transition_lane_table->setHorizontalHeaderItem(0,
+    new QTableWidgetItem("Internal vertex"));
+  _transition_lane_table->horizontalHeader()->setSectionResizeMode(
+    0, QHeaderView::Stretch);
+
+  _transition_lane_table->setHorizontalHeaderItem(1,
+    new QTableWidgetItem("External vertex"));
+  _transition_lane_table->horizontalHeader()->setSectionResizeMode(
+    1, QHeaderView::ResizeToContents);
+
+  _transition_lane_table->setHorizontalHeaderItem(2,
+    new QTableWidgetItem("is exit lane"));
+  _transition_lane_table->horizontalHeader()->setSectionResizeMode(
+    2, QHeaderView::ResizeToContents);
+
+  _transition_lane_table->setHorizontalHeaderItem(3,
+    new QTableWidgetItem("is entry lane"));
+  _transition_lane_table->horizontalHeader()->setSectionResizeMode(
+    3, QHeaderView::ResizeToContents);
+
+  _transition_lane_table->setHorizontalHeaderItem(4,
+    new QTableWidgetItem("Add lane..."));
+  _transition_lane_table->horizontalHeader()->setSectionResizeMode(
+    4, QHeaderView::ResizeToContents);
+
+  QVBoxLayout* left_vbox = new QVBoxLayout;
+  left_vbox->addLayout(name_hbox);
+  left_vbox->addLayout(level_hbox);
+  left_vbox->addLayout(width_hbox);
+  left_vbox->addLayout(depth_hbox);
+  left_vbox->addLayout(x_hbox);
+  left_vbox->addLayout(y_hbox);
+  left_vbox->addLayout(yaw_hbox);
+  left_vbox->addWidget(_transition_lane_table);
+  left_vbox->addLayout(show_vertices_hbox);
+
+  QVBoxLayout* right_vbox = new QVBoxLayout;
+
+  _zone_scene = new QGraphicsScene;
+
+  _zone_view = new QGraphicsView;
+  _zone_view->setScene(_zone_scene);
+  _zone_view->setMinimumSize(400, 400);
+  right_vbox->addWidget(_zone_view, 1);
+
+  right_vbox->addWidget(_vertex_table);
+
+  QHBoxLayout* top_hbox = new QHBoxLayout;
+  top_hbox->addLayout(left_vbox);
+  top_hbox->addLayout(right_vbox, 1);
+
+  QVBoxLayout* top_vbox = new QVBoxLayout;
+  top_vbox->addLayout(top_hbox);
+  // todo: some sort of separator (?)
+  top_vbox->addLayout(bottom_buttons_hbox);
+
+  setLayout(top_vbox);
+
+  _name_line_edit->setFocus(Qt::OtherFocusReason);
+
+  update_vertex_table();
+  update_transition_lane_table();
+  update_level_table();
+
+  connect(
+    _vertex_table, &QTableWidget::cellChanged,
+    this, &ZoneDialog::vertex_table_cell_changed);
+
+  connect(
+    _transition_lane_table, &QTableWidget::cellChanged,
+    this, &ZoneDialog::transition_lane_table_cell_changed);
+
+  update_zone_view();
+  adjustSize();
+}
+
+// ======================================================================================================================
+ZoneDialog::~ZoneDialog()
+{
+}
+
+bool ZoneDialog::is_zone_name_unique(const std::string& name) const
+{
+  for (const auto& zone : _building.zones)
+  {
+    // skip comparing with itself (important when editing existing zone)
+    if (&zone == &_zone)
+      continue;
+
+    if (zone.name == name)
+      return false;
+  }
+  return true;
+}
+
+// ======================================================================================================================
+void ZoneDialog::ok_button_clicked()
+{
+  if (_name_line_edit->text().isEmpty())
+  {
+    QMessageBox::critical(this, "Error", "Zone name is empty");
+    return;
+  }
+
+  if (!has_valid_entry_and_exit_transition_lanes())
+  {
+    QMessageBox::critical(
+      this,
+      "Error",
+      "Each internal vertex must have at least one entry lane and "
+      "one exit lane.\n\nThey cannot share the same external vertex.");
+    return;
+  }
+
+  _zone.name = _name_line_edit->text().toStdString();
+  _zone.level = _level_combo_box->currentText().toStdString();
+  _zone.entry_point = _entry_combo_box->currentText().toStdString();
+  _zone.external_entry_point =
+    _external_entry_combo_box->currentText().toStdString();
+
+  for (std::size_t i = 0; i < _level_names.size(); i++)
+  {
+    if (_level_names[i].toStdString() == _zone.level)
+    {
+      _zone.zone_elevation = _level_elevations[i];
+      break;
+    }
+  }
+
+  _zone.x = _x_line_edit->text().toDouble();
+  _zone.y = _y_line_edit->text().toDouble();
+  _zone.yaw = _yaw_line_edit->text().toDouble();
+
+  _zone.width = _width_line_edit->text().toDouble();
+  _zone.depth = _depth_line_edit->text().toDouble();
+
+  if (!is_zone_name_unique(_name_line_edit->text().toStdString()))
+  {
+    QMessageBox::critical(this, "Error", "Zone name must be unique");
+    return;
+  }
+
+  update_zone_view();
+  emit redraw();
+  accept();
+}
+
+// ======================================================================================================================
+void ZoneDialog::cancel_button_clicked()
+{
+  _zone = _zone_copy;
+  update_zone_view();
+  emit redraw();
+  reject();
+}
+
+// ======================================================================================================================
+void ZoneDialog::update_vertex_table()
+{
+  _vertex_table->setRowCount(1 + _zone.vertices.size());
+  for (std::size_t i = 0; i < _zone.vertices.size(); i++)
+  {
+    const ZoneVertex& vertex = _zone.vertices[i];  // save some typing
+    set_vertex_cell(i, 0, QString::fromStdString(vertex.name));
+
+    // set the numeric fields
+    set_vertex_cell(i, 1, QString::number(vertex.x));
+    set_vertex_cell(i, 2, QString::number(vertex.y));
+
+    // set the group name
+    set_vertex_cell(i, 3, QString::fromStdString(vertex.group));
+
+    _priority_box = new QComboBox;
+    for (std::size_t j = 0; j < _zone.vertices.size(); j++)
+    {
+      _priority_box->addItem(QString::number(j+1));
+    }
+    _priority_box->setCurrentText(QString::number(vertex.priority));
+    connect(
+      _priority_box,
+      &QComboBox::currentTextChanged,
+      [this, i](const QString& text)
+      {
+        _zone.vertices[i].priority = text.toInt();
+        update_vertex_table();
+        update_zone_view();
+        emit redraw();
+      });
+    _vertex_table->setCellWidget(i, 4, _priority_box);
+
+    QPushButton* delete_button = new QPushButton("Delete...", this);
+    _vertex_table->setCellWidget(i, 5, delete_button);
+
+    connect(
+      delete_button,
+      &QAbstractButton::clicked,
+      [this, i]()
+      {
+        _zone.vertices.erase(_zone.vertices.begin() + i);
+        set_vertex_cell(_zone.vertices.size(), 0, nullptr);
+        set_vertex_cell(_zone.vertices.size(), 1, nullptr);
+        set_vertex_cell(_zone.vertices.size(), 2, nullptr);
+        set_vertex_cell(_zone.vertices.size(), 3, nullptr);
+        update_entry_combobox();
+        update_vertex_table();
+        update_zone_view();
+      });
+  }
+
+  // we'll use the last row for the "Add" button
+  const int last_row_idx = static_cast<int>(_zone.vertices.size());
+  _vertex_table->setCellWidget(last_row_idx, 0, nullptr);
+  _vertex_table->setCellWidget(last_row_idx, 1, nullptr);
+  _vertex_table->setCellWidget(last_row_idx, 2, nullptr);
+  _vertex_table->setCellWidget(last_row_idx, 3, nullptr);
+  _vertex_table->setCellWidget(last_row_idx, 4, nullptr);
+  QPushButton* add_button = new QPushButton("Add...", this);
+  _vertex_table->setCellWidget(last_row_idx, 5, add_button);
+  connect(
+    add_button,
+    &QAbstractButton::clicked,
+    [this]()
+    {
+      if (!is_vertex_name_unique("name", -1))
+      {
+        QMessageBox::warning(this, "Duplicate name",
+        "A vertex with the name 'name' already exists."
+        " Please change the name of existing vertex first.");
+        return;
+      }
+      ZoneVertex vertex;
+      vertex.name = "name";
+      vertex.priority = _zone.vertices.size()+1;
+      _zone.vertices.push_back(vertex);
+      update_entry_combobox();
+      update_vertex_table();
+      update_zone_view();
+    });
+}
+
+// ======================================================================================================================
+void ZoneDialog::update_transition_lane_table()
+{
+  _transition_lane_table->setRowCount(1 + _zone.transition_lanes.size());
+
+  for (std::size_t i = 0; i < _zone.transition_lanes.size(); i++)
+  {
+    const ZoneTransitionLane& lane = _zone.transition_lanes[i];  // save some typing
+
+    // set_transition_lane_cell(i, 0, QString::fromStdString(lane.internal_vertex));
+    // set_transition_lane_cell(i, 1, QString::fromStdString(lane.external_vertex));
+
+    _internal_vertex_combo_box = new QComboBox;
+    update_internal_vertex_combobox();
+    _internal_vertex_combo_box->setCurrentText(
+      QString::fromStdString(lane.internal_vertex));
+    connect(
+      _internal_vertex_combo_box,
+      &QComboBox::currentTextChanged,
+      [this, i](const QString& text)
+      {
+        _zone.transition_lanes[i].internal_vertex = text.toStdString();
+      });
+    _transition_lane_table->setCellWidget(i, 0, _internal_vertex_combo_box);
+
+
+    _external_vertex_combo_box = new QComboBox;
+    // update_external_vertex_combobox();
+    _external_vertex_combo_box->addItem("Select vertex");
+    for (const QString& vertex_name : _vertex_names)
+    {
+      _external_vertex_combo_box->addItem(vertex_name);
+    }
+    _external_vertex_combo_box->setCurrentText(
+      QString::fromStdString(lane.external_vertex));
+    connect(
+      _external_vertex_combo_box,
+      &QComboBox::currentTextChanged,
+      [this, i](const QString& text)
+      {
+        _zone.transition_lanes[i].external_vertex = text.toStdString();
+      });
+    _transition_lane_table->setCellWidget(i, 1, _external_vertex_combo_box);
+
+    _exit_lanecheckbox = new QCheckBox;
+    _exit_lanecheckbox->setChecked(lane.is_exit_lane);
+    connect(
+      _exit_lanecheckbox,
+      &QAbstractButton::clicked,
+      [this, i](bool box_checked)
+      {
+        _zone.transition_lanes[i].is_exit_lane = box_checked;
+      });
+    _transition_lane_table->setCellWidget(i, 2, _exit_lanecheckbox);
+
+
+    _entry_lanecheckbox = new QCheckBox;
+    _entry_lanecheckbox->setChecked(lane.is_entry_lane);
+    connect(
+      _entry_lanecheckbox,
+      &QAbstractButton::clicked,
+      [this, i](bool box_checked)
+      {
+        _zone.transition_lanes[i].is_entry_lane = box_checked;
+      });
+    _transition_lane_table->setCellWidget(i, 3, _entry_lanecheckbox);
+
+    QPushButton* delete_button = new QPushButton("Delete...", this);
+    _transition_lane_table->setCellWidget(i, 4, delete_button);
+
+    connect(
+      delete_button,
+      &QAbstractButton::clicked,
+      [this, i]()
+      {
+        if (_zone.transition_lanes.size() <= 2)
+        {
+          QMessageBox::warning(
+            this,
+            "Cannot delete",
+            "At least two transition lanes are required "
+            "(internal ↔ external vertex each).");
+          return;
+        }
+        _zone.transition_lanes.erase(_zone.transition_lanes.begin() + i);
+        set_transition_lane_cell(_zone.transition_lanes.size(), 0, nullptr);
+        set_transition_lane_cell(_zone.transition_lanes.size(), 1, nullptr);
+        _transition_lane_table->setCellWidget(_zone.transition_lanes.size(), 2,
+        nullptr);
+        _transition_lane_table->setCellWidget(_zone.transition_lanes.size(), 3,
+        nullptr);
+        update_transition_lane_table();
+        update_zone_view();
+      });
+  }
+
+  // we'll use the last row for the "Add" button
+  const int last_row_idx = static_cast<int>(_zone.transition_lanes.size());
+  _transition_lane_table->setCellWidget(last_row_idx, 0, nullptr);
+  _transition_lane_table->setCellWidget(last_row_idx, 1, nullptr);
+  _transition_lane_table->setCellWidget(last_row_idx, 2, nullptr);
+  _transition_lane_table->setCellWidget(last_row_idx, 3, nullptr);
+  QPushButton* add_button = new QPushButton("Add...", this);
+  _transition_lane_table->setCellWidget(last_row_idx, 4, add_button);
+  connect(
+    add_button,
+    &QAbstractButton::clicked,
+    [this]()
+    {
+      ZoneTransitionLane new_transition_lane;
+      _zone.transition_lanes.push_back(new_transition_lane);
+      update_transition_lane_table();
+      update_zone_view();
+    });
+}
+// ======================================================================================================================
+void ZoneDialog::update_entry_combobox()
+{
+  _entry_combo_box->clear();
+  for (const auto& vertex : _zone.vertices)
+  {
+    _entry_combo_box->addItem(QString::fromStdString(vertex.name));
+  }
+}
+// ======================================================================================================================
+void ZoneDialog::update_internal_vertex_combobox()
+{
+  _internal_vertex_combo_box->clear();
+  _internal_vertex_combo_box->addItem(QString::fromStdString(
+      "<select vertex>"));
+  for (const auto& vertex : _zone.vertices)
+  {
+    _internal_vertex_combo_box->addItem(QString::fromStdString(vertex.name));
+  }
+}
+
+bool ZoneDialog::transition_lane_vertices_valid(const ZoneTransitionLane& lane)
+const
+{
+  static const char* const k_internal_placeholder = "<select vertex>";
+  static const char* const k_external_placeholder = "Select vertex";
+
+  if (lane.internal_vertex.empty() ||
+    lane.internal_vertex == k_internal_placeholder)
+  {
+    return false;
+  }
+  if (lane.external_vertex.empty() ||
+    lane.external_vertex == k_external_placeholder)
+  {
+    return false;
+  }
+
+  bool internal_ok = false;
+  for (const auto& vertex : _zone.vertices)
+  {
+    if (vertex.name == lane.internal_vertex)
+    {
+      internal_ok = true;
+      break;
+    }
+  }
+  if (!internal_ok)
+  {
+    return false;
+  }
+
+  const QString external_q = QString::fromStdString(lane.external_vertex);
+  for (const QString& name : _vertex_names)
+  {
+    if (name == external_q)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool ZoneDialog::has_valid_entry_and_exit_transition_lanes() const
+{
+  // Check that each internal vertex has at least one entry lane and one exit lane
+  for (const auto& vertex : _zone.vertices)
+  {
+    int entry_count = 0;
+    int exit_count = 0;
+
+    for (const auto& lane : _zone.transition_lanes)
+    {
+      if (!transition_lane_vertices_valid(lane))
+        continue;
+
+      if (lane.internal_vertex == vertex.name)
+      {
+        if (lane.is_entry_lane)
+          entry_count++;
+        if (lane.is_exit_lane)
+          exit_count++;
+      }
+    }
+
+    if (entry_count < 1 || exit_count < 1)
+      return false;
+  }
+
+  // Also check that there's at least one entry lane and one exit lane (can be the same lane)
+  // with different external vertices
+  for (const auto& entry_lane : _zone.transition_lanes)
+  {
+    if (!entry_lane.is_entry_lane)
+      continue;
+
+    for (const auto& exit_lane : _zone.transition_lanes)
+    {
+      if (!exit_lane.is_exit_lane)
+        continue;
+
+      if (entry_lane.external_vertex != exit_lane.external_vertex)
+        return true;
+    }
+  }
+
+  return false;
+}
+
+// ======================================================================================================================
+void ZoneDialog::set_vertex_cell(const int row, const int col,
+  const QString& text)
+{
+  _vertex_table->setItem(row, col, new QTableWidgetItem(text));
+}
+// ======================================================================================================================
+void ZoneDialog::set_transition_lane_cell(const int row, const int col,
+  const QString& text)
+{
+  _transition_lane_table->setItem(row, col, new QTableWidgetItem(text));
+}
+
+// ======================================================================================================================
+void ZoneDialog::update_level_table()
+{
+  _level_table->setColumnCount(1 + static_cast<int>(_zone.vertices.size()));
+  _level_table->setHorizontalHeaderItem(0, new QTableWidgetItem("Level"));
+  for (std::size_t vertex_idx = 0; vertex_idx < _zone.vertices.size();
+    vertex_idx++)
+  {
+    _level_table->setHorizontalHeaderItem(
+      vertex_idx + 1,
+      new QTableWidgetItem(
+        QString::fromStdString(_zone.vertices[vertex_idx].name)));
+  }
+}
+// ======================================================================================================================
+bool ZoneDialog::is_vertex_name_unique(const std::string& name,
+  int ignore_index) const
+{
+  for (std::size_t i = 0; i < _zone.vertices.size(); ++i)
+  {
+    // skip itself when editing
+    if (static_cast<int>(i) == ignore_index)
+      continue;
+
+    if (_zone.vertices[i].name == name)
+      return false;
+  }
+  return true;
+}
+// ======================================================================================================================
+void ZoneDialog::vertex_table_cell_changed(int row, int col)
+{
+  // printf("vertex_table_cell_changed(%d, %d)\n", row, col);
+  if (row >= static_cast<int>(_zone.vertices.size()))
+  {
+    printf("invalid zone row: %d\n", row);
+    return;  // let's not crash
+  }
+
+  // If a vertex name was changed, we need to update the options shown in all
+  // the level_table combo boxes
+  if (col == 0)  // name
+  {
+    std::string new_name =
+      _vertex_table->item(row, col)->text().toStdString();
+
+    if (new_name.empty())
+    {
+      QMessageBox::warning(this, "Invalid name", "Vertex name cannot be empty");
+      return;
+    }
+
+    if (!is_vertex_name_unique(new_name, row))
+    {
+      QMessageBox::warning(this, "Duplicate name",
+        "Vertex name must be unique");
+
+      // revert to previous value
+      _vertex_table->item(row, col)->setText(
+        QString::fromStdString(_zone.vertices[row].name));
+      return;
+    }
+
+    _zone.vertices[row].name = new_name;
+
+    update_entry_combobox();
+    update_level_table();
+  }
+  else if (col == 1) // x
+    _zone.vertices[row].x = _vertex_table->item(row, col)->text().toDouble();
+  else if (col == 2) // y
+    _zone.vertices[row].y = _vertex_table->item(row, col)->text().toDouble();
+  else if (col == 3)
+    _zone.vertices[row].group =
+      _vertex_table->item(row, col)->text().toStdString();
+  else if (col == 4)
+    _zone.vertices[row].priority =
+      _vertex_table->item(row, col)->text().toInt();
+
+  update_transition_lane_table();
+  update_zone_view();
+  emit redraw();
+}
+// ======================================================================================================================
+void ZoneDialog::transition_lane_table_cell_changed(int row, int col)
+{
+  // printf("vertex_table_cell_changed(%d, %d)\n", row, col);
+  if (row >= static_cast<int>(_zone.transition_lanes.size()))
+  {
+    printf("invalid zone row: %d\n", row);
+    return;  // let's not crash
+  }
+
+  // If a vertex name was changed, we need to update the options shown in all
+  // the level_table combo boxes
+  if (col == 0) // name
+    _zone.transition_lanes[row].internal_vertex = _transition_lane_table->item(
+      row, col)->text().toStdString();
+  else if (col == 1) // x
+    _zone.transition_lanes[row].external_vertex = _transition_lane_table->item(
+      row, col)->text().toStdString();
+  else if (col == 2) // y
+    _zone.transition_lanes[row].is_exit_lane = _transition_lane_table->item(
+      row, col)->text().toInt();
+  else if (col == 3)
+    _zone.transition_lanes[row].is_entry_lane = _transition_lane_table->item(
+      row, col)->text().toInt();
+
+  update_internal_vertex_combobox();
+  update_level_table();
+  update_zone_view();
+  emit redraw();
+}
+// ======================================================================================================================
+void ZoneDialog::update_zone_view()
+{
+  _zone_scene->clear();
+  _zone.draw(_zone_scene, 0.01, std::string(), _zone.zone_elevation, false);
+}

--- a/rmf_traffic_editor/gui/zone_dialog.cpp
+++ b/rmf_traffic_editor/gui/zone_dialog.cpp
@@ -337,20 +337,24 @@ void ZoneDialog::ok_button_clicked()
     return;
   }
 
-  if (!has_valid_entry_and_exit_transition_lanes())
-  {
-    QMessageBox::critical(
-      this,
-      "Error",
-      "Each internal vertex must have at least one entry lane and "
-      "one exit lane.\n\nThey cannot share the same external vertex.");
-    return;
-  }
-
   if (!is_zone_name_unique(_name_line_edit->text().toStdString()))
   {
     QMessageBox::critical(this, "Error", "Zone name must be unique");
     return;
+  }
+  
+  if (!has_valid_entry_and_exit_transition_lanes())
+  {
+    QMessageBox mb(this);
+    mb.setIcon(QMessageBox::Warning);
+    mb.setWindowTitle("Warning");
+    mb.setText(
+      "Current lanes configuration might cause issues when robots "
+      "enter/exit the zone");
+    mb.addButton("Cancel", QMessageBox::RejectRole);
+    mb.addButton("OK", QMessageBox::AcceptRole);
+    if (mb.exec() != QDialog::Accepted)
+      return;
   }
 
   update_zone_view();

--- a/rmf_traffic_editor/gui/zone_dialog.cpp
+++ b/rmf_traffic_editor/gui/zone_dialog.cpp
@@ -451,6 +451,33 @@ void ZoneDialog::ok_button_clicked()
       return;
     }
 
+    for (const auto& level : _building.levels)
+    {
+      if (!is_vertex_name_unique(level.vertices, iv.name))
+      {
+        QMessageBox::critical(this, "Error",
+          QString::fromStdString(
+            "Vertex name [" + iv.name + "] already exists on level [" +
+            level.name + "]. Internal vertex names must be unique."));
+        return;
+      }
+    }
+
+    for (const auto& zone : _building.zones)
+    {
+      if (&zone == &_zone)
+        continue;
+
+      if (!is_vertex_name_unique(zone.internal_vertices, iv.name))
+      {
+        QMessageBox::critical(this, "Error",
+          QString::fromStdString(
+            "Vertex name [" + iv.name + "] is already used by zone [" +
+            zone.name + "]. Internal vertex names must be unique."));
+        return;
+      }
+    }
+
     if (!is_vertex_name_unique(_zone.internal_vertices, iv.name, i))
     {
       QMessageBox::critical(this, "Error",

--- a/rmf_traffic_editor/gui/zone_dialog.cpp
+++ b/rmf_traffic_editor/gui/zone_dialog.cpp
@@ -307,6 +307,7 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
   update_zone_view();
   adjustSize();
   _ok_button->setFocus(Qt::OtherFocusReason);
+  _ok_button->setDefault(true);
 }
 
 // ======================================================================================================================

--- a/rmf_traffic_editor/gui/zone_dialog.cpp
+++ b/rmf_traffic_editor/gui/zone_dialog.cpp
@@ -346,15 +346,9 @@ void ZoneDialog::ok_button_clicked()
   
   if (!has_valid_entry_and_exit_transition_lanes())
   {
-    QMessageBox mb(this);
-    mb.setIcon(QMessageBox::Warning);
-    mb.setWindowTitle("Warning");
-    mb.setText(
+    if (!confirm_warning(
       "Current lanes configuration might cause issues when robots "
-      "enter/exit the zone");
-    mb.addButton("Cancel", QMessageBox::RejectRole);
-    mb.addButton("OK", QMessageBox::AcceptRole);
-    if (mb.exec() != QDialog::Accepted)
+      "enter/exit the zone"))
       return;
   }
 
@@ -675,6 +669,37 @@ bool ZoneDialog::has_valid_entry_and_exit_transition_lanes() const
   }
 
   return true;
+}
+
+// ======================================================================================================================
+bool ZoneDialog::confirm_warning(const QString& text)
+{
+  QDialog dialog(this);
+  dialog.setWindowTitle("Warning");
+
+  QHBoxLayout* msg_hbox = new QHBoxLayout;
+  QLabel* icon_label = new QLabel;
+  icon_label->setPixmap(
+    dialog.style()->standardIcon(QStyle::SP_MessageBoxWarning).pixmap(48, 48));
+  msg_hbox->addWidget(icon_label);
+  msg_hbox->addWidget(new QLabel(text), 1);
+
+  QPushButton* ok_button = new QPushButton("OK");
+  QPushButton* cancel_button = new QPushButton("Cancel");
+  QHBoxLayout* button_hbox = new QHBoxLayout;
+  button_hbox->addStretch(1);
+  button_hbox->addWidget(ok_button);
+  button_hbox->addWidget(cancel_button);
+
+  QVBoxLayout* vbox = new QVBoxLayout;
+  vbox->addLayout(msg_hbox);
+  vbox->addLayout(button_hbox);
+  dialog.setLayout(vbox);
+
+  connect(ok_button, &QAbstractButton::clicked, &dialog, &QDialog::accept);
+  connect(cancel_button, &QAbstractButton::clicked, &dialog, &QDialog::reject);
+
+  return dialog.exec() == QDialog::Accepted;
 }
 
 // ======================================================================================================================

--- a/rmf_traffic_editor/gui/zone_dialog.cpp
+++ b/rmf_traffic_editor/gui/zone_dialog.cpp
@@ -347,8 +347,6 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
 
   setLayout(top_vbox);
 
-  _name_line_edit->setFocus(Qt::OtherFocusReason);
-
   update_vertex_table();
   update_transition_lane_table();
   update_level_table();
@@ -363,6 +361,7 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
 
   update_zone_view();
   adjustSize();
+  _ok_button->setFocus(Qt::OtherFocusReason);
 }
 
 // ======================================================================================================================

--- a/rmf_traffic_editor/gui/zone_dialog.cpp
+++ b/rmf_traffic_editor/gui/zone_dialog.cpp
@@ -17,6 +17,7 @@
 
 #include "zone_dialog.h"
 #include <cfloat>
+#include <cmath>
 #include <QtWidgets>
 using std::vector;
 
@@ -352,6 +353,19 @@ void ZoneDialog::ok_button_clicked()
       return;
   }
 
+  const std::vector<std::string> outside = vertices_outside_zone();
+  if (!outside.empty())
+  {
+    QStringList names;
+    for (const auto& name : outside)
+      names.append(QString::fromStdString(name));
+
+    if (!confirm_warning(
+      "These internal vertices lie outside the zone bounds:\n  " +
+      names.join("\n  ")))
+      return;
+  }
+
   update_zone_view();
   emit redraw();
   accept();
@@ -663,6 +677,20 @@ bool ZoneDialog::has_valid_entry_and_exit_transition_lanes() const
   }
 
   return true;
+}
+
+// ======================================================================================================================
+std::vector<std::string> ZoneDialog::vertices_outside_zone() const
+{
+  std::vector<std::string> outside;
+  const double half_w = _zone.width / 2.0;
+  const double half_d = _zone.depth / 2.0;
+  for (const auto& vertex : _zone.vertices)
+  {
+    if (std::abs(vertex.x) > half_w || std::abs(vertex.y) > half_d)
+      outside.push_back(vertex.name);
+  }
+  return outside;
 }
 
 // ======================================================================================================================

--- a/rmf_traffic_editor/gui/zone_dialog.cpp
+++ b/rmf_traffic_editor/gui/zone_dialog.cpp
@@ -97,7 +97,6 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
         }
       }
       emit redraw();
-
     });
   _level_combo_box->setToolTip("Level which the zone is in.");
   level_hbox->addWidget(_level_combo_box);
@@ -115,7 +114,7 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
       emit redraw();
     });
   _x_line_edit->setToolTip(
-    "This <X> refers to either the global <X> of the zone");
+    "This <X> refers to the global <X> of the zone");
   x_hbox->addWidget(_x_line_edit);
 
   QHBoxLayout* y_hbox = new QHBoxLayout;
@@ -131,7 +130,7 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
       emit redraw();
     });
   _y_line_edit->setToolTip(
-    "This <Y> refers to either the global <Y> of the zone");
+    "This <Y> refers to  the global <Y> of the zone");
   y_hbox->addWidget(_y_line_edit);
 
   QHBoxLayout* yaw_hbox = new QHBoxLayout;
@@ -148,7 +147,7 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
       emit redraw();
     });
   _yaw_line_edit->setToolTip(
-    "This <Yaw> refers to either the global <Yaw> of the zone.\n The yaw is in radians.");
+    "This <Yaw> refers to the global <Yaw> of the zone.\n The yaw is in radians.");
   yaw_hbox->addWidget(_yaw_line_edit);
 
   QHBoxLayout* width_hbox = new QHBoxLayout;
@@ -180,52 +179,8 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
       update_zone_view();
       emit redraw();
     });
-  _depth_line_edit->setToolTip("Width of the zone.");
+  _depth_line_edit->setToolTip("Depth of the zone.");
   depth_hbox->addWidget(_depth_line_edit);
-
-
-  QHBoxLayout* entry_hbox = new QHBoxLayout;
-  entry_hbox->addWidget(new QLabel("Entry point:"));
-  _entry_combo_box = new QComboBox;
-  update_entry_combobox();
-  _entry_combo_box->setCurrentText(
-    QString::fromStdString(_zone.entry_point));
-  connect(
-    _entry_combo_box,
-    &QComboBox::currentTextChanged,
-    [this](const QString& text)
-    {
-      _zone.entry_point = text.toStdString();
-    });
-  entry_hbox->addWidget(_entry_combo_box);
-
-  QHBoxLayout* external_entry_hbox = new QHBoxLayout;
-  external_entry_hbox->addWidget(new QLabel("External entry point:"));
-  _external_entry_combo_box = new QComboBox;
-  for (const QString& vertex_name : _vertex_names)
-  {
-    _external_entry_combo_box->addItem(vertex_name);
-  }
-  _external_entry_combo_box->setCurrentText(
-    QString::fromStdString(_zone.external_entry_point));
-  connect(
-    _external_entry_combo_box,
-    &QComboBox::currentTextChanged,
-    [this](const QString& text)
-    {
-      _zone.external_entry_point = text.toStdString();
-      for (std::size_t i = 0; i < _vertex_names.size(); i++)
-      {
-        if (_vertex_names[i].toStdString() == _zone.external_entry_point)
-        {
-          _zone.external_entry_point_x = _vertex_x[i];
-          _zone.external_entry_point_y = _vertex_y[i];
-        }
-      }
-
-    });
-  _external_entry_combo_box->setToolTip("Level which the zone is in.");
-  external_entry_hbox->addWidget(_external_entry_combo_box);
 
   QHBoxLayout* show_vertices_hbox = new QHBoxLayout;
   show_vertices_hbox->addWidget(new QLabel("Show vertices:"));
@@ -242,12 +197,6 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
     });
   show_vertices_hbox->addWidget(_vertexcheckbox);
 
-  _level_table = new QTableWidget;
-  _level_table->setMinimumSize(200, 200);
-  _level_table->verticalHeader()->setVisible(false);
-  _level_table->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
-  _level_table->setHorizontalHeaderItem(0, new QTableWidgetItem("Level name"));
-
   _vertex_table = new QTableWidget;
   _vertex_table->setMinimumSize(400, 200);
   _vertex_table->verticalHeader()->setVisible(false);
@@ -255,32 +204,32 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
   _vertex_table->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
 
   _vertex_table->setHorizontalHeaderItem(0,
-    new QTableWidgetItem("Vertex name"));
+    new QTableWidgetItem("Add Internal Vertex..."));
   _vertex_table->horizontalHeader()->setSectionResizeMode(
-    0, QHeaderView::Stretch);
+    0, QHeaderView::ResizeToContents);
 
   _vertex_table->setHorizontalHeaderItem(1,
-    new QTableWidgetItem("X (m)"));
+    new QTableWidgetItem("Vertex name"));
   _vertex_table->horizontalHeader()->setSectionResizeMode(
-    1, QHeaderView::ResizeToContents);
+    1, QHeaderView::Stretch);
 
   _vertex_table->setHorizontalHeaderItem(2,
-    new QTableWidgetItem("Y (m)"));
+    new QTableWidgetItem("X (m)"));
   _vertex_table->horizontalHeader()->setSectionResizeMode(
     2, QHeaderView::ResizeToContents);
 
   _vertex_table->setHorizontalHeaderItem(3,
-    new QTableWidgetItem("Group"));
+    new QTableWidgetItem("Y (m)"));
   _vertex_table->horizontalHeader()->setSectionResizeMode(
     3, QHeaderView::ResizeToContents);
 
   _vertex_table->setHorizontalHeaderItem(4,
-    new QTableWidgetItem("Priority"));
+    new QTableWidgetItem("Group"));
   _vertex_table->horizontalHeader()->setSectionResizeMode(
     4, QHeaderView::ResizeToContents);
 
   _vertex_table->setHorizontalHeaderItem(5,
-    new QTableWidgetItem("Add Vertex..."));
+    new QTableWidgetItem("Priority"));
   _vertex_table->horizontalHeader()->setSectionResizeMode(
     5, QHeaderView::ResizeToContents);
 
@@ -290,27 +239,27 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
   _transition_lane_table->setColumnCount(5);
 
   _transition_lane_table->setHorizontalHeaderItem(0,
-    new QTableWidgetItem("Internal vertex"));
+    new QTableWidgetItem("Add lane..."));
   _transition_lane_table->horizontalHeader()->setSectionResizeMode(
-    0, QHeaderView::Stretch);
+    0, QHeaderView::ResizeToContents);
 
   _transition_lane_table->setHorizontalHeaderItem(1,
-    new QTableWidgetItem("External vertex"));
+    new QTableWidgetItem("Internal vertex"));
   _transition_lane_table->horizontalHeader()->setSectionResizeMode(
-    1, QHeaderView::ResizeToContents);
+    1, QHeaderView::Stretch);
 
   _transition_lane_table->setHorizontalHeaderItem(2,
-    new QTableWidgetItem("is exit lane"));
+    new QTableWidgetItem("External vertex"));
   _transition_lane_table->horizontalHeader()->setSectionResizeMode(
     2, QHeaderView::ResizeToContents);
 
   _transition_lane_table->setHorizontalHeaderItem(3,
-    new QTableWidgetItem("is entry lane"));
+    new QTableWidgetItem("is exit lane"));
   _transition_lane_table->horizontalHeader()->setSectionResizeMode(
     3, QHeaderView::ResizeToContents);
 
   _transition_lane_table->setHorizontalHeaderItem(4,
-    new QTableWidgetItem("Add lane..."));
+    new QTableWidgetItem("is entry lane"));
   _transition_lane_table->horizontalHeader()->setSectionResizeMode(
     4, QHeaderView::ResizeToContents);
 
@@ -323,18 +272,15 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
   left_vbox->addLayout(y_hbox);
   left_vbox->addLayout(yaw_hbox);
   left_vbox->addWidget(_transition_lane_table);
-  left_vbox->addLayout(show_vertices_hbox);
-
+  
   QVBoxLayout* right_vbox = new QVBoxLayout;
-
   _zone_scene = new QGraphicsScene;
-
   _zone_view = new QGraphicsView;
   _zone_view->setScene(_zone_scene);
   _zone_view->setMinimumSize(400, 400);
   right_vbox->addWidget(_zone_view, 1);
-
   right_vbox->addWidget(_vertex_table);
+  right_vbox->addLayout(show_vertices_hbox);
 
   QHBoxLayout* top_hbox = new QHBoxLayout;
   top_hbox->addLayout(left_vbox);
@@ -349,7 +295,6 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
 
   update_vertex_table();
   update_transition_lane_table();
-  update_level_table();
 
   connect(
     _vertex_table, &QTableWidget::cellChanged,
@@ -402,28 +347,6 @@ void ZoneDialog::ok_button_clicked()
     return;
   }
 
-  _zone.name = _name_line_edit->text().toStdString();
-  _zone.level = _level_combo_box->currentText().toStdString();
-  _zone.entry_point = _entry_combo_box->currentText().toStdString();
-  _zone.external_entry_point =
-    _external_entry_combo_box->currentText().toStdString();
-
-  for (std::size_t i = 0; i < _level_names.size(); i++)
-  {
-    if (_level_names[i].toStdString() == _zone.level)
-    {
-      _zone.zone_elevation = _level_elevations[i];
-      break;
-    }
-  }
-
-  _zone.x = _x_line_edit->text().toDouble();
-  _zone.y = _y_line_edit->text().toDouble();
-  _zone.yaw = _yaw_line_edit->text().toDouble();
-
-  _zone.width = _width_line_edit->text().toDouble();
-  _zone.depth = _depth_line_edit->text().toDouble();
-
   if (!is_zone_name_unique(_name_line_edit->text().toStdString()))
   {
     QMessageBox::critical(this, "Error", "Zone name must be unique");
@@ -447,18 +370,27 @@ void ZoneDialog::cancel_button_clicked()
 // ======================================================================================================================
 void ZoneDialog::update_vertex_table()
 {
+  _vertex_table->blockSignals(true);
   _vertex_table->setRowCount(1 + _zone.vertices.size());
   for (std::size_t i = 0; i < _zone.vertices.size(); i++)
   {
     const ZoneVertex& vertex = _zone.vertices[i];  // save some typing
-    set_vertex_cell(i, 0, QString::fromStdString(vertex.name));
+
+    // clear any lingering placeholder items (e.g. when a row was previously the Add row)
+    _vertex_table->setItem(i, 0, new QTableWidgetItem());
+    _vertex_table->setItem(i, 5, new QTableWidgetItem());
+
+    QPushButton* delete_button = new QPushButton("Delete...", this);
+    _vertex_table->setCellWidget(i, 0, delete_button);
+
+    set_vertex_cell(i, 1, QString::fromStdString(vertex.name));
 
     // set the numeric fields
-    set_vertex_cell(i, 1, QString::number(vertex.x));
-    set_vertex_cell(i, 2, QString::number(vertex.y));
+    set_vertex_cell(i, 2, QString::number(vertex.x));
+    set_vertex_cell(i, 3, QString::number(vertex.y));
 
     // set the group name
-    set_vertex_cell(i, 3, QString::fromStdString(vertex.group));
+    set_vertex_cell(i, 4, QString::fromStdString(vertex.group));
 
     _priority_box = new QComboBox;
     for (std::size_t j = 0; j < _zone.vertices.size(); j++)
@@ -476,10 +408,7 @@ void ZoneDialog::update_vertex_table()
         update_zone_view();
         emit redraw();
       });
-    _vertex_table->setCellWidget(i, 4, _priority_box);
-
-    QPushButton* delete_button = new QPushButton("Delete...", this);
-    _vertex_table->setCellWidget(i, 5, delete_button);
+    _vertex_table->setCellWidget(i, 5, _priority_box);
 
     connect(
       delete_button,
@@ -487,25 +416,24 @@ void ZoneDialog::update_vertex_table()
       [this, i]()
       {
         _zone.vertices.erase(_zone.vertices.begin() + i);
-        set_vertex_cell(_zone.vertices.size(), 0, nullptr);
-        set_vertex_cell(_zone.vertices.size(), 1, nullptr);
-        set_vertex_cell(_zone.vertices.size(), 2, nullptr);
-        set_vertex_cell(_zone.vertices.size(), 3, nullptr);
-        update_entry_combobox();
         update_vertex_table();
+        update_transition_lane_table();
         update_zone_view();
       });
   }
 
   // we'll use the last row for the "Add" button
   const int last_row_idx = static_cast<int>(_zone.vertices.size());
-  _vertex_table->setCellWidget(last_row_idx, 0, nullptr);
-  _vertex_table->setCellWidget(last_row_idx, 1, nullptr);
-  _vertex_table->setCellWidget(last_row_idx, 2, nullptr);
-  _vertex_table->setCellWidget(last_row_idx, 3, nullptr);
-  _vertex_table->setCellWidget(last_row_idx, 4, nullptr);
   QPushButton* add_button = new QPushButton("Add...", this);
-  _vertex_table->setCellWidget(last_row_idx, 5, add_button);
+  _vertex_table->setCellWidget(last_row_idx, 0, add_button);
+  for (int col = 1; col <= 5; col++)
+  {
+    _vertex_table->setCellWidget(last_row_idx, col, nullptr);
+    auto* placeholder = new QTableWidgetItem();
+    placeholder->setFlags(Qt::NoItemFlags);
+    placeholder->setBackground(QColor(180, 180, 180));
+    _vertex_table->setItem(last_row_idx, col, placeholder);
+  }
   connect(
     add_button,
     &QAbstractButton::clicked,
@@ -522,23 +450,29 @@ void ZoneDialog::update_vertex_table()
       vertex.name = "name";
       vertex.priority = _zone.vertices.size()+1;
       _zone.vertices.push_back(vertex);
-      update_entry_combobox();
       update_vertex_table();
+      update_transition_lane_table();
       update_zone_view();
     });
+  _vertex_table->blockSignals(false);
 }
 
 // ======================================================================================================================
 void ZoneDialog::update_transition_lane_table()
 {
+  _transition_lane_table->blockSignals(true);
   _transition_lane_table->setRowCount(1 + _zone.transition_lanes.size());
 
   for (std::size_t i = 0; i < _zone.transition_lanes.size(); i++)
   {
     const ZoneTransitionLane& lane = _zone.transition_lanes[i];  // save some typing
 
-    // set_transition_lane_cell(i, 0, QString::fromStdString(lane.internal_vertex));
-    // set_transition_lane_cell(i, 1, QString::fromStdString(lane.external_vertex));
+    // clear any lingering placeholder items (e.g. when a row was previously the Add row)
+    for (int col = 0; col <= 4; col++)
+      _transition_lane_table->setItem(i, col, new QTableWidgetItem());
+
+    QPushButton* delete_button = new QPushButton("Delete...", this);
+    _transition_lane_table->setCellWidget(i, 0, delete_button);
 
     _internal_vertex_combo_box = new QComboBox;
     update_internal_vertex_combobox();
@@ -551,11 +485,9 @@ void ZoneDialog::update_transition_lane_table()
       {
         _zone.transition_lanes[i].internal_vertex = text.toStdString();
       });
-    _transition_lane_table->setCellWidget(i, 0, _internal_vertex_combo_box);
-
+    _transition_lane_table->setCellWidget(i, 1, _internal_vertex_combo_box);
 
     _external_vertex_combo_box = new QComboBox;
-    // update_external_vertex_combobox();
     _external_vertex_combo_box->addItem("Select vertex");
     for (const QString& vertex_name : _vertex_names)
     {
@@ -570,7 +502,7 @@ void ZoneDialog::update_transition_lane_table()
       {
         _zone.transition_lanes[i].external_vertex = text.toStdString();
       });
-    _transition_lane_table->setCellWidget(i, 1, _external_vertex_combo_box);
+    _transition_lane_table->setCellWidget(i, 2, _external_vertex_combo_box);
 
     _exit_lanecheckbox = new QCheckBox;
     _exit_lanecheckbox->setChecked(lane.is_exit_lane);
@@ -581,8 +513,7 @@ void ZoneDialog::update_transition_lane_table()
       {
         _zone.transition_lanes[i].is_exit_lane = box_checked;
       });
-    _transition_lane_table->setCellWidget(i, 2, _exit_lanecheckbox);
-
+    _transition_lane_table->setCellWidget(i, 3, _exit_lanecheckbox);
 
     _entry_lanecheckbox = new QCheckBox;
     _entry_lanecheckbox->setChecked(lane.is_entry_lane);
@@ -593,17 +524,15 @@ void ZoneDialog::update_transition_lane_table()
       {
         _zone.transition_lanes[i].is_entry_lane = box_checked;
       });
-    _transition_lane_table->setCellWidget(i, 3, _entry_lanecheckbox);
-
-    QPushButton* delete_button = new QPushButton("Delete...", this);
-    _transition_lane_table->setCellWidget(i, 4, delete_button);
+    _transition_lane_table->setCellWidget(i, 4, _entry_lanecheckbox);
 
     connect(
       delete_button,
       &QAbstractButton::clicked,
       [this, i]()
       {
-        if (_zone.transition_lanes.size() <= 2)
+        if (_zone.transition_lanes.size() <= 2 &&
+          transition_lane_vertices_valid(_zone.transition_lanes[i]))
         {
           QMessageBox::warning(
             this,
@@ -613,11 +542,11 @@ void ZoneDialog::update_transition_lane_table()
           return;
         }
         _zone.transition_lanes.erase(_zone.transition_lanes.begin() + i);
-        set_transition_lane_cell(_zone.transition_lanes.size(), 0, nullptr);
         set_transition_lane_cell(_zone.transition_lanes.size(), 1, nullptr);
-        _transition_lane_table->setCellWidget(_zone.transition_lanes.size(), 2,
-        nullptr);
+        set_transition_lane_cell(_zone.transition_lanes.size(), 2, nullptr);
         _transition_lane_table->setCellWidget(_zone.transition_lanes.size(), 3,
+        nullptr);
+        _transition_lane_table->setCellWidget(_zone.transition_lanes.size(), 4,
         nullptr);
         update_transition_lane_table();
         update_zone_view();
@@ -626,32 +555,37 @@ void ZoneDialog::update_transition_lane_table()
 
   // we'll use the last row for the "Add" button
   const int last_row_idx = static_cast<int>(_zone.transition_lanes.size());
-  _transition_lane_table->setCellWidget(last_row_idx, 0, nullptr);
-  _transition_lane_table->setCellWidget(last_row_idx, 1, nullptr);
-  _transition_lane_table->setCellWidget(last_row_idx, 2, nullptr);
-  _transition_lane_table->setCellWidget(last_row_idx, 3, nullptr);
   QPushButton* add_button = new QPushButton("Add...", this);
-  _transition_lane_table->setCellWidget(last_row_idx, 4, add_button);
+  _transition_lane_table->setCellWidget(last_row_idx, 0, add_button);
+  for (int col = 1; col <= 4; col++)
+  {
+    _transition_lane_table->setCellWidget(last_row_idx, col, nullptr);
+    auto* placeholder = new QTableWidgetItem();
+    placeholder->setFlags(Qt::NoItemFlags);
+    placeholder->setBackground(QColor(180, 180, 180));
+    _transition_lane_table->setItem(last_row_idx, col, placeholder);
+  }
   connect(
     add_button,
     &QAbstractButton::clicked,
     [this]()
     {
+      if (_zone.vertices.size() < 1)
+      {
+        QMessageBox::warning(
+          this,
+          "Cannot add lane",
+          "At least one internal vertex is required ");
+        return;
+      }
       ZoneTransitionLane new_transition_lane;
       _zone.transition_lanes.push_back(new_transition_lane);
       update_transition_lane_table();
       update_zone_view();
     });
+  _transition_lane_table->blockSignals(false);
 }
-// ======================================================================================================================
-void ZoneDialog::update_entry_combobox()
-{
-  _entry_combo_box->clear();
-  for (const auto& vertex : _zone.vertices)
-  {
-    _entry_combo_box->addItem(QString::fromStdString(vertex.name));
-  }
-}
+
 // ======================================================================================================================
 void ZoneDialog::update_internal_vertex_combobox()
 {
@@ -708,48 +642,44 @@ const
 
 bool ZoneDialog::has_valid_entry_and_exit_transition_lanes() const
 {
-  // Check that each internal vertex has at least one entry lane and one exit lane
   for (const auto& vertex : _zone.vertices)
   {
-    int entry_count = 0;
-    int exit_count = 0;
+    bool has_valid_pair = false;
 
-    for (const auto& lane : _zone.transition_lanes)
+    for (const auto& entry_lane : _zone.transition_lanes)
     {
-      if (!transition_lane_vertices_valid(lane))
+      if (!transition_lane_vertices_valid(entry_lane))
+        continue;
+      if (!entry_lane.is_entry_lane)
+        continue;
+      if (entry_lane.internal_vertex != vertex.name)
         continue;
 
-      if (lane.internal_vertex == vertex.name)
+      for (const auto& exit_lane : _zone.transition_lanes)
       {
-        if (lane.is_entry_lane)
-          entry_count++;
-        if (lane.is_exit_lane)
-          exit_count++;
+        if (!transition_lane_vertices_valid(exit_lane))
+          continue;
+        if (!exit_lane.is_exit_lane)
+          continue;
+        if (exit_lane.internal_vertex != vertex.name)
+          continue;
+
+        if (entry_lane.external_vertex != exit_lane.external_vertex)
+        {
+          has_valid_pair = true;
+          break;
+        }
       }
+
+      if (has_valid_pair)
+        break;
     }
 
-    if (entry_count < 1 || exit_count < 1)
+    if (!has_valid_pair)
       return false;
   }
 
-  // Also check that there's at least one entry lane and one exit lane (can be the same lane)
-  // with different external vertices
-  for (const auto& entry_lane : _zone.transition_lanes)
-  {
-    if (!entry_lane.is_entry_lane)
-      continue;
-
-    for (const auto& exit_lane : _zone.transition_lanes)
-    {
-      if (!exit_lane.is_exit_lane)
-        continue;
-
-      if (entry_lane.external_vertex != exit_lane.external_vertex)
-        return true;
-    }
-  }
-
-  return false;
+  return true;
 }
 
 // ======================================================================================================================
@@ -765,20 +695,6 @@ void ZoneDialog::set_transition_lane_cell(const int row, const int col,
   _transition_lane_table->setItem(row, col, new QTableWidgetItem(text));
 }
 
-// ======================================================================================================================
-void ZoneDialog::update_level_table()
-{
-  _level_table->setColumnCount(1 + static_cast<int>(_zone.vertices.size()));
-  _level_table->setHorizontalHeaderItem(0, new QTableWidgetItem("Level"));
-  for (std::size_t vertex_idx = 0; vertex_idx < _zone.vertices.size();
-    vertex_idx++)
-  {
-    _level_table->setHorizontalHeaderItem(
-      vertex_idx + 1,
-      new QTableWidgetItem(
-        QString::fromStdString(_zone.vertices[vertex_idx].name)));
-  }
-}
 // ======================================================================================================================
 bool ZoneDialog::is_vertex_name_unique(const std::string& name,
   int ignore_index) const
@@ -806,7 +722,7 @@ void ZoneDialog::vertex_table_cell_changed(int row, int col)
 
   // If a vertex name was changed, we need to update the options shown in all
   // the level_table combo boxes
-  if (col == 0)  // name
+  if (col == 1)  // name
   {
     std::string new_name =
       _vertex_table->item(row, col)->text().toStdString();
@@ -829,18 +745,15 @@ void ZoneDialog::vertex_table_cell_changed(int row, int col)
     }
 
     _zone.vertices[row].name = new_name;
-
-    update_entry_combobox();
-    update_level_table();
   }
-  else if (col == 1) // x
+  else if (col == 2) // x
     _zone.vertices[row].x = _vertex_table->item(row, col)->text().toDouble();
-  else if (col == 2) // y
+  else if (col == 3) // y
     _zone.vertices[row].y = _vertex_table->item(row, col)->text().toDouble();
-  else if (col == 3)
+  else if (col == 4) // group
     _zone.vertices[row].group =
       _vertex_table->item(row, col)->text().toStdString();
-  else if (col == 4)
+  else if (col == 5) // priority
     _zone.vertices[row].priority =
       _vertex_table->item(row, col)->text().toInt();
 
@@ -860,21 +773,20 @@ void ZoneDialog::transition_lane_table_cell_changed(int row, int col)
 
   // If a vertex name was changed, we need to update the options shown in all
   // the level_table combo boxes
-  if (col == 0) // name
+  if (col == 1) // internal vertex
     _zone.transition_lanes[row].internal_vertex = _transition_lane_table->item(
       row, col)->text().toStdString();
-  else if (col == 1) // x
+  else if (col == 2) // external vertex
     _zone.transition_lanes[row].external_vertex = _transition_lane_table->item(
       row, col)->text().toStdString();
-  else if (col == 2) // y
+  else if (col == 3) // is exit lane
     _zone.transition_lanes[row].is_exit_lane = _transition_lane_table->item(
       row, col)->text().toInt();
-  else if (col == 3)
+  else if (col == 4) // is entry lane
     _zone.transition_lanes[row].is_entry_lane = _transition_lane_table->item(
       row, col)->text().toInt();
 
   update_internal_vertex_combobox();
-  update_level_table();
   update_zone_view();
   emit redraw();
 }

--- a/rmf_traffic_editor/gui/zone_dialog.cpp
+++ b/rmf_traffic_editor/gui/zone_dialog.cpp
@@ -269,11 +269,11 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
   QVBoxLayout* left_vbox = new QVBoxLayout;
   left_vbox->addLayout(name_hbox);
   left_vbox->addLayout(level_hbox);
-  left_vbox->addLayout(width_hbox);
-  left_vbox->addLayout(depth_hbox);
   left_vbox->addLayout(x_hbox);
   left_vbox->addLayout(y_hbox);
   left_vbox->addLayout(yaw_hbox);
+  left_vbox->addLayout(width_hbox);
+  left_vbox->addLayout(depth_hbox);
   left_vbox->addWidget(_internal_vertex_table);
   left_vbox->addWidget(_external_vertex_table);
 

--- a/rmf_traffic_editor/gui/zone_dialog.cpp
+++ b/rmf_traffic_editor/gui/zone_dialog.cpp
@@ -531,12 +531,6 @@ void ZoneDialog::update_transition_lane_table()
       [this, i]()
       {
         _zone.transition_lanes.erase(_zone.transition_lanes.begin() + i);
-        set_transition_lane_cell(_zone.transition_lanes.size(), 1, nullptr);
-        set_transition_lane_cell(_zone.transition_lanes.size(), 2, nullptr);
-        _transition_lane_table->setCellWidget(_zone.transition_lanes.size(), 3,
-        nullptr);
-        _transition_lane_table->setCellWidget(_zone.transition_lanes.size(), 4,
-        nullptr);
         update_transition_lane_table();
         update_zone_view();
       });
@@ -707,12 +701,6 @@ void ZoneDialog::set_vertex_cell(const int row, const int col,
   const QString& text)
 {
   _vertex_table->setItem(row, col, new QTableWidgetItem(text));
-}
-// ======================================================================================================================
-void ZoneDialog::set_transition_lane_cell(const int row, const int col,
-  const QString& text)
-{
-  _transition_lane_table->setItem(row, col, new QTableWidgetItem(text));
 }
 
 // ======================================================================================================================

--- a/rmf_traffic_editor/gui/zone_dialog.cpp
+++ b/rmf_traffic_editor/gui/zone_dialog.cpp
@@ -333,6 +333,19 @@ bool ZoneDialog::is_zone_name_unique(const std::string& name) const
 }
 
 // ======================================================================================================================
+bool ZoneDialog::has_duplicate_priority(
+  const std::vector<InternalVertex>& vertices)
+{
+  std::unordered_set<uint> seen;
+  for (const auto& v : vertices)
+  {
+    if (!seen.insert(v.priority).second)
+      return true;
+  }
+  return false;
+}
+
+// ======================================================================================================================
 bool ZoneDialog::confirm_warning(const QString& text)
 {
   QDialog dialog(this);
@@ -462,6 +475,13 @@ void ZoneDialog::ok_button_clicked()
           "Duplicate internal vertex [" + iv.name + "]."));
       return;
     }
+  }
+
+  if (has_duplicate_priority(_zone.internal_vertices))
+  {
+    if (!confirm_warning(
+        "Duplicate internal vertex priority."))
+      return;
   }
 
   if (!has_entry || !has_exit)

--- a/rmf_traffic_editor/gui/zone_dialog.cpp
+++ b/rmf_traffic_editor/gui/zone_dialog.cpp
@@ -80,7 +80,10 @@ ZoneDialog::ZoneDialog(Zone& zone, Building& building)
       for (const auto& level : _building.levels)
       {
         if (level.name == _zone.level)
+        {
           _zone.elevation = level.elevation;
+          _zone.external_vertices.clear();
+        }
       }
       update_ex_vertex_table();
       update_zone_view();
@@ -330,25 +333,6 @@ bool ZoneDialog::is_zone_name_unique(const std::string& name) const
 }
 
 // ======================================================================================================================
-bool ZoneDialog::level_has_vertex(
-  const std::string& level_name,
-  const std::string& vertex_name) const
-{
-  for (const auto& level : _building.levels)
-  {
-    if (level.name != level_name)
-      continue;
-
-    for (const auto& v : level.vertices)
-    {
-      if (v.name == vertex_name)
-        return true;
-    }
-  }
-  return false;
-}
-
-// ======================================================================================================================
 bool ZoneDialog::confirm_warning(const QString& text)
 {
   QDialog dialog(this);
@@ -402,14 +386,7 @@ void ZoneDialog::ok_button_clicked()
     if (ev.name.empty())
     {
       QMessageBox::critical(this, "Error",
-        "Select a vertex for every external vertex row, or delete the row.");
-      return;
-    }
-
-    if (!level_has_vertex(_zone.level, ev.name))
-    {
-      QMessageBox::critical(this, "Error",
-        "Reset external vertices that were on a different level.");
+        "External vertex name cannot be empty.");
       return;
     }
 

--- a/rmf_traffic_editor/gui/zone_dialog.cpp
+++ b/rmf_traffic_editor/gui/zone_dialog.cpp
@@ -399,7 +399,7 @@ void ZoneDialog::ok_button_clicked()
     if (ev.name.empty())
     {
       QMessageBox::critical(this, "Error",
-        "External vertex name cannot be empty.");
+        "External vertex name cannot be empty");
       return;
     }
 
@@ -408,20 +408,12 @@ void ZoneDialog::ok_button_clicked()
     {
       QMessageBox::critical(this, "Error",
         QString::fromStdString(
-          "Duplicate external vertex [" + ev.name + "]."));
+          "Duplicate external vertex [" + ev.name + "]"));
       return;
     }
 
     has_entry = has_entry || ev.is_entry_point;
     has_exit = has_exit || ev.is_exit_point;
-  }
-
-  if (_zone.internal_vertices.empty())
-  {
-    if (!confirm_warning(
-        "This zone has no internal vertices, so a robot has nowhere to go "
-        "inside it."))
-      return;
   }
 
   for (std::size_t i = 0; i < _zone.internal_vertices.size(); i++)
@@ -430,14 +422,14 @@ void ZoneDialog::ok_button_clicked()
     if (iv.name.empty())
     {
       QMessageBox::critical(this, "Error",
-        "Internal vertex name cannot be empty.");
+        "Internal vertex name cannot be empty");
       return;
     }
 
     if (iv.group.empty())
     {
       QMessageBox::critical(this, "Error",
-        "Internal vertex group cannot be empty.");
+        "Internal vertex group cannot be empty");
       return;
     }
 
@@ -448,7 +440,7 @@ void ZoneDialog::ok_button_clicked()
         QMessageBox::critical(this, "Error",
           QString::fromStdString(
             "Vertex name [" + iv.name + "] already exists on level [" +
-            level.name + "]. Internal vertex names must be unique."));
+            level.name + "]. Internal vertex names must be unique"));
         return;
       }
     }
@@ -463,7 +455,7 @@ void ZoneDialog::ok_button_clicked()
         QMessageBox::critical(this, "Error",
           QString::fromStdString(
             "Vertex name [" + iv.name + "] is already used by zone [" +
-            zone.name + "]. Internal vertex names must be unique."));
+            zone.name + "]. Internal vertex names must be unique"));
         return;
       }
     }
@@ -472,7 +464,7 @@ void ZoneDialog::ok_button_clicked()
     {
       QMessageBox::critical(this, "Error",
         QString::fromStdString(
-          "Duplicate internal vertex [" + iv.name + "]."));
+          "Duplicate internal vertex [" + iv.name + "]"));
       return;
     }
   }
@@ -480,21 +472,21 @@ void ZoneDialog::ok_button_clicked()
   if (has_duplicate_priority(_zone.internal_vertices))
   {
     if (!confirm_warning(
-        "Duplicate internal vertex priority."))
+        "Duplicate internal vertex priority"))
       return;
   }
 
   if (!has_entry || !has_exit)
   {
-    QStringList missing;
-    if (!has_entry)
-      missing.append("Zone has no entry point.");
-    if (!has_exit)
-      missing.append("Zone has no exit point.");
+    QString missing;
+    if (!has_entry && !has_exit)
+      missing = "entry and exit points";
+    else if (!has_entry)
+      missing = "entry point";
+    else if (!has_exit)
+      missing = "exit point";
 
-    if (!confirm_warning(
-        missing.join("\n") +
-        "\nRobots will not be able to enter or leave this zone."))
+    if (!confirm_warning("Zone has no " + missing))
       return;
   }
 
@@ -510,8 +502,8 @@ void ZoneDialog::ok_button_clicked()
   if (!outside.isEmpty())
   {
     if (!confirm_warning(
-        "These internal vertices lie outside the zone bounds:\n  " +
-        outside.join("\n  ")))
+        "These internal vertices lie outside the zone bounds:\n -  " +
+        outside.join("\n -  ")))
       return;
   }
 
@@ -754,7 +746,7 @@ void ZoneDialog::in_vertex_table_cell_changed(int row, int col)
     if (priority < 1)
     {
       QMessageBox::warning(this, "Invalid priority",
-        "Priority must be a positive integer");
+        "Priority must be a positive integer.");
       _internal_vertex_table->blockSignals(true);
       _internal_vertex_table->item(row, col)->setText(
         QString::number(vertex.priority));

--- a/rmf_traffic_editor/gui/zone_dialog.h
+++ b/rmf_traffic_editor/gui/zone_dialog.h
@@ -53,10 +53,8 @@ private:
   std::vector<double> _level_elevations;
 
   QLineEdit* _name_line_edit;
-  QComboBox* _entry_combo_box;
   QComboBox* _internal_vertex_combo_box;
   QComboBox* _external_vertex_combo_box;
-  QComboBox* _external_entry_combo_box;
   QComboBox* _level_combo_box;
   QLineEdit* _x_line_edit;
   QLineEdit* _y_line_edit;
@@ -70,7 +68,6 @@ private:
 
   QTableWidget* _vertex_table;
   QTableWidget* _transition_lane_table;
-  QTableWidget* _level_table;
 
   QGraphicsView* _zone_view;
   QGraphicsScene* _zone_scene;
@@ -86,10 +83,8 @@ private:
     const QString& text);
   void transition_lane_table_cell_changed(int row, int col);
 
-  void update_level_table();
   void update_zone_view();
 
-  void update_entry_combobox();
   void update_internal_vertex_combobox();
 
   /// True if internal_vertex names a zone vertex and external_vertex a level vertex (not placeholders).

--- a/rmf_traffic_editor/gui/zone_dialog.h
+++ b/rmf_traffic_editor/gui/zone_dialog.h
@@ -92,6 +92,9 @@ private:
   /// True if zone name is unique
   bool is_zone_name_unique(const std::string& name) const;
 
+  /// Internal vertices that are outside the zone.
+  std::vector<std::string> vertices_outside_zone() const;
+
   bool confirm_warning(const QString& text);
 
   bool is_vertex_name_unique(const std::string& name, int ignore_index) const;

--- a/rmf_traffic_editor/gui/zone_dialog.h
+++ b/rmf_traffic_editor/gui/zone_dialog.h
@@ -18,11 +18,11 @@
 #ifndef ZONE_DIALOG_H
 #define ZONE_DIALOG_H
 
+#include <string>
 #include <vector>
 
 #include <QDialog>
 #include <QObject>
-#include <QRadioButton>
 
 #include "zone.h"
 #include "building.h"
@@ -47,57 +47,56 @@ private:
 
   Zone _zone_copy;
   std::vector<QString> _level_names;
-  std::vector<QString> _vertex_names;
-  std::vector<double> _vertex_x;
-  std::vector<double> _vertex_y;
-  std::vector<double> _level_elevations;
 
   QLineEdit* _name_line_edit;
-  QComboBox* _internal_vertex_combo_box;
-  QComboBox* _external_vertex_combo_box;
   QComboBox* _level_combo_box;
   QLineEdit* _x_line_edit;
   QLineEdit* _y_line_edit;
   QLineEdit* _yaw_line_edit;
   QLineEdit* _width_line_edit;
   QLineEdit* _depth_line_edit;
-  QComboBox* _priority_box;
-  QCheckBox* _exit_lanecheckbox;
-  QCheckBox* _entry_lanecheckbox;
+
   QCheckBox* _vertexcheckbox;
+  QCheckBox* _lanecheckbox;
 
-  QTableWidget* _vertex_table;
-  QTableWidget* _transition_lane_table;
-
+  QTableWidget* _internal_vertex_table;
+  QTableWidget* _external_vertex_table;
   QGraphicsView* _zone_view;
   QGraphicsScene* _zone_scene;
 
   QPushButton* _ok_button, * _cancel_button;
 
-  void update_vertex_table();
-  void set_vertex_cell(const int row, const int col, const QString& text);
-  void vertex_table_cell_changed(int row, int col);
-
-  void update_transition_lane_table();
-  void transition_lane_table_cell_changed(int row, int col);
+  void update_in_vertex_table();
+  void update_ex_vertex_table();
+  void in_vertex_table_cell_changed(int row, int col);
 
   void update_zone_view();
 
-  void update_internal_vertex_combobox();
-
-  /// True if internal_vertex names a zone vertex and external_vertex a level vertex (not placeholders).
-  bool transition_lane_vertices_valid(const ZoneTransitionLane& lane) const;
-  /// True if some valid entry lane row differs from some valid exit lane row.
-  bool has_valid_entry_and_exit_transition_lanes() const;
-  /// True if zone name is unique
   bool is_zone_name_unique(const std::string& name) const;
 
-  /// Internal vertices that are outside the zone.
-  std::vector<std::string> vertices_outside_zone() const;
+  /// True if no vertex in the given list, other than ignore_index, uses name.
+  template<typename VertexT>
+  bool is_vertex_name_unique(
+    const std::vector<VertexT>& vertices,
+    const std::string& name,
+    int ignore_index) const
+  {
+    for (std::size_t i = 0; i < vertices.size(); ++i)
+    {
+      if (static_cast<int>(i) == ignore_index)
+        continue;
+
+      if (vertices[i].name == name)
+        return false;
+    }
+    return true;
+  }
+
+  bool level_has_vertex(
+    const std::string& level_name,
+    const std::string& vertex_name) const;
 
   bool confirm_warning(const QString& text);
-
-  bool is_vertex_name_unique(const std::string& name, int ignore_index) const;
 
 private slots:
   void ok_button_clicked();

--- a/rmf_traffic_editor/gui/zone_dialog.h
+++ b/rmf_traffic_editor/gui/zone_dialog.h
@@ -94,6 +94,8 @@ private:
   /// True if zone name is unique
   bool is_zone_name_unique(const std::string& name) const;
 
+  bool confirm_warning(const QString& text);
+
   bool is_vertex_name_unique(const std::string& name, int ignore_index) const;
 
 private slots:

--- a/rmf_traffic_editor/gui/zone_dialog.h
+++ b/rmf_traffic_editor/gui/zone_dialog.h
@@ -79,7 +79,7 @@ private:
   bool is_vertex_name_unique(
     const std::vector<VertexT>& vertices,
     const std::string& name,
-    int ignore_index) const
+    int ignore_index = -1) const
   {
     for (std::size_t i = 0; i < vertices.size(); ++i)
     {

--- a/rmf_traffic_editor/gui/zone_dialog.h
+++ b/rmf_traffic_editor/gui/zone_dialog.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2020-2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef ZONE_DIALOG_H
+#define ZONE_DIALOG_H
+
+#include <vector>
+
+#include <QDialog>
+#include <QObject>
+#include <QRadioButton>
+
+#include "zone.h"
+#include "building.h"
+
+class QLineEdit;
+class QLabel;
+class QTableWidget;
+class QComboBox;
+class QCheckBox;
+
+class ZoneDialog : public QDialog
+{
+  Q_OBJECT
+
+public:
+  ZoneDialog(Zone& zone, Building& building);
+  ~ZoneDialog();
+
+private:
+  Zone& _zone;
+  Building& _building;
+
+  Zone _zone_copy;
+  std::vector<QString> _level_names;
+  std::vector<QString> _vertex_names;
+  std::vector<double> _vertex_x;
+  std::vector<double> _vertex_y;
+  std::vector<double> _level_elevations;
+
+  QLineEdit* _name_line_edit;
+  QComboBox* _entry_combo_box;
+  QComboBox* _internal_vertex_combo_box;
+  QComboBox* _external_vertex_combo_box;
+  QComboBox* _external_entry_combo_box;
+  QComboBox* _level_combo_box;
+  QLineEdit* _x_line_edit;
+  QLineEdit* _y_line_edit;
+  QLineEdit* _yaw_line_edit;
+  QLineEdit* _width_line_edit;
+  QLineEdit* _depth_line_edit;
+  QComboBox* _priority_box;
+  QCheckBox* _exit_lanecheckbox;
+  QCheckBox* _entry_lanecheckbox;
+  QCheckBox* _vertexcheckbox;
+
+  QTableWidget* _vertex_table;
+  QTableWidget* _transition_lane_table;
+  QTableWidget* _level_table;
+
+  QGraphicsView* _zone_view;
+  QGraphicsScene* _zone_scene;
+
+  QPushButton* _ok_button, * _cancel_button;
+
+  void update_vertex_table();
+  void set_vertex_cell(const int row, const int col, const QString& text);
+  void vertex_table_cell_changed(int row, int col);
+
+  void update_transition_lane_table();
+  void set_transition_lane_cell(const int row, const int col,
+    const QString& text);
+  void transition_lane_table_cell_changed(int row, int col);
+
+  void update_level_table();
+  void update_zone_view();
+
+  void update_entry_combobox();
+  void update_internal_vertex_combobox();
+
+  /// True if internal_vertex names a zone vertex and external_vertex a level vertex (not placeholders).
+  bool transition_lane_vertices_valid(const ZoneTransitionLane& lane) const;
+  /// True if some valid entry lane row differs from some valid exit lane row.
+  bool has_valid_entry_and_exit_transition_lanes() const;
+  /// True if zone name is unique
+  bool is_zone_name_unique(const std::string& name) const;
+
+  bool is_vertex_name_unique(const std::string& name, int ignore_index) const;
+
+private slots:
+  void ok_button_clicked();
+  void cancel_button_clicked();
+
+signals:
+  void redraw();
+};
+
+#endif

--- a/rmf_traffic_editor/gui/zone_dialog.h
+++ b/rmf_traffic_editor/gui/zone_dialog.h
@@ -79,8 +79,6 @@ private:
   void vertex_table_cell_changed(int row, int col);
 
   void update_transition_lane_table();
-  void set_transition_lane_cell(const int row, const int col,
-    const QString& text);
   void transition_lane_table_cell_changed(int row, int col);
 
   void update_zone_view();

--- a/rmf_traffic_editor/gui/zone_dialog.h
+++ b/rmf_traffic_editor/gui/zone_dialog.h
@@ -92,9 +92,6 @@ private:
     return true;
   }
 
-  bool level_has_vertex(
-    const std::string& level_name,
-    const std::string& vertex_name) const;
 
   bool confirm_warning(const QString& text);
 

--- a/rmf_traffic_editor/gui/zone_dialog.h
+++ b/rmf_traffic_editor/gui/zone_dialog.h
@@ -19,6 +19,7 @@
 #define ZONE_DIALOG_H
 
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include <QDialog>
@@ -92,6 +93,7 @@ private:
     return true;
   }
 
+  bool has_duplicate_priority(const std::vector<InternalVertex>& vertices);
 
   bool confirm_warning(const QString& text);
 

--- a/rmf_traffic_editor/gui/zone_table.cpp
+++ b/rmf_traffic_editor/gui/zone_table.cpp
@@ -122,4 +122,6 @@ void ZoneTable::update(Building& building)
     });
 
   blockSignals(false);
+  resizeColumnToContents(2);
+  resizeColumnToContents(3);
 }

--- a/rmf_traffic_editor/gui/zone_table.cpp
+++ b/rmf_traffic_editor/gui/zone_table.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2019-2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "zone_dialog.h"
+#include "zone_table.h"
+#include <QtWidgets>
+
+ZoneTable::ZoneTable()
+: TableList(4)
+{
+  const QStringList labels = { "Name", "Show", "", ""};
+  setHorizontalHeaderLabels(labels);
+}
+
+ZoneTable::~ZoneTable()
+{
+}
+
+void ZoneTable::update(Building& building)
+{
+  blockSignals(true);
+  setRowCount(1 + building.zones.size());
+  setColumnCount(4);
+
+  for (std::size_t i = 0; i < building.zones.size(); i++)
+  {
+    QCheckBox* checkbox = new QCheckBox;
+    checkbox->setChecked(building.zones[i].show_zone);
+    setCellWidget(i, 1, checkbox);
+    connect(
+      checkbox,
+      &QAbstractButton::clicked,
+      [this, &building, i](bool box_checked)
+      {
+        building.zones[i].show_zone = box_checked;
+        emit redraw();
+      });
+
+    setItem(
+      i,
+      0,
+      new QTableWidgetItem(
+        QString::fromStdString(building.zones[i].name)));
+
+    QPushButton* edit_button = new QPushButton("Edit...", this);
+    setCellWidget(i, 2, edit_button);
+
+    QPushButton* delete_button = new QPushButton("Delete...", this);
+    setCellWidget(i, 3, delete_button);
+
+    connect(
+      edit_button,
+      &QAbstractButton::clicked,
+      [this, &building, i]()
+      {
+        ZoneDialog* dialog = new ZoneDialog(building.zones[i], building);
+        dialog->show();
+        dialog->raise();
+        dialog->activateWindow();
+        connect(
+          dialog,
+          &ZoneDialog::redraw,
+          [this, &building]()
+          {
+            update(building);
+            emit redraw();
+          });
+      });
+
+    connect(
+      delete_button,
+      &QAbstractButton::clicked,
+      [this, &building, i]()
+      {
+        if (i < building.zones.size())
+        {
+          building.zones.erase(building.zones.begin() + i);
+          update(building);
+          emit redraw();
+        }
+      });
+  }
+
+  // we'll use the last row for the "Add" button
+  const int last_row_idx = static_cast<int>(building.zones.size());
+  setCellWidget(last_row_idx, 0, nullptr);
+  setItem(
+    last_row_idx,
+    0,
+    new QTableWidgetItem(
+      QString::fromStdString("")));
+  QPushButton* add_button = new QPushButton("Add...", this);
+  setCellWidget(last_row_idx, 2, add_button);
+  removeCellWidget(last_row_idx, 1);
+  connect(
+    add_button, &QAbstractButton::clicked,
+    [this, &building]()
+    {
+      Zone zone;
+      zone.level = building.levels[0].name;
+      ZoneDialog zone_dialog(zone, building);
+      if (zone_dialog.exec() == QDialog::Accepted)
+      {
+        building.zones.push_back(zone);
+        update(building);
+        emit redraw();
+      }
+    });
+
+  blockSignals(false);
+}

--- a/rmf_traffic_editor/gui/zone_table.cpp
+++ b/rmf_traffic_editor/gui/zone_table.cpp
@@ -112,6 +112,7 @@ void ZoneTable::update(Building& building)
     {
       Zone zone;
       zone.level = building.levels[0].name;
+      zone.zone_elevation = building.levels[0].elevation;
       ZoneDialog zone_dialog(zone, building);
       if (zone_dialog.exec() == QDialog::Accepted)
       {

--- a/rmf_traffic_editor/gui/zone_table.cpp
+++ b/rmf_traffic_editor/gui/zone_table.cpp
@@ -112,7 +112,7 @@ void ZoneTable::update(Building& building)
     {
       Zone zone;
       zone.level = building.levels[0].name;
-      zone.zone_elevation = building.levels[0].elevation;
+      zone.elevation = building.levels[0].elevation;
       ZoneDialog zone_dialog(zone, building);
       if (zone_dialog.exec() == QDialog::Accepted)
       {

--- a/rmf_traffic_editor/gui/zone_table.h
+++ b/rmf_traffic_editor/gui/zone_table.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2019-2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef ZONE_TABLE_H
+#define ZONE_TABLE_H
+
+#include <QTableWidget>
+
+#include "table_list.h"
+#include "building.h"
+
+class ZoneTable : public TableList
+{
+public:
+  ZoneTable();
+  ~ZoneTable();
+
+  void update(Building& building);
+};
+
+#endif


### PR DESCRIPTION

## New feature implementation

### Implemented feature
This is part of an 8-repo Simple GoToZone feature. Tracked in Stage A of [open-rmf/rmf#726](https://github.com/open-rmf/rmf/issues/726).

Adds zone support to Traffic Editor: a Qt UI for creating, editing, and viewing zones, plus YAML serialization that emits zone structure into building and nav-graph files. Building-map tools now generate zones into the nav-graph yaml.

### Implementation description
#### What's added

##### Traffic Editor UI
Added a new zone dialog: 
<img width="1281" height="702" alt="Screenshot from 2026-04-17 22-08-48" src="https://github.com/user-attachments/assets/587e1889-abe2-40ed-b8b0-1bfc2bf05fe3" />


##### Input validation in the zone dialog

- Zone names must be unique within the building.
- Internal-vertex names must be unique within the zone.
- Every internal vertex must have at least one entry lane and one exit lane.
- At least one entry lane and one exit lane must connect to different external waypoints. This prevents "single-door" zones where every entry and exit would go through the same external waypoint and causing deadlock.




### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI
