### PR TITLE
Applied explicit string conversion to str_param in building_map_server.py

### DIFF
--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -206,7 +206,7 @@ class BuildingMapServer(Node):
                         p = Param()
                         p.name = str_param
                         p.type = p.TYPE_STRING
-                        p.value_string = v[2][str_param]
+                        p.value_string = str(v[2][str_param])
                         gn.params.append(p)
 
                 for bool_param in ["is_charger",


### PR DESCRIPTION
## Bug fix

### Fixed bug

Hello everyone!

For each vertices in rmf_traffic_editor, it's possible to set a `dock_name`, `pickup_dispenser`, `dropoff_ingestor`, and `mutex` properties. However, these properties are read from the map YAML with its native YAML type, so an unquoted value such as `123` becomes an integer.
If a user wants to define this value as a `TYPE_STRING`, but in the form of a `123` value, for example, the system produces a `TypeError` during publication.

### Fix applied

The property value of `dock_name`, `pickup_dispenser`, `dropoff_ingestor`, and `mutex` is explicitly serialized as ROS string.

### GenAI Use

- [ ] I used a GenAI tool in this PR.
- [X] I did not use GenAI
